### PR TITLE
fix: 7119 parameter array shape uses invalid syntax

### DIFF
--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -64,7 +64,7 @@ abstract class Parameter
     }
 
     /**
-     * @return array{type?: string, default?: string, ...array<string, mixed>}|null $schema
+     * @return array{type?: string, default?: string, ...<string, mixed>}|null $schema
      */
     public function getSchema(): ?array
     {
@@ -180,7 +180,7 @@ abstract class Parameter
     }
 
     /**
-     * @param array{type?: string, default?: string, ...array<string, mixed>}|null $schema
+     * @param array{type?: string, default?: string, ...<string, mixed>}|null $schema
      */
     public function withSchema(array $schema): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #7119
| License       | MIT
| Doc PR        | N/A

Fixes the array syntax for `Parameter::$schema`. Similar to https://github.com/api-platform/core/pull/7150.
