### PR TITLE
feat(doctrine): BackedEnumFilter allow multiple values similar to SearchFilter[exact]

### DIFF
--- a/src/Doctrine/Orm/Filter/BackedEnumFilter.php
+++ b/src/Doctrine/Orm/Filter/BackedEnumFilter.php
@@ -125,8 +125,14 @@ final class BackedEnumFilter extends AbstractFilter
             return;
         }
 
-        $value = $this->normalizeValue($value, $property);
-        if (null === $value) {
+        $values = \is_array($value) ? $value : [$value];
+
+        $normalizedValues = array_filter(array_map(
+            fn ($v) => $this->normalizeValue($v, $property),
+            $values
+        ));
+
+        if (empty($normalizedValues)) {
             return;
         }
 
@@ -139,9 +145,17 @@ final class BackedEnumFilter extends AbstractFilter
 
         $valueParameter = $queryNameGenerator->generateParameterName($field);
 
+        if (1 === \count($values)) {
+            $queryBuilder
+                ->andWhere(\sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
+                ->setParameter($valueParameter, $values[0]);
+
+            return;
+        }
+
         $queryBuilder
-            ->andWhere(\sprintf('%s.%s = :%s', $alias, $field, $valueParameter))
-            ->setParameter($valueParameter, $value);
+            ->andWhere(\sprintf('%s.%s IN (:%s)', $alias, $field, $valueParameter))
+            ->setParameter($valueParameter, $values);
     }
 
     /**

--- a/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTest.php
+++ b/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTest.php
@@ -43,6 +43,15 @@ final class BackedEnumFilterTest extends DoctrineOrmFilterTestCase
                 'invalid case for nested property' => [
                     \sprintf('SELECT o FROM %s o', Dummy::class),
                 ],
+                'valid case (multiple values)' => [
+                    \sprintf('SELECT o FROM %s o WHERE o.dummyBackedEnum IN (:dummyBackedEnum_p1)', Dummy::class),
+                    [
+                        'dummyBackedEnum_p1' => [
+                            'one',
+                            'two',
+                        ],
+                    ],
+                ],
             ]
         );
     }

--- a/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTestTrait.php
+++ b/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTestTrait.php
@@ -32,9 +32,23 @@ trait BackedEnumFilterTestTrait
                 'property' => 'dummyBackedEnum',
                 'type' => 'string',
                 'required' => false,
+                'is_collection' => false,
                 'schema' => [
                     'type' => 'string',
                     'enum' => ['one', 'two'],
+                ],
+            ],
+            'dummyBackedEnum[]' => [
+                'property' => 'dummyBackedEnum',
+                'type' => 'string',
+                'required' => false,
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['one', 'two'],
+                    ],
                 ],
             ],
         ], $filter->getDescription($this->resourceClass));
@@ -49,9 +63,23 @@ trait BackedEnumFilterTestTrait
                 'property' => 'dummyBackedEnum',
                 'type' => 'string',
                 'required' => false,
+                'is_collection' => false,
                 'schema' => [
                     'type' => 'string',
                     'enum' => ['one', 'two'],
+                ],
+            ],
+            'dummyBackedEnum[]' => [
+                'property' => 'dummyBackedEnum',
+                'type' => 'string',
+                'required' => false,
+                'is_collection' => true,
+                'schema' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'string',
+                        'enum' => ['one', 'two'],
+                    ],
                 ],
             ],
         ], $filter->getDescription($this->resourceClass));
@@ -98,6 +126,19 @@ trait BackedEnumFilterTestTrait
                 ],
                 [
                     'relatedDummy.dummyBackedEnum' => 'foo',
+                ],
+            ],
+            'valid case (multiple values)' => [
+                [
+                    'id' => null,
+                    'name' => null,
+                    'dummyBackedEnum' => null,
+                ],
+                [
+                    'dummyBackedEnum' => [
+                        'one',
+                        'two',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #7128
| License       | MIT
| Doc PR        |  

Allows multiple values for BackedEnumFilter to make it work similar to SearchFilter[exact].

There currently is no section for BackedEnumFilter in https://github.com/api-platform/docs/blob/main/core/doctrine-filters.md I can create a PR to add one if needed.

Before:  
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/61f7d26c-ca60-442a-bb09-ad0a907a6042" /> 
After:  
<img width="1359" alt="image" src="https://github.com/user-attachments/assets/41fa2af0-818c-429c-a414-77d64e69c223" />


