### PR TITLE
fix(httpcache): generating iri cache tag for collection operation with path para…

### DIFF
--- a/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -111,8 +111,7 @@ final class PurgeHttpCacheListener
     private function gatherResourceAndItemTags(object $entity, bool $purgeItem): void
     {
         try {
-            $resourceClass = $this->resourceClassResolver->getResourceClass($entity);
-            $iri = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, new GetCollection());
+            $iri = $this->iriConverter->getIriFromResource($entity, UrlGeneratorInterface::ABS_PATH, new GetCollection());
             $this->tags[$iri] = $iri;
 
             if ($purgeItem) {

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -121,7 +121,7 @@ final class IriConverter implements IriConverterInterface
             $operation = $this->operationMetadataFactory->create($context['item_uri_template']);
         }
 
-        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_c' : '_i');
+        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.((\is_string($resource) || $operation instanceof CollectionOperationInterface) ? '_c' : '_i');
         if ($operation && isset($this->localOperationCache[$localOperationCacheKey])) {
             return $this->generateSymfonyRoute($resource, $referenceType, $this->localOperationCache[$localOperationCacheKey], $context, $this->localIdentifiersExtractorOperationCache[$localOperationCacheKey] ?? null);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix: Generating IRI Cache Tag for collection operation with path parameter
This pull request addresses an issue in the PurgeHttpCacheListener where the IRI cache tag for collection operations was not being generated when path parameters were involved. 

Changes:
- Updated the gatherResourceAndItemTags method to use the entity directly when generating the IRI for a collection operation, instead of resolving the resource class. I think it should not be an issue as IriConverter handles non resource objects.
- Adjusted local operation cache key setting for collection operations

Simplified Use Case:
Consider an entity A with a OneToMany relationship to entity B. The collection operation URI template for entity B might look like /a/{id}/b. Since entity B is only relevant in the context of its parent entity A, when updating A, we want to purge the cache using the tag /a/{id}/b instead of /b. This ensures that we avoid purging cache for all responses containing B tags, maintaining more precise cache invalidation.

