### PR TITLE
fix(metadata): parameter cast to array flag

### DIFF
--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -50,6 +50,7 @@ abstract class Parameter
         protected ?array $extraProperties = [],
         protected array|string|null $filterContext = null,
         protected ?Type $nativeType = null,
+        protected ?bool $castToArray = null,
     ) {
     }
 
@@ -309,6 +310,19 @@ abstract class Parameter
     {
         $self = clone $this;
         $self->nativeType = $nativeType;
+
+        return $self;
+    }
+
+    public function getCastToArray(): ?bool
+    {
+        return $this->castToArray;
+    }
+
+    public function withCastToArray(bool $castToArray): self
+    {
+        $self = clone $this;
+        $self->castToArray = $castToArray;
 
         return $self;
     }

--- a/src/State/Util/ParameterParserTrait.php
+++ b/src/State/Util/ParameterParserTrait.php
@@ -92,9 +92,11 @@ trait ParameterParserTrait
             }
         }
 
-        if ($isCollection) {
-            $value = \is_array($value) ? $value : [$value];
-        } elseif ($parameter instanceof HeaderParameter && \is_array($value) && array_is_list($value) && 1 === \count($value)) {
+        if ($isCollection && true === $parameter->getCastToArray() && !\is_array($value)) {
+            $value = [$value];
+        }
+
+        if (!$isCollection && $parameter instanceof HeaderParameter && \is_array($value) && array_is_list($value) && 1 === \count($value)) {
             $value = $value[0];
         }
 

--- a/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WithParameter.php
@@ -29,7 +29,9 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Constraints\Country;
 
 #[Get(
     uriTemplate: 'with_parameters/{id}{._format}',
@@ -55,6 +57,20 @@ use Symfony\Component\Validator\Constraints as Assert;
         'hydra' => new QueryParameter(property: 'a', required: true),
     ],
     provider: [self::class, 'collectionProvider']
+)]
+#[GetCollection(
+    uriTemplate: 'with_parameters_country{._format}',
+    parameters: [
+        'country' => new QueryParameter(schema: ['type' => 'string'], constraints: [new Country()]),
+    ],
+    provider: [self::class, 'collectionProvider']
+)]
+#[GetCollection(
+    uriTemplate: 'with_parameters_countries{._format}',
+    parameters: [
+        'country' => new QueryParameter(constraints: [new All([new Country()])], castToArray: true),
+    ],
+    provider: [self::class, 'collectionProvider'],
 )]
 #[GetCollection(
     uriTemplate: 'validate_parameters{._format}',
@@ -105,7 +121,6 @@ use Symfony\Component\Validator\Constraints as Assert;
     parameters: new Parameters([
         new QueryParameter(
             key: 'q',
-            nativeType: new BuiltinType(TypeIdentifier::STRING),
         ),
         new HeaderParameter(
             key: 'q',

--- a/tests/Functional/Parameters/ParameterTest.php
+++ b/tests/Functional/Parameters/ParameterTest.php
@@ -102,6 +102,15 @@ final class ParameterTest extends ApiTestCase
         ]);
     }
 
+    public function testHeaderAndQueryWithArray(): void
+    {
+        $response = self::createClient()->request('GET', 'with_parameters_header_and_query?q[]=blabla', ['headers' => ['q' => '(complex stuff)']]);
+        $this->assertEquals($response->toArray(), [
+            '(complex stuff)',
+            ['blabla'],
+        ]);
+    }
+
     public function testHeaderParameterRequired(): void
     {
         self::createClient()->request('GET', 'header_required', ['headers' => ['req' => 'blabla']]);
@@ -124,5 +133,31 @@ final class ParameterTest extends ApiTestCase
         yield 'too high' => ['6', 422];
         yield 'too low' => ['0', 422];
         yield 'invalid integer' => ['string', 422];
+    }
+
+    #[DataProvider('provideCountryValues')]
+    public function testIssue7157(string $queryParameter, int $expectedStatusCode): void
+    {
+        self::createClient()->request('GET', 'with_parameters_country?'.$queryParameter);
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public static function provideCountryValues(): iterable
+    {
+        yield 'valid country' => ['country=FR', 200];
+        yield 'array of countries' => ['country[]=FR', 422];
+    }
+
+    #[DataProvider('provideCountriesValues')]
+    public function testIssue7157WithCountries(string $queryParameter, int $expectedStatusCode): void
+    {
+        self::createClient()->request('GET', 'with_parameters_countries?'.$queryParameter);
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public static function provideCountriesValues(): iterable
+    {
+        yield 'valid country' => ['country=FR', 200];
+        yield 'array of countries' => ['country[]=FR', 200];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #7157
| License       | MIT

This fixes a breaking change into how parameters are parsed when a string is expected. This also fixes an inconsistency where the default `string|string[]` type for a query parameter should allow both types. 
