### PR TITLE
Purge parent collections in inheritance cases

### DIFF
--- a/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -80,6 +80,7 @@ final class PurgeHttpCacheListener
 
         foreach ($uow->getScheduledEntityInsertions() as $entity) {
             $this->gatherResourceAndItemTags($entity, false);
+            $this->gatherParentResourceTags($em, $entity);
             $this->gatherRelationTags($em, $entity);
         }
 
@@ -119,6 +120,25 @@ final class PurgeHttpCacheListener
                 $this->addTagForItem($entity);
             }
         } catch (OperationNotFoundException|InvalidArgumentException) {
+        }
+    }
+
+    private function gatherParentResourceTags(EntityManagerInterface $em, object $entity): void
+    {
+        $classMetadata = $em->getClassMetadata($entity::class);
+
+        if ($classMetadata->isInheritanceTypeNone()) {
+            return;
+        }
+
+        foreach ($classMetadata->parentClasses as $parentClass) {
+            if ($this->resourceClassResolver->isResourceClass($parentClass)) {
+                try {
+                    $iri = $this->iriConverter->getIriFromResource($parentClass, UrlGeneratorInterface::ABS_PATH, new GetCollection());
+                    $this->tags[$iri] = $iri;
+                } catch (OperationNotFoundException|InvalidArgumentException) {
+                }
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | https://github.com/api-platform/core/issues/7034
| License       | MIT
| Doc PR        | 

In the case when we clear the cache, we haven't covered the scenario where an entity is part of a class hierarchy (such as STI). In this case, the cache for all parent collections should also be cleared.

For example, we have a Product and its subclass ChildProduct. If we already have a Products collection in the cache, when a new ChildProduct is created, only the cache for the ChildProduct collection will be purged, while the parent collection will remain unchanged.

In my opinion, this is more of a bug than a feature request.
