### PR TITLE
fix: allow parameter provider as object

### DIFF
--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -83,13 +83,16 @@ final class ParameterProvider implements ProviderInterface
                 continue;
             }
 
-            if (!\is_string($provider) || !$this->locator->has($provider)) {
-                throw new ProviderNotFoundException(\sprintf('Provider "%s" not found on operation "%s"', $provider, $operation->getName()));
+            if (\is_string($provider)) {
+                if (!$this->locator->has($provider)) {
+                    throw new ProviderNotFoundException(\sprintf('Provider "%s" not found on operation "%s"', $provider, $operation->getName()));
+                }
+
+                /** @var ParameterProviderInterface $provider */
+                $provider = $this->locator->get($provider);
             }
 
-            /** @var ParameterProviderInterface $providerInstance */
-            $providerInstance = $this->locator->get($provider);
-            if (($op = $providerInstance->provide($parameter, $values, $context)) instanceof Operation) {
+            if (($op = $provider->provide($parameter, $values, $context)) instanceof Operation) {
                 $operation = $op;
             }
         }

--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Exception\ProviderNotFoundException;
 use ApiPlatform\State\ParameterNotFound;
-use ApiPlatform\State\ParameterProviderInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\Util\ParameterParserTrait;
 use ApiPlatform\State\Util\RequestParser;
@@ -88,7 +87,6 @@ final class ParameterProvider implements ProviderInterface
                     throw new ProviderNotFoundException(\sprintf('Provider "%s" not found on operation "%s"', $provider, $operation->getName()));
                 }
 
-                /** @var ParameterProviderInterface $provider */
                 $provider = $this->locator->get($provider);
             }
 

--- a/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
@@ -39,6 +39,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         'group' => new QueryParameter(provider: [self::class, 'provideGroup']),
         'properties' => new QueryParameter(filter: 'my_dummy.property'),
         'service' => new QueryParameter(provider: CustomGroupParameterProvider::class),
+        'object' => new QueryParameter(provider: new CustomGroupParameterProvider()),
         'auth' => new HeaderParameter(provider: [self::class, 'restrictAccess']),
         'priority' => new QueryParameter(provider: [self::class, 'assertSecond'], priority: 10),
         'priorityb' => new QueryParameter(provider: [self::class, 'assertFirst'], priority: 20),

--- a/tests/Functional/Parameters/ParameterTest.php
+++ b/tests/Functional/Parameters/ParameterTest.php
@@ -43,6 +43,12 @@ final class ParameterTest extends ApiTestCase
         $this->assertArrayNotHasKey('a', $response->toArray());
     }
 
+    public function testWithObjectProvider(): void
+    {
+        $response = self::createClient()->request('GET', 'with_parameters/1?service=blabla');
+        $this->assertArrayNotHasKey('a', $response->toArray());
+    }
+
     public function testWithHeader(): void
     {
         self::createClient()->request('GET', 'with_parameters/1?service=blabla', ['headers' => ['auth' => 'foo']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.x
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

The type-hint on `ApiPlatform\Metadata\Parameter` suggest a `ParameterProviderInterface` can be passed to `provider` property, but this won't work as expected in this case. This PR ensures it works.

Example:

```php
#[Api\ApiResource(
    operations: [
        new Api\GetCollection(
            parameters: [
                'foo' => new Api\QueryParameter(
                    provider: new FooParameterProvider(),
                ),
            ],
        ),
    ]
)]
class Resource
{
}
```
