### PR TITLE
fix(state): specify :property parameter properties

### DIFF
--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -26,6 +26,7 @@ abstract class Parameter
      * @param (array<string, mixed>&array{type?: string, default?: string})|null $schema
      * @param array<string, mixed>                                               $extraProperties
      * @param ParameterProviderInterface|callable|string|null                    $provider
+     * @param list<string>                                                       $properties      a list of properties this parameter applies to (works with the :property placeholder)
      * @param FilterInterface|string|null                                        $filter
      * @param mixed                                                              $constraints     an array of Symfony constraints, or an array of Laravel rules
      */
@@ -37,6 +38,7 @@ abstract class Parameter
         protected mixed $filter = null,
         protected ?string $property = null,
         protected ?string $description = null,
+        protected ?array $properties = null,
         protected ?bool $required = null,
         protected ?int $priority = null,
         protected ?false $hydra = null,
@@ -278,6 +280,19 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->extraProperties = $extraProperties;
+
+        return $self;
+    }
+
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    public function withProperties(?array $properties): self
+    {
+        $self = clone $this;
+        $self->properties = $properties;
 
         return $self;
     }

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -91,15 +91,16 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
     /**
      * @return array{propertyNames: string[], properties: array<string, ApiProperty>}
      */
-    private function getProperties(string $resourceClass): array
+    private function getProperties(string $resourceClass, ?Parameter $parameter = null): array
     {
-        if (isset($this->localPropertyCache[$resourceClass])) {
-            return $this->localPropertyCache[$resourceClass];
+        $k = $resourceClass.($parameter?->getProperties() ? ($parameter->getKey() ?? '') : '');
+        if (isset($this->localPropertyCache[$k])) {
+            return $this->localPropertyCache[$k];
         }
 
         $propertyNames = [];
         $properties = [];
-        foreach ($this->propertyNameCollectionFactory->create($resourceClass) as $property) {
+        foreach ($parameter?->getProperties() ?? $this->propertyNameCollectionFactory->create($resourceClass) as $property) {
             $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property);
             if ($propertyMetadata->isReadable()) {
                 $propertyNames[] = $property;
@@ -107,16 +108,17 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             }
         }
 
-        $this->localPropertyCache = [$resourceClass => ['propertyNames' => $propertyNames, 'properties' => $properties]];
+        $this->localPropertyCache[$k] = ['propertyNames' => $propertyNames, 'properties' => $properties];
 
-        return $this->localPropertyCache[$resourceClass];
+        return $this->localPropertyCache[$k];
     }
 
     private function getDefaultParameters(Operation $operation, string $resourceClass, int &$internalPriority): Parameters
     {
-        ['propertyNames' => $propertyNames, 'properties' => $properties] = $this->getProperties($resourceClass);
+        $propertyNames = $properties = [];
         $parameters = $operation->getParameters() ?? new Parameters();
         foreach ($parameters as $key => $parameter) {
+            ['propertyNames' => $propertyNames, 'properties' => $properties] = $this->getProperties($resourceClass, $parameter);
             if (null === $parameter->getProvider() && (($f = $parameter->getFilter()) && $f instanceof ParameterProviderFilterInterface)) {
                 $parameters->add($key, $parameter->withProvider($f->getParameterProvider()));
             }

--- a/src/Metadata/Tests/Fixtures/ApiResource/WithLimitedPropertyParameter.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/WithLimitedPropertyParameter.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+
+#[
+    ApiResource(operations: [
+        new GetCollection(name: 'collection', parameters: [':property' => new QueryParameter(properties: ['name'])]),
+    ])
+]
+class WithLimitedPropertyParameter
+{
+    public $id;
+    public $name;
+    public $description;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 (may be considered as a feature, experimental classes + really improves usability) 
| License       | MIT

When using a parameter on multiple properties it's common usage to want to use only a specific range of properties (only dates, etc.). 