### PR TITLE
refactor(metadata): type parameters to list<string>|string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,7 @@
         "symfony/property-info": "^6.4 || ^7.1",
         "symfony/serializer": "^6.4 || ^7.0",
         "symfony/translation-contracts": "^3.3",
+        "symfony/type-info": "^7.2",
         "symfony/web-link": "^6.4 || ^7.1",
         "willdurand/negotiation": "^3.1"
     },

--- a/src/Laravel/Eloquent/Extension/FilterQueryExtension.php
+++ b/src/Laravel/Eloquent/Extension/FilterQueryExtension.php
@@ -53,6 +53,11 @@ final readonly class FilterQueryExtension implements QueryExtensionInterface
                 continue;
             }
 
+            // most eloquent filters work with only a single value
+            if (\is_array($values) && array_is_list($values) && 1 === \count($values)) {
+                $values = current($values);
+            }
+
             $filter = $filterId instanceof FilterInterface ? $filterId : ($this->filterLocator->has($filterId) ? $this->filterLocator->get($filterId) : null);
             if ($filter instanceof FilterInterface) {
                 $builder = $filter->apply($builder, $values, $parameter, $context + ($parameter->getFilterContext() ?? []));

--- a/src/Laravel/Eloquent/Filter/JsonApi/SortFilterParameterProvider.php
+++ b/src/Laravel/Eloquent/Filter/JsonApi/SortFilterParameterProvider.php
@@ -28,6 +28,12 @@ final readonly class SortFilterParameterProvider implements ParameterProviderInt
         $parameters = $operation->getParameters();
         $properties = $parameter->getExtraProperties()['_properties'] ?? [];
         $value = $parameter->getValue();
+
+        // most eloquent filters work with only a single value
+        if (\is_array($value) && array_is_list($value) && 1 === \count($value)) {
+            $value = current($value);
+        }
+
         if (!\is_string($value)) {
             return $operation;
         }

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Metadata;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use ApiPlatform\State\ParameterNotFound;
 use ApiPlatform\State\ParameterProviderInterface;
+use Symfony\Component\TypeInfo\Type;
 
 /**
  * @experimental
@@ -29,6 +30,7 @@ abstract class Parameter
      * @param list<string>                                                       $properties      a list of properties this parameter applies to (works with the :property placeholder)
      * @param FilterInterface|string|null                                        $filter
      * @param mixed                                                              $constraints     an array of Symfony constraints, or an array of Laravel rules
+     * @param Type                                                               $nativeType      the PHP native type, we cast values to an array if its a CollectionType, if not and it's an array with a single value we use it (eg: HTTP Header)
      */
     public function __construct(
         protected ?string $key = null,
@@ -47,6 +49,7 @@ abstract class Parameter
         protected ?string $securityMessage = null,
         protected ?array $extraProperties = [],
         protected array|string|null $filterContext = null,
+        protected ?Type $nativeType = null,
     ) {
     }
 
@@ -293,6 +296,19 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->properties = $properties;
+
+        return $self;
+    }
+
+    public function getNativeType(): ?Type
+    {
+        return $this->nativeType;
+    }
+
+    public function withNativeType(Type $nativeType): self
+    {
+        $self = clone $this;
+        $self->nativeType = $nativeType;
 
         return $self;
     }

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -33,7 +33,7 @@
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/property-info": "^6.4 || ^7.1",
         "symfony/string": "^6.4 || ^7.0",
-        "symfony/type-info": "^7.1"
+        "symfony/type-info": "^7.2"
     },
     "require-dev": {
         "api-platform/json-schema": "^4.1",

--- a/src/State/Util/ParameterParserTrait.php
+++ b/src/State/Util/ParameterParserTrait.php
@@ -13,10 +13,13 @@ declare(strict_types=1);
 
 namespace ApiPlatform\State\Util;
 
+use ApiPlatform\Metadata\HeaderParameter;
 use ApiPlatform\Metadata\HeaderParameterInterface;
 use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\State\ParameterNotFound;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\UnionType;
 
 /**
  * @internal
@@ -64,17 +67,35 @@ trait ParameterParserTrait
         }
 
         $value = $values[$key] ?? new ParameterNotFound();
-        if (!$accessors) {
-            return $value;
-        }
-
-        foreach ($accessors as $accessor) {
+        foreach ($accessors ?? [] as $accessor) {
             if (\is_array($value) && isset($value[$accessor])) {
                 $value = $value[$accessor];
             } else {
                 $value = new ParameterNotFound();
                 continue;
             }
+        }
+
+        if ($value instanceof ParameterNotFound) {
+            return $value;
+        }
+
+        $isCollectionType = fn ($t) => $t instanceof CollectionType;
+        $isCollection = $parameter->getNativeType()?->isSatisfiedBy($isCollectionType) ?? false;
+
+        // type-info 7.2
+        if (!$isCollection && $parameter->getNativeType() instanceof UnionType) {
+            foreach ($parameter->getNativeType()->getTypes() as $t) {
+                if ($isCollection = $t->isSatisfiedBy($isCollectionType)) {
+                    break;
+                }
+            }
+        }
+
+        if ($isCollection) {
+            $value = \is_array($value) ? $value : [$value];
+        } elseif ($parameter instanceof HeaderParameter && \is_array($value) && array_is_list($value) && 1 === \count($value)) {
+            $value = $value[0];
         }
 
         return $value;

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -62,14 +62,7 @@ final class ParameterValidatorProvider implements ProviderInterface
                 $value = null;
             }
 
-            $violations = [];
-            if (\is_array($value) && $properties = $parameter->getExtraProperties()['_properties'] ?? []) {
-                foreach ($properties as $property) {
-                    $violations = [...$violations, ...$this->validator->validate($value[$property] ?? null, $constraints)];
-                }
-            } else {
-                $violations = $this->validator->validate($value, $constraints);
-            }
+            $violations = $this->validator->validate($value, $constraints);
 
             foreach ($violations as $violation) {
                 $constraintViolationList->add(new ConstraintViolation(
@@ -108,7 +101,7 @@ final class ParameterValidatorProvider implements ProviderInterface
         }
 
         if ($p = $violation->getPropertyPath()) {
-            return $p;
+            return $key.$p;
         }
 
         return $key;

--- a/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
@@ -21,7 +21,11 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Constraints\GreaterThan;
@@ -31,6 +35,7 @@ use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\Unique;
@@ -108,29 +113,27 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
         }
 
         $assertions = [];
-
-        if ($required && false !== ($allowEmptyValue = $openApi?->getAllowEmptyValue())) {
-            $assertions[] = new NotNull(message: \sprintf('The parameter "%s" is required.', $parameter->getKey()));
-        }
-
+        $allowEmptyValue = $openApi?->getAllowEmptyValue();
         if (false === ($allowEmptyValue ?? $openApi?->getAllowEmptyValue())) {
             $assertions[] = new NotBlank(allowNull: !$required);
         }
 
-        if (isset($schema['exclusiveMinimum'])) {
-            $assertions[] = new GreaterThan(value: $schema['exclusiveMinimum']);
-        }
+        $minimum = $schema['exclusiveMinimum'] ?? $schema['minimum'] ?? null;
+        $exclusiveMinimum = isset($schema['exclusiveMinimum']);
+        $maximum = $schema['exclusiveMaximum'] ?? $schema['maximum'] ?? null;
+        $exclusiveMaximum = isset($schema['exclusiveMaximum']);
 
-        if (isset($schema['exclusiveMaximum'])) {
-            $assertions[] = new LessThan(value: $schema['exclusiveMaximum']);
-        }
-
-        if (isset($schema['minimum'])) {
-            $assertions[] = new GreaterThanOrEqual(value: $schema['minimum']);
-        }
-
-        if (isset($schema['maximum'])) {
-            $assertions[] = new LessThanOrEqual(value: $schema['maximum']);
+        if ($minimum && $maximum) {
+            if (!$exclusiveMinimum && !$exclusiveMaximum) {
+                $assertions[] = new Range(min: $minimum, max: $maximum);
+            } else {
+                $assertions[] = $exclusiveMinimum ? new GreaterThan(value: $minimum) : new GreaterThanOrEqual(value: $minimum);
+                $assertions[] = $exclusiveMaximum ? new LessThan(value: $maximum) : new LessThanOrEqual(value: $maximum);
+            }
+        } elseif ($minimum) {
+            $assertions[] = $exclusiveMinimum ? new GreaterThan(value: $minimum) : new GreaterThanOrEqual(value: $minimum);
+        } elseif ($maximum) {
+            $assertions[] = $exclusiveMaximum ? new LessThan(value: $maximum) : new LessThanOrEqual(value: $maximum);
         }
 
         if (isset($schema['pattern'])) {
@@ -141,20 +144,49 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
             $assertions[] = new Length(min: $schema['minLength'] ?? null, max: $schema['maxLength'] ?? null);
         }
 
-        if (isset($schema['minItems']) || isset($schema['maxItems'])) {
-            $assertions[] = new Count(min: $schema['minItems'] ?? null, max: $schema['maxItems'] ?? null);
-        }
-
         if (isset($schema['multipleOf'])) {
             $assertions[] = new DivisibleBy(value: $schema['multipleOf']);
         }
 
-        if ($schema['uniqueItems'] ?? false) {
-            $assertions[] = new Unique();
-        }
-
         if (isset($schema['enum'])) {
             $assertions[] = new Choice(choices: $schema['enum']);
+        }
+
+        if ($properties = $parameter->getExtraProperties()['_properties'] ?? []) {
+            $fields = [];
+            foreach ($properties as $propertyName) {
+                $fields[$propertyName] = $assertions;
+            }
+
+            return $parameter->withConstraints(new Collection(fields: $fields, allowMissingFields: true));
+        }
+
+        $isCollectionType = fn ($t) => $t instanceof CollectionType;
+        $isCollection = $parameter->getNativeType()?->isSatisfiedBy($isCollectionType) ?? false;
+
+        // type-info 7.2
+        if (!$isCollection && $parameter->getNativeType() instanceof UnionType) {
+            foreach ($parameter->getNativeType()->getTypes() as $t) {
+                if ($isCollection = $t->isSatisfiedBy($isCollectionType)) {
+                    break;
+                }
+            }
+        }
+
+        if ($isCollection) {
+            $assertions = $assertions ? [new All($assertions)] : [];
+        }
+
+        if ($required && false !== $allowEmptyValue) {
+            $assertions[] = new NotNull(message: \sprintf('The parameter "%s" is required.', $parameter->getKey()));
+        }
+
+        if (isset($schema['minItems']) || isset($schema['maxItems'])) {
+            $assertions[] = new Count(min: $schema['minItems'] ?? null, max: $schema['maxItems'] ?? null);
+        }
+
+        if ($schema['uniqueItems'] ?? false) {
+            $assertions[] = new Unique();
         }
 
         if (isset($schema['type']) && 'array' === $schema['type']) {

--- a/src/Validator/composer.json
+++ b/src/Validator/composer.json
@@ -24,6 +24,7 @@
     "require": {
         "php": ">=8.2",
         "api-platform/metadata": "^4.1",
+        "symfony/type-info": "^7.2",
         "symfony/web-link": "^6.4 || ^7.1"
     },
     "require-dev": {

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6673/MutlipleParameterProvider.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6673/MutlipleParameterProvider.php
@@ -17,6 +17,8 @@ use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\Metadata\QueryParameter;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[GetCollection(
     uriTemplate: 'issue6673_multiple_parameter_provider',
@@ -25,9 +27,11 @@ use ApiPlatform\Metadata\QueryParameter;
     parameters: [
         'a' => new QueryParameter(
             provider: [self::class, 'parameterOneProvider'],
+            nativeType: new BuiltinType(TypeIdentifier::STRING),
         ),
         'b' => new QueryParameter(
             provider: [self::class, 'parameterTwoProvider'],
+            nativeType: new BuiltinType(TypeIdentifier::STRING),
         ),
     ],
     provider: [self::class, 'provide']

--- a/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithSecurityParameter.php
@@ -16,13 +16,15 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HeaderParameter;
 use ApiPlatform\Metadata\QueryParameter;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[GetCollection(
     uriTemplate: 'with_security_parameters_collection{._format}',
     parameters: [
         'name' => new QueryParameter(security: 'is_granted("ROLE_ADMIN")'),
-        'auth' => new HeaderParameter(security: '"secured" == auth[0]'),
-        'secret' => new QueryParameter(security: '"secured" == secret'),
+        'auth' => new HeaderParameter(security: '"secured" == auth', nativeType: new BuiltinType(TypeIdentifier::STRING)),
+        'secret' => new QueryParameter(security: '"secured" == secret', nativeType: new BuiltinType(TypeIdentifier::STRING)),
     ],
     provider: [self::class, 'collectionProvider'],
 )]

--- a/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredBooleanParameter.php
@@ -18,16 +18,20 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
     parameters: [
         'active' => new QueryParameter(
             filter: new BooleanFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'enabled' => new QueryParameter(
             filter: new BooleanFilter(),
             property: 'active',
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
     ],
 )]

--- a/tests/Fixtures/TestBundle/Document/FilteredExistsParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredExistsParameter.php
@@ -18,6 +18,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
@@ -25,10 +27,12 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
     parameters: [
         'createdAt' => new QueryParameter(
             filter: new ExistsFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'hasCreationDate' => new QueryParameter(
             filter: new ExistsFilter(),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'exists[:property]' => new QueryParameter(
             filter: new ExistsFilter(),

--- a/tests/Fixtures/TestBundle/Document/FilteredOrderParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredOrderParameter.php
@@ -19,6 +19,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
@@ -26,19 +28,23 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
     parameters: [
         'createdAt' => new QueryParameter(
             filter: new OrderFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date' => new QueryParameter(
             filter: new OrderFilter(),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date_null_always_first' => new QueryParameter(
             filter: new OrderFilter(),
             property: 'createdAt',
             filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date_null_always_first_old_way' => new QueryParameter(
             filter: new OrderFilter(properties: ['createdAt' => OrderFilterInterface::NULLS_ALWAYS_FIRST]),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'order[:property]' => new QueryParameter(
             filter: new OrderFilter(),

--- a/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredBooleanParameter.php
@@ -18,16 +18,20 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
     parameters: [
         'active' => new QueryParameter(
             filter: new BooleanFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'enabled' => new QueryParameter(
             filter: new BooleanFilter(),
             property: 'active',
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
     ],
 )]

--- a/tests/Fixtures/TestBundle/Entity/FilteredExistsParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredExistsParameter.php
@@ -18,6 +18,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
@@ -25,10 +27,12 @@ use Doctrine\ORM\Mapping as ORM;
     parameters: [
         'createdAt' => new QueryParameter(
             filter: new ExistsFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'hasCreationDate' => new QueryParameter(
             filter: new ExistsFilter(),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::BOOL),
         ),
         'exists[:property]' => new QueryParameter(
             filter: new ExistsFilter(),

--- a/tests/Fixtures/TestBundle/Entity/FilteredOrderParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredOrderParameter.php
@@ -19,6 +19,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 #[ApiResource]
 #[GetCollection(
@@ -26,19 +28,23 @@ use Doctrine\ORM\Mapping as ORM;
     parameters: [
         'createdAt' => new QueryParameter(
             filter: new OrderFilter(),
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date' => new QueryParameter(
             filter: new OrderFilter(),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date_null_always_first' => new QueryParameter(
             filter: new OrderFilter(),
             property: 'createdAt',
             filterContext: OrderFilterInterface::NULLS_ALWAYS_FIRST,
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'date_null_always_first_old_way' => new QueryParameter(
             filter: new OrderFilter(properties: ['createdAt' => OrderFilterInterface::NULLS_ALWAYS_FIRST]),
             property: 'createdAt',
+            nativeType: new BuiltinType(TypeIdentifier::STRING)
         ),
         'order[:property]' => new QueryParameter(
             filter: new OrderFilter(),

--- a/tests/Functional/Parameters/ParameterTest.php
+++ b/tests/Functional/Parameters/ParameterTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Functional\Parameters;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WithParameter;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ParameterTest extends ApiTestCase
 {
@@ -96,7 +97,7 @@ final class ParameterTest extends ApiTestCase
     {
         $response = self::createClient()->request('GET', 'with_parameters_header_and_query?q=blabla', ['headers' => ['q' => '(complex stuff)']]);
         $this->assertEquals($response->toArray(), [
-            ['(complex stuff)'],
+            '(complex stuff)',
             'blabla',
         ]);
     }
@@ -108,5 +109,20 @@ final class ParameterTest extends ApiTestCase
 
         self::createClient()->request('GET', 'header_required', ['headers' => []]);
         $this->assertResponseStatusCodeSame(422);
+    }
+
+    #[DataProvider('provideHeaderValues')]
+    public function testHeaderParameterInteger(string $value, int $expectedStatusCode): void
+    {
+        self::createClient()->request('GET', 'header_integer', ['headers' => ['Foo' => $value]]);
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public static function provideHeaderValues(): iterable
+    {
+        yield 'valid integer' => ['3', 200];
+        yield 'too high' => ['6', 422];
+        yield 'too low' => ['0', 422];
+        yield 'invalid integer' => ['string', 422];
     }
 }

--- a/tests/Functional/Parameters/ValidationTest.php
+++ b/tests/Functional/Parameters/ValidationTest.php
@@ -59,10 +59,13 @@ final class ValidationTest extends ApiTestCase
                 'enum[]=c&enum[]=c',
                 [
                     [
-                        'message' => 'This collection should contain only unique elements.',
+                        'propertyPath' => 'enum[0]', 'message' => 'The value you selected is not a valid choice.',
                     ],
                     [
-                        'propertyPath' => 'enum', 'message' => 'The value you selected is not a valid choice.',
+                        'propertyPath' => 'enum[1]', 'message' => 'The value you selected is not a valid choice.',
+                    ],
+                    [
+                        'message' => 'This collection should contain only unique elements.',
                     ],
                 ],
             ],
@@ -101,7 +104,7 @@ final class ValidationTest extends ApiTestCase
             [
                 'num=5',
                 [
-                    ['propertyPath' => 'num', 'message' => 'This value should be less than or equal to 3.'],
+                    ['propertyPath' => 'num', 'message' => 'This value should be between 1 and 3.'],
                 ],
             ],
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #7111
| License       | MIT

Adds a nativeType to parameters, defaults to `list<string>|string` as this is the default with Symfony query parameters parsing and for HTTP Headers. It also fixes the value extraction accordingly and the validation that may have work partially on a value that's extracted as an array.

TODO:

- [x] fix doctrine filters
