### PR TITLE
fix(openapi): `example` and `default` with nullable value not being s…

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -88,14 +88,14 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
 
         $types = $propertyMetadata->getBuiltinTypes() ?? [];
 
-        if (!\array_key_exists('default', $propertySchema) && !empty($default = $propertyMetadata->getDefault()) && (!\count($types) || null === ($className = $types[0]->getClassName()) || !$this->isResourceClass($className))) {
+        if (!\array_key_exists('default', $propertySchema) && null !== ($default = $propertyMetadata->getDefault()) && (!\count($types) || null === ($className = $types[0]->getClassName()) || !$this->isResourceClass($className))) {
             if ($default instanceof \BackedEnum) {
                 $default = $default->value;
             }
             $propertySchema['default'] = $default;
         }
 
-        if (!\array_key_exists('example', $propertySchema) && !empty($example = $propertyMetadata->getExample())) {
+        if (!\array_key_exists('example', $propertySchema) && null !== ($example = $propertyMetadata->getExample())) {
             $propertySchema['example'] = $example;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | #7144 
| License       | MIT
| Doc PR        | 

Using a nullable value such as `false` or `0` results in the documentation not rendering these values.
Below are some perfect valid examples where the `default` and `example` are explicitly set but are not shown.
`#[ApiProperty(default: false, example: false)]`
`#[ApiProperty(default: 0, example: 0)]`

Fixed by using a null comparison instead of PHP's `empty` function.
