### PR TITLE
fix(doctrine): support integer-backed enums in BackedEnumFilter

### DIFF
--- a/src/Doctrine/Common/Filter/BackedEnumFilterTrait.php
+++ b/src/Doctrine/Common/Filter/BackedEnumFilterTrait.php
@@ -32,7 +32,7 @@ trait BackedEnumFilterTrait
     use PropertyHelperTrait;
 
     /**
-     * @var array<string, string>
+     * @var array<string, class-string>
      */
     private array $enumTypes;
 
@@ -80,6 +80,14 @@ trait BackedEnumFilterTrait
 
     private function normalizeValue($value, string $property): mixed
     {
+        $firstCase = $this->enumTypes[$property]::cases()[0] ?? null;
+        if (
+            \is_int($firstCase?->value)
+            && false !== filter_var($value, \FILTER_VALIDATE_INT)
+        ) {
+            $value = (int) $value;
+        }
+
         $values = array_map(fn (\BackedEnum $case) => $case->value, $this->enumTypes[$property]::cases());
 
         if (\in_array($value, $values, true)) {

--- a/tests/Fixtures/TestBundle/Entity/Issue7126/DummyForBackedEnumFilter.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7126/DummyForBackedEnumFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126;
+
+use ApiPlatform\Doctrine\Orm\Filter\BackedEnumFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[GetCollection(
+    uriTemplate: 'backed_enum_filter{._format}',
+)]
+#[ApiFilter(BackedEnumFilter::class, properties: ['stringBackedEnum', 'integerBackedEnum'])]
+#[ORM\Entity]
+class DummyForBackedEnumFilter
+{
+    /**
+     * @var int The id
+     */
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(nullable: true, enumType: StringBackedEnum::class)]
+    private ?StringBackedEnum $stringBackedEnum = null;
+
+    #[ORM\Column(nullable: true, enumType: IntegerBackedEnum::class)]
+    private ?IntegerBackedEnum $integerBackedEnum = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStringBackedEnum(): ?StringBackedEnum
+    {
+        return $this->stringBackedEnum;
+    }
+
+    public function setStringBackedEnum(StringBackedEnum $stringBackedEnum): void
+    {
+        $this->stringBackedEnum = $stringBackedEnum;
+    }
+
+    public function getIntegerBackedEnum(): ?IntegerBackedEnum
+    {
+        return $this->integerBackedEnum;
+    }
+
+    public function setIntegerBackedEnum(IntegerBackedEnum $IntegerBackedEnum): void
+    {
+        $this->integerBackedEnum = $IntegerBackedEnum;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7126/IntegerBackedEnum.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7126/IntegerBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126;
+
+enum IntegerBackedEnum: int
+{
+    case One = 1;
+    case Two = 2;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7126/StringBackedEnum.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7126/StringBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126;
+
+enum StringBackedEnum: string
+{
+    case One = 'one';
+    case Two = 'two';
+}

--- a/tests/Functional/BackedEnumFilterTest.php
+++ b/tests/Functional/BackedEnumFilterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126\DummyForBackedEnumFilter;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126\IntegerBackedEnum;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7126\StringBackedEnum;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class BackedEnumFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [DummyForBackedEnumFilter::class];
+    }
+
+    public function testFilterStringBackedEnum(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema($this->getResources());
+        $this->loadFixtures();
+        $route = 'backed_enum_filter';
+        $response = self::createClient()->request('GET', $route.'?stringBackedEnum='.StringBackedEnum::One->value);
+        $a = $response->toArray();
+        $this->assertCount(1, $a['hydra:member']);
+        $this->assertEquals(StringBackedEnum::One->value, $a['hydra:member'][0]['stringBackedEnum']);
+    }
+
+    public function testFilterIntegerBackedEnum(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema($this->getResources());
+        $this->loadFixtures();
+        $route = 'backed_enum_filter';
+        $response = self::createClient()->request('GET', $route.'?integerBackedEnum='.IntegerBackedEnum::Two->value);
+        $a = $response->toArray();
+        $this->assertCount(1, $a['hydra:member']);
+        $this->assertEquals(IntegerBackedEnum::Two->value, $a['hydra:member'][0]['integerBackedEnum']);
+    }
+
+    public function loadFixtures(): void
+    {
+        $container = static::$kernel->getContainer();
+        $registry = $container->get('doctrine');
+        $manager = $registry->getManager();
+
+        $dummyOne = new DummyForBackedEnumFilter();
+        $dummyOne->setStringBackedEnum(StringBackedEnum::One);
+        $dummyOne->setIntegerBackedEnum(IntegerBackedEnum::One);
+        $manager->persist($dummyOne);
+
+        $dummyTwo = new DummyForBackedEnumFilter();
+        $dummyTwo->setStringBackedEnum(StringBackedEnum::Two);
+        $dummyTwo->setIntegerBackedEnum(IntegerBackedEnum::Two);
+        $manager->persist($dummyTwo);
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | #7126
| License       | MIT
| Doc PR        |

Currently BackedEnumFilter displays integer backed enums on the docs page but does not filter them.
This is because the $value received by `filterProperty` is a string and not an integer.
I solved this by adding this short code snippet at the start of the `normalizeValue` function in the `BackedEnumFilterTrait` to attempt to convert the value to an integer if the enum is a backed integer enum.

```php
        $firstCase = $this->enumTypes[$property]::cases()[0] ?? null;
        if (
            is_int($firstCase?->value)
            && false !== filter_var($value, FILTER_VALIDATE_INT)
        ) {
            $value = (int) $value;
        }
  ```
  Alternatively, we could use ReflectionEnum::getBackingType(), but this avoids the reflection overhead.
      
  Example Repo: https://github.com/MeronNagy/api-platform-integer-backed-enum