### PR TITLE
fix: array shape in ProviderInterface

### DIFF
--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -29,8 +29,8 @@ interface ProviderInterface
     /**
      * Provides data.
      *
-     * @param array<string, mixed>                                                   $uriVariables
-     * @param array{request?: Request, resource_class?: string, ...<string, mixed>}  $context
+     * @param array<string, mixed>                                                  $uriVariables
+     * @param array{request?: Request, resource_class?: string, ...<string, mixed>} $context
      *
      * @return T|PartialPaginatorInterface<T>|iterable<T>|null
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

With this syntax `request` and `resource_class` can be detected. Otherwise it just becomes an unsealed associative array.

See https://github.com/phpstan/phpdoc-parser/pull/250 for the syntax. I reported https://github.com/phpstan/phpstan/issues/13019 because the extra keys aren't working as per the PR that added support, but the known keys do.


