### PR TITLE
ci: remove version from composer to avoid release side effects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ concurrency:
 
 env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  COMPOSER_ROOT_VERSION: "4.1.x-dev"
 
 jobs:
   commitlint:

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -10,6 +10,7 @@ on:
       - '3.3'
       - '3.4'
       - '4.0'
+      - '4.1'
 
 env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-    "version": "v4.1.15",
     "authors": [
         {
             "name": "Kévin Dunglas",

--- a/src/Doctrine/Common/composer.json
+++ b/src/Doctrine/Common/composer.json
@@ -80,6 +80,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Doctrine/Odm/composer.json
+++ b/src/Doctrine/Odm/composer.json
@@ -80,6 +80,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Doctrine/Orm/composer.json
+++ b/src/Doctrine/Orm/composer.json
@@ -80,6 +80,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Documentation/composer.json
+++ b/src/Documentation/composer.json
@@ -45,6 +45,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -80,6 +80,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/GraphQl/composer.json
+++ b/src/GraphQl/composer.json
@@ -87,6 +87,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Hal/composer.json
+++ b/src/Hal/composer.json
@@ -69,6 +69,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/HttpCache/composer.json
+++ b/src/HttpCache/composer.json
@@ -74,6 +74,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Hydra/composer.json
+++ b/src/Hydra/composer.json
@@ -81,6 +81,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/JsonApi/composer.json
+++ b/src/JsonApi/composer.json
@@ -75,6 +75,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/JsonLd/composer.json
+++ b/src/JsonLd/composer.json
@@ -74,6 +74,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/JsonSchema/composer.json
+++ b/src/JsonSchema/composer.json
@@ -75,6 +75,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -93,6 +93,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/OpenApi/composer.json
+++ b/src/OpenApi/composer.json
@@ -83,6 +83,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/RamseyUuid/composer.json
+++ b/src/RamseyUuid/composer.json
@@ -69,6 +69,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Serializer/composer.json
+++ b/src/Serializer/composer.json
@@ -87,6 +87,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/State/composer.json
+++ b/src/State/composer.json
@@ -88,6 +88,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -121,6 +121,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }

--- a/src/Validator/composer.json
+++ b/src/Validator/composer.json
@@ -71,6 +71,5 @@
             "type": "vcs",
             "url": "https://github.com/soyuka/phpunit"
         }
-    ],
-    "version": "v4.1.15"
+    ]
 }


### PR DESCRIPTION
The solution to test lower branches implemented at https://github.com/api-platform/core/commit/0a1a1eac0ed8b04a32e724fe324937a70b3cc5f5 actually has an impact on the release process and I didn't anticipated that... 

This should do the same although it'll be harder to reproduce a lower-branch control locally (as you need this environment variable). 