### PR TITLE
fix: filtering not using strategy set in attribute when strategy not set per property

### DIFF
--- a/src/Metadata/Util/AttributeFilterExtractorTrait.php
+++ b/src/Metadata/Util/AttributeFilterExtractorTrait.php
@@ -49,7 +49,7 @@ trait AttributeFilterExtractorTrait
         if ($filterAttribute->properties) {
             foreach ($filterAttribute->properties as $property => $strategy) {
                 if (\is_int($property)) {
-                    $properties[$strategy] = null;
+                    $properties[$strategy] = $properties[$strategy] = null !== $reflectionProperty ? $filterAttribute->strategy : null;
                 } else {
                     $properties[$property] = $strategy;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1 <!-- see below -->
| Tickets       | N/A <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

When specifying properties on a `SearchFilter`, it does not use the `strategy` if the `properties` is only an array of property names and does not specify a per property strategy.

```
#[ApiFilter(filterClass: SearchFilter::class, strategy: 'ipartial', properties: ['link.name'])]
```

Without this PR, the strategy for `link.name` is `exact`.