### PR TITLE
fix(state): update generic template type variable in ProviderInterface

### DIFF
--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Retrieves data from a persistence layer.
  *
- * @template T of object|iterable
+ * @template T of object|array
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */

--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Retrieves data from a persistence layer.
  *
- * @template T of object
+ * @template T of object|array
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */

--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Retrieves data from a persistence layer.
  *
- * @template T of object|array
+ * @template T of object|iterable
  *
  * @author Antoine Bluchet <soyuka@gmail.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | #5303
| License       | MIT

The actual phpDoc `@template` definition does not allow the provider to return arrays (like Doctrine mixed results).

This tiny PR avoid PHPStan (and probably Psalms too) to throw some errors like the following
```
@param for parameter \$collectionProvider is not subtype of template type T of object of interface
```

This was initially a feedback by @nesl247 for Psalm and not really fixed by #5024 
