### PR TITLE
fix(symfony): fix property restrictions for root resource with dynamic validation groups

### DIFF
--- a/src/Symfony/Validator/ValidationGroupsExtractorTrait.php
+++ b/src/Symfony/Validator/ValidationGroupsExtractorTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Validator;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Validator\Constraints\GroupSequence;
+
+trait ValidationGroupsExtractorTrait
+{
+    /**
+     * A service locator for ValidationGroupsGenerator.
+     */
+    private ?ContainerInterface $container = null;
+
+    public function getValidationGroups(\Closure|array|string|null $validationGroups, ?object $data = null): string|array|GroupSequence|null
+    {
+        if (null === $validationGroups) {
+            return $validationGroups;
+        }
+
+        if (
+            $this->container
+            && \is_string($validationGroups)
+            && $this->container->has($validationGroups)
+            && ($service = $this->container->get($validationGroups))
+            && \is_callable($service)
+        ) {
+            $validationGroups = $service($data);
+        } elseif (\is_callable($validationGroups)) {
+            $validationGroups = $validationGroups($data);
+        }
+
+        if (!$validationGroups instanceof GroupSequence) {
+            $validationGroups = (array) $validationGroups;
+        }
+
+        return $validationGroups;
+    }
+}

--- a/src/Symfony/Validator/Validator.php
+++ b/src/Symfony/Validator/Validator.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Symfony\Validator;
 use ApiPlatform\Validator\Exception\ValidationException;
 use ApiPlatform\Validator\ValidatorInterface;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Validator\ValidatorInterface as SymfonyValidatorInterface;
 
 /**
@@ -26,8 +25,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface as SymfonyValidator
  */
 final class Validator implements ValidatorInterface
 {
-    public function __construct(private readonly SymfonyValidatorInterface $validator, private readonly ?ContainerInterface $container = null)
+    use ValidationGroupsExtractorTrait;
+
+    public function __construct(private readonly SymfonyValidatorInterface $validator, ?ContainerInterface $container = null)
     {
+        $this->container = $container;
     }
 
     /**
@@ -35,25 +37,7 @@ final class Validator implements ValidatorInterface
      */
     public function validate(object $data, array $context = []): void
     {
-        if (null !== $validationGroups = $context['groups'] ?? null) {
-            if (
-                $this->container
-                && \is_string($validationGroups)
-                && $this->container->has($validationGroups)
-                && ($service = $this->container->get($validationGroups))
-                && \is_callable($service)
-            ) {
-                $validationGroups = $service($data);
-            } elseif (\is_callable($validationGroups)) {
-                $validationGroups = $validationGroups($data);
-            }
-
-            if (!$validationGroups instanceof GroupSequence) {
-                $validationGroups = (array) $validationGroups;
-            }
-        }
-
-        $violations = $this->validator->validate($data, null, $validationGroups);
+        $violations = $this->validator->validate($data, null, $this->getValidationGroups($context['groups'] ?? null, $data));
         if (0 !== \count($violations)) {
             throw new ValidationException($violations);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
similar to #6908 
```php
#[ApiResource(
    validationContext: [
        'groups' => ValidationGroupsGenerator::class,
    ],
)]
class Foo
```
If root resource has dynamic validation groups via `\ApiPlatform\Symfony\Validator\ValidationGroupsGeneratorInterface` service - validation groups for it in `ValidatorPropertyMetadataFactory` are evaluated as plain array `['\App\Validator\ValidationGroupsGenerator']` and as a result no constraint is found for these validation groups.

use same checks as in https://github.com/api-platform/core/blob/main/src/Symfony/Validator/Validator.php#L39-L45