### PR TITLE
fix(hydra): use correctly enable_docs

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -54,6 +54,7 @@ final class DocumentationNormalizer implements NormalizerInterface
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly ?NameConverterInterface $nameConverter = null,
         private readonly ?array $defaultContext = [],
+        private readonly ?bool $entrypointEnabled = true,
     ) {
     }
 
@@ -443,19 +444,21 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getClasses(array $entrypointProperties, array $classes, string $hydraPrefix = ContextBuilder::HYDRA_PREFIX): array
     {
-        $classes[] = [
-            '@id' => '#Entrypoint',
-            '@type' => $hydraPrefix.'Class',
-            $hydraPrefix.'title' => 'Entrypoint',
-            $hydraPrefix.'supportedProperty' => $entrypointProperties,
-            $hydraPrefix.'supportedOperation' => [
-                '@type' => $hydraPrefix.'Operation',
-                $hydraPrefix.'method' => 'GET',
-                $hydraPrefix.'title' => 'index',
-                $hydraPrefix.'description' => 'The API Entrypoint.',
-                $hydraPrefix.'returns' => 'Entrypoint',
-            ],
-        ];
+        if ($this->entrypointEnabled) {
+            $classes[] = [
+                '@id' => '#Entrypoint',
+                '@type' => $hydraPrefix.'Class',
+                $hydraPrefix.'title' => 'Entrypoint',
+                $hydraPrefix.'supportedProperty' => $entrypointProperties,
+                $hydraPrefix.'supportedOperation' => [
+                    '@type' => $hydraPrefix.'Operation',
+                    $hydraPrefix.'method' => 'GET',
+                    $hydraPrefix.'title' => 'index',
+                    $hydraPrefix.'description' => 'The API Entrypoint.',
+                    $hydraPrefix.'returns' => 'Entrypoint',
+                ],
+            ];
+        }
 
         $classes[] = [
             '@id' => '#ConstraintViolationList',
@@ -560,7 +563,9 @@ final class DocumentationNormalizer implements NormalizerInterface
             $doc[$hydraPrefix.'description'] = $object->getDescription();
         }
 
-        $doc[$hydraPrefix.'entrypoint'] = $this->urlGenerator->generate('api_entrypoint');
+        if ($this->entrypointEnabled) {
+            $doc[$hydraPrefix.'entrypoint'] = $this->urlGenerator->generate('api_entrypoint');
+        }
         $doc[$hydraPrefix.'supportedClass'] = $classes;
 
         return $doc;

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -731,6 +731,7 @@ class ApiPlatformProvider extends ServiceProvider
         $this->app->singleton(HydraDocumentationNormalizer::class, function (Application $app) {
             $config = $app['config'];
             $defaultContext = $config->get('api-platform.serializer', []);
+            $entrypointEnabled = $config->get('api-platform.enable_entrypoint', true);
 
             return new HydraDocumentationNormalizer(
                 $app->make(ResourceMetadataCollectionFactoryInterface::class),
@@ -739,7 +740,8 @@ class ApiPlatformProvider extends ServiceProvider
                 $app->make(ResourceClassResolverInterface::class),
                 $app->make(UrlGeneratorInterface::class),
                 $app->make(NameConverterInterface::class),
-                $defaultContext
+                $defaultContext,
+                $entrypointEnabled
             );
         });
 

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -112,6 +112,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $patchFormats = $this->getFormats($config['patch_formats']);
         $errorFormats = $this->getFormats($config['error_formats']);
         $docsFormats = $this->getFormats($config['docs_formats']);
+        if (!$config['enable_docs']) {
+            // JSON-LD documentation format is mandatory, even if documentation is disabled.
+            $docsFormats = isset($formats['jsonld']) ? ['jsonld' => ['application/ld+json']] : [];
+            // If documentation is disabled, the Hydra documentation for all the resources is hidden by default.
+            if (!isset($config['defaults']['hideHydraOperation']) && !isset($config['defaults']['hide_hydra_operation'])) {
+                $config['defaults']['hideHydraOperation'] = true;
+            }
+        }
         $jsonSchemaFormats = $config['jsonschema_formats'];
 
         if (!$jsonSchemaFormats) {
@@ -537,11 +545,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         if (!$container->has('api_platform.json_schema.schema_factory')) {
             $container->removeDefinition('api_platform.hydra.json_schema.schema_factory');
-        }
-
-        if (!$config['enable_docs']) {
-            $container->removeDefinition('api_platform.hydra.listener.response.add_link_header');
-            $container->removeDefinition('api_platform.hydra.processor.link');
         }
     }
 

--- a/src/Symfony/Bundle/Resources/config/hydra.xml
+++ b/src/Symfony/Bundle/Resources/config/hydra.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="api_platform.router" />
             <argument type="service" id="api_platform.name_converter" on-invalid="ignore" />
             <argument>%api_platform.serializer.default_context%</argument>
+            <argument>%api_platform.enable_entrypoint%</argument>
 
             <tag name="serializer.normalizer" priority="-800" />
         </service>

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -36,7 +36,7 @@ final class ApiLoader extends Loader
 
     private readonly XmlFileLoader $fileLoader;
 
-    public function __construct(KernelInterface $kernel, private readonly ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, private readonly ContainerInterface $container, private readonly array $formats, private readonly array $resourceClassDirectories = [], private readonly bool $graphqlEnabled = false, private readonly bool $entrypointEnabled = true, private readonly bool $docsEnabled = true, private readonly bool $graphiQlEnabled = false, private readonly bool $graphQlPlaygroundEnabled = false)
+    public function __construct(KernelInterface $kernel, private readonly ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, private readonly ContainerInterface $container, private readonly array $formats, private readonly array $resourceClassDirectories = [], private readonly bool $graphqlEnabled = false, private readonly bool $entrypointEnabled = true, readonly bool $docsEnabled = true, private readonly bool $graphiQlEnabled = false, private readonly bool $graphQlPlaygroundEnabled = false)
     {
         /** @var string[]|string $paths */
         $paths = $kernel->locateResource('@ApiPlatformBundle/Resources/config/routing');
@@ -124,15 +124,12 @@ final class ApiLoader extends Loader
      */
     private function loadExternalFiles(RouteCollection $routeCollection): void
     {
+        $routeCollection->addCollection($this->fileLoader->load('docs.xml'));
         $routeCollection->addCollection($this->fileLoader->load('genid.xml'));
         $routeCollection->addCollection($this->fileLoader->load('errors.xml'));
 
         if ($this->entrypointEnabled) {
             $routeCollection->addCollection($this->fileLoader->load('api.xml'));
-        }
-
-        if ($this->docsEnabled) {
-            $routeCollection->addCollection($this->fileLoader->load('docs.xml'));
         }
 
         if ($this->graphqlEnabled) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR aims to fix definitively a recurring issue: **JSON-LD documentation is mandatory** but users don't want to expose their endpoints when the API is private: https://github.com/api-platform/core/issues/1568

The `enable_docs` configuration parameter removes the `api_doc` route: the documentation is not exposed anymore, but the URL is needed in some parts of the API Platform code: JSON-LD context, Hydra links, etc.
It regularly causes some bugs.

A relating PR was done in 2018:
https://github.com/api-platform/core/pull/1731

This PR was removing the code adding the Hydra headers when the docs is disabled.
IMO @dunglas's [comment](https://github.com/api-platform/core/pull/1731#issuecomment-369886941) was right:
> IMO we must never disable the Hydra docs (or throw) when JSON-LD is enabled. The hydra "doc" is mandatory for JSON-LD (because we use Hydra types everywhere in JSON-LD documents) and Hydra compliance.

In 2023 another PRs were done but never merged:
https://github.com/api-platform/core/pull/5676
https://github.com/api-platform/core/pull/5862

@dunglas's comments were having the same point:

https://github.com/api-platform/core/pull/5676#issuecomment-1643448156
> No, contexts must always exist according to the JSON-LD spec.
>
> IMHO we have two options:
> - Always register the docs route but "manually" throw a NotFoundHttpException if enable_docs is set to false (consequently the route will technically exists in the Symfony router and the error will be prevented)
> - Always generate the Hydra "docs" if JSON-LD is enabled, even if enable_docs is set to false (but continue to disable the OpenAPI endpoint, Swagger UI etc)
>
> IMHO option 2 is more correct and easier to implement.

https://github.com/api-platform/core/pull/5862#issuecomment-1781885058
> I wonder if we cannot do that in a cleaner way: for instance, we could set docs_formats in the DI Extension to jsonld if enabled_docs is false, so we can simplify the routing part and always register the route, as it will work only for JSON-LD.

My proposal:
- Always enable the route.
- If `enable_docs` is set to `false`, only the `jsonld` documentation format is registered.
- Since the JSON-LD/Hydra documentation is always exposed, if `enable_docs` is `false`, `hydra:supportedClass` is not filled: the API resources are not included in the documentation but all the other keys stay (`@context`, `@vocab`...). To do this, it uses the new `hideHydraOperation` introduced in https://github.com/api-platform/core/pull/6871.
- Bonus: if the entrypoint is also disabled (`enable_entrypoint` set to `false`), the entrypoint is not added to `hydra:entrypoint` and `hydra:supportedClass`.