### PR TITLE
Generate correct `Error` OpenApi

### DIFF
--- a/src/State/ApiResource/Error.php
+++ b/src/State/ApiResource/Error.php
@@ -104,7 +104,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
             identifier: true,
             writable: false,
             initializable: false,
-            schema: ['type' => 'number', 'examples' => [404], 'default' => 400]
+            schema: ['type' => 'number', 'example' => [404], 'default' => 400]
         )] private int $status,
         ?array $originalTrace = null,
         private ?string $instance = null,


### PR DESCRIPTION
In OpenApi both `example` and `examples` keyword exist. The difference relies in the fact that `example` takes one (or more) *anonymous example* whereas `examples` requires *named examples*.

Given the current code, using an anonymous example looked more concise than a named one.

More info available on official doc: https://swagger.io/docs/specification/v3_0/adding-examples/