### PR TITLE
Fix: PHPize HTTP cache headers

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -301,7 +301,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
                 continue;
             }
 
-            $data[(string) $cacheHeader['name']] = (string) $cacheHeader;
+            $data[(string) $cacheHeader['name']] = XmlUtils::phpize((string) $cacheHeader);
         }
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Building HTTP cache headers in `XmlResourceExtractor` does not cast read values, which means all values will be strings. In case of eg. `s-maxage` header, that will result in error since Symfony's `Response::setSharedMaxAge(int $value): object` expects it to be an integer.

```xml
<cacheHeaders>
    <cacheHeader name="shared_max_age">7200</cacheHeader>
</cacheHeaders>
```