### PR TITLE
fix(state): allow mixed result in Doctrine item provider

### DIFF
--- a/src/Doctrine/Orm/State/ItemProvider.php
+++ b/src/Doctrine/Orm/State/ItemProvider.php
@@ -46,7 +46,7 @@ final class ItemProvider implements ProviderInterface
         $this->managerRegistry = $managerRegistry;
     }
 
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $entityClass = $operation->getClass();
         if (($options = $operation->getStateOptions()) && $options instanceof Options && $options->getEntityClass()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #7084 | License       | MIT

The current signature of Doctrine ORM ItemProvider allow only null or object to be returned.

This PR allow mixed results (as array) for item.