### PR TITLE
feat(serializer): set the object-to-populate in deserializer context as soon as data !== null

### DIFF
--- a/src/State/Provider/DeserializeProvider.php
+++ b/src/State/Provider/DeserializeProvider.php
@@ -75,18 +75,23 @@ final class DeserializeProvider implements ProviderInterface
             throw new UnsupportedMediaTypeHttpException('Format not supported.');
         }
 
-        $method = $operation->getMethod();
-
-        if (
-            null !== $data
-            && (
-                'POST' === $method
+        if ($operation instanceof HttpOperation && null === ($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE] ?? null)) {
+            $method = $operation->getMethod();
+            $assignObjectToPopulate = 'POST' === $method
                 || 'PATCH' === $method
-                || ('PUT' === $method && !($operation->getExtraProperties()['standard_put'] ?? true))
-            )
-        ) {
+                || ('PUT' === $method && !($operation->getExtraProperties()['standard_put'] ?? true));
+
+            if ($assignObjectToPopulate) {
+                $serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE] = true;
+                trigger_deprecation('api-platform/core', '5.0', 'To assign an object to populate you should set "%s" in your denormalizationContext, not defining it is deprecated.', SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE);
+            }
+        }
+
+        if (null !== $data && ($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE] ?? false)) {
             $serializerContext[AbstractNormalizer::OBJECT_TO_POPULATE] = $data;
         }
+
+        unset($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE]);
 
         try {
             return $this->serializer->deserialize((string) $request->getContent(), $serializerContext['deserializer_type'] ?? $operation->getClass(), $format, $serializerContext);

--- a/src/State/SerializerContextBuilderInterface.php
+++ b/src/State/SerializerContextBuilderInterface.php
@@ -24,6 +24,9 @@ use Symfony\Component\HttpFoundation\Request;
  */
 interface SerializerContextBuilderInterface
 {
+    // @see ApiPlatform\Symfony\Controller\MainController and ApiPlatform\State\Provider\DeserializerProvider
+    public const ASSIGN_OBJECT_TO_POPULATE = 'api_assign_object_to_populate';
+
     /**
      * Creates a serialization context from a Request.
      *
@@ -51,6 +54,7 @@ interface SerializerContextBuilderInterface
      *   api_included?: bool,
      *   attributes?: string[],
      *   deserializer_type?: string,
+     *   api_assign_object_to_populate?: bool,
      * }
      */
     public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | alternative to #7123
| License       | MIT
| Doc PR        |

I have a use case where I need to send a "code" (2FA code) when deleting a resource.

With this PR, I'm able to send the code along with a DELETE request:

```
curl --request DELETE \
  --url https://redirection-io.test/app_dev.php/api/users/424e19b0-0db9-4595-bc43-f03632b3fe65/two-factor/devices/4d9853c3-f53c-422d-80cd-6c4c4fa64650 \
  --header 'Authorization: Bearer .....'
  --header 'Content-Type: application/json' \
  --header 'accept: application/ld+json' \
  --data '{
    "code": "610432"
}'
```

I use a custom DTO to do so:

```php
#[ApiResource(
    operations: [
        new Delete(
            uriTemplate: '/users/{id}/two-factor/devices/{deviceId}',
            provider: RemoveDeviceProvider::class,
            input: RemoveDeviceInput::class,
            deserialize: true, // We force since it's delete
            validate: true, // We force since it's delete
            processor: RemoveDeviceProcessor::class,
            // More properties, but not relevant here
        ),
    ]
)]
final class RemoveDevice
{
}
```

The input:

```php
#[AssertTwoFactorCode(withDeviceId: true)]
final class RemoveDeviceInput
{
    #[Assert\NotBlank]
    public string $code;

    public function __construct(
        #[Ignore]
        #[Assert\NotBlank]
        public ?User $user,
        #[Ignore]
        #[Assert\NotBlank]
        public string $deviceId,
    ) {
    }
}
```

with a custom provider:

```php
class RemoveDeviceProvider implements ProviderInterface
{
    public function __construct(
        private UserRepository $userRepository,
    ) {
    }

    public function provide(Operation $operation, array $uriVariables = [], array $context = []): RemoveDeviceInput
    {
        return new RemoveDeviceInput(
            user: $this->userRepository->find($uriVariables['id']),
            deviceId: $uriVariables['deviceId'],
        );
    }
}
```

So I want APIP to create the RemoveDeviceInput with the RemoveDeviceProvider (it's works)
But then I want it to hydrates **this** object from the request body (it's not, this PR fix that)

