### PR TITLE
feat(metadata) customize resource & operations

### DIFF
--- a/src/Metadata/Extractor/AbstractClosureExtractor.php
+++ b/src/Metadata/Extractor/AbstractClosureExtractor.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Base file extractor.
+ *
+ * @author Loïc Frémont <lc.fremont@gmail.com>
+ */
+abstract class AbstractClosureExtractor implements ClosureExtractorInterface
+{
+    use ResolveValueTrait;
+
+    protected ?array $closures = null;
+    private array $collectedParameters = [];
+
+    /**
+     * @param string[] $paths
+     */
+    public function __construct(protected array $paths, private readonly ?ContainerInterface $container = null)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClosures(): array
+    {
+        if (null !== $this->closures) {
+            return $this->closures;
+        }
+
+        $this->closures = [];
+        foreach ($this->paths as $path) {
+            $closure = $this->getPHPFileClosure($path)();
+
+            if (!$closure instanceof \Closure || !$this->isClosureSupported($closure)) {
+                continue;
+            }
+
+            $this->closures[] = $closure;
+        }
+
+        return $this->closures;
+    }
+
+    /**
+     * Check if the closure is supported.
+     */
+    abstract protected function isClosureSupported(\Closure $closure): bool;
+
+    /**
+     * Scope isolated include.
+     *
+     * Prevents access to $this/self from included files.
+     */
+    protected function getPHPFileClosure(string $filePath): \Closure
+    {
+        return \Closure::bind(function () use ($filePath): mixed {
+            return require $filePath;
+        }, null, null);
+    }
+}

--- a/src/Metadata/Extractor/AbstractPropertyExtractor.php
+++ b/src/Metadata/Extractor/AbstractPropertyExtractor.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Extractor;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 /**
  * Base file extractor.
@@ -23,6 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainer
  */
 abstract class AbstractPropertyExtractor implements PropertyExtractorInterface
 {
+    use ResolveValueTrait;
+
     protected ?array $properties = null;
     private array $collectedParameters = [];
 
@@ -54,70 +55,4 @@ abstract class AbstractPropertyExtractor implements PropertyExtractorInterface
      * Extracts metadata from a given path.
      */
     abstract protected function extractPath(string $path): void;
-
-    /**
-     * Recursively replaces placeholders with the service container parameters.
-     *
-     * @see https://github.com/symfony/symfony/blob/6fec32c/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
-     *
-     * @copyright (c) Fabien Potencier <fabien@symfony.com>
-     *
-     * @param mixed $value The source which might contain "%placeholders%"
-     *
-     * @throws \RuntimeException When a container value is not a string or a numeric value
-     *
-     * @return mixed The source with the placeholders replaced by the container
-     *               parameters. Arrays are resolved recursively.
-     */
-    protected function resolve(mixed $value): mixed
-    {
-        if (null === $this->container) {
-            return $value;
-        }
-
-        if (\is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $this->resolve($val);
-            }
-
-            return $value;
-        }
-
-        if (!\is_string($value)) {
-            return $value;
-        }
-
-        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($value) {
-            $parameter = $match[1] ?? null;
-
-            // skip %%
-            if (!isset($parameter)) {
-                return '%%';
-            }
-
-            if (preg_match('/^env\(\w+\)$/', $parameter)) {
-                throw new \RuntimeException(\sprintf('Using "%%%s%%" is not allowed in routing configuration.', $parameter));
-            }
-
-            if (\array_key_exists($parameter, $this->collectedParameters)) {
-                return $this->collectedParameters[$parameter];
-            }
-
-            if ($this->container instanceof SymfonyContainerInterface) {
-                $resolved = $this->container->getParameter($parameter);
-            } else {
-                $resolved = $this->container->get($parameter);
-            }
-
-            if (\is_string($resolved) || is_numeric($resolved)) {
-                $this->collectedParameters[$parameter] = $resolved;
-
-                return (string) $resolved;
-            }
-
-            throw new \RuntimeException(\sprintf('The container parameter "%s", used in the resource configuration value "%s", must be a string or numeric, but it is of type %s.', $parameter, $value, \gettype($resolved)));
-        }, $value);
-
-        return str_replace('%%', '%', $escapedValue);
-    }
 }

--- a/src/Metadata/Extractor/AbstractResourceExtractor.php
+++ b/src/Metadata/Extractor/AbstractResourceExtractor.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Extractor;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 
 /**
  * Base file extractor.
@@ -23,6 +22,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainer
  */
 abstract class AbstractResourceExtractor implements ResourceExtractorInterface
 {
+    use ResolveValueTrait;
+
     protected ?array $resources = null;
     private array $collectedParameters = [];
 
@@ -54,70 +55,4 @@ abstract class AbstractResourceExtractor implements ResourceExtractorInterface
      * Extracts metadata from a given path.
      */
     abstract protected function extractPath(string $path): void;
-
-    /**
-     * Recursively replaces placeholders with the service container parameters.
-     *
-     * @see https://github.com/symfony/symfony/blob/6fec32c/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
-     *
-     * @copyright (c) Fabien Potencier <fabien@symfony.com>
-     *
-     * @param mixed $value The source which might contain "%placeholders%"
-     *
-     * @throws \RuntimeException When a container value is not a string or a numeric value
-     *
-     * @return mixed The source with the placeholders replaced by the container
-     *               parameters. Arrays are resolved recursively.
-     */
-    protected function resolve(mixed $value): mixed
-    {
-        if (null === $this->container) {
-            return $value;
-        }
-
-        if (\is_array($value)) {
-            foreach ($value as $key => $val) {
-                $value[$key] = $this->resolve($val);
-            }
-
-            return $value;
-        }
-
-        if (!\is_string($value)) {
-            return $value;
-        }
-
-        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($value) {
-            $parameter = $match[1] ?? null;
-
-            // skip %%
-            if (!isset($parameter)) {
-                return '%%';
-            }
-
-            if (preg_match('/^env\(\w+\)$/', $parameter)) {
-                throw new \RuntimeException(\sprintf('Using "%%%s%%" is not allowed in routing configuration.', $parameter));
-            }
-
-            if (\array_key_exists($parameter, $this->collectedParameters)) {
-                return $this->collectedParameters[$parameter];
-            }
-
-            if ($this->container instanceof SymfonyContainerInterface) {
-                $resolved = $this->container->getParameter($parameter);
-            } else {
-                $resolved = $this->container->get($parameter);
-            }
-
-            if (\is_string($resolved) || is_numeric($resolved)) {
-                $this->collectedParameters[$parameter] = $resolved;
-
-                return (string) $resolved;
-            }
-
-            throw new \RuntimeException(\sprintf('The container parameter "%s", used in the resource configuration value "%s", must be a string or numeric, but it is of type %s.', $parameter, $value, \gettype($resolved)));
-        }, $value);
-
-        return str_replace('%%', '%', $escapedValue);
-    }
 }

--- a/src/Metadata/Extractor/ClosureExtractorInterface.php
+++ b/src/Metadata/Extractor/ClosureExtractorInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+
+/**
+ * Extracts an array of closure from a file or a list of files.
+ *
+ * @author Loïc Frémont <lc.fremont@gmail.com>
+ */
+interface ClosureExtractorInterface
+{
+    /**
+     * Parses all metadata files and convert them in an array.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getClosures(): array;
+}

--- a/src/Metadata/Extractor/PhpFileResourceClosureExtractor.php
+++ b/src/Metadata/Extractor/PhpFileResourceClosureExtractor.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+use ApiPlatform\Metadata\ApiResource;
+
+/**
+ * Extracts an array of closure from a list of PHP files.
+ *
+ * @author Loïc Frémont <lc.fremont@gmail.com>
+ */
+final class PhpFileResourceClosureExtractor extends AbstractClosureExtractor
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function isClosureSupported(\Closure $closure): bool
+    {
+        $resourceReflection = new \ReflectionFunction($closure);
+
+        if (1 !== $resourceReflection->getNumberOfParameters()) {
+            return false;
+        }
+
+        $firstParameterType = ($resourceReflection->getParameters()[0] ?? null)?->getType();
+
+        if (!$firstParameterType instanceof \ReflectionNamedType) {
+            return false;
+        }
+
+        // Check if the closure parameter is an API resource
+        return is_a($firstParameterType->getName(), ApiResource::class, true);
+    }
+}

--- a/src/Metadata/Extractor/ResolveValueTrait.php
+++ b/src/Metadata/Extractor/ResolveValueTrait.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Extractor;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
+
+/**
+ * @internal
+ *
+ * @property ContainerInterface|null $container
+ */
+trait ResolveValueTrait
+{
+    /**
+     * Recursively replaces placeholders with the service container parameters.
+     *
+     * @see https://github.com/symfony/symfony/blob/6fec32c/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+     *
+     * @copyright (c) Fabien Potencier <fabien@symfony.com>
+     *
+     * @param mixed $value The source which might contain "%placeholders%"
+     *
+     * @throws \RuntimeException When a container value is not a string or a numeric value
+     *
+     * @return mixed The source with the placeholders replaced by the container
+     *               parameters. Arrays are resolved recursively.
+     */
+    protected function resolve(mixed $value): mixed
+    {
+        if (null === $this->container) {
+            return $value;
+        }
+
+        if (\is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->resolve($val);
+            }
+
+            return $value;
+        }
+
+        if (!\is_string($value)) {
+            return $value;
+        }
+
+        $escapedValue = preg_replace_callback('/%%|%([^%\s]++)%/', function ($match) use ($value) {
+            $parameter = $match[1] ?? null;
+
+            // skip %%
+            if (!isset($parameter)) {
+                return '%%';
+            }
+
+            if (preg_match('/^env\(\w+\)$/', $parameter)) {
+                throw new \RuntimeException(\sprintf('Using "%%%s%%" is not allowed in routing configuration.', $parameter));
+            }
+
+            if (\array_key_exists($parameter, $this->collectedParameters)) {
+                return $this->collectedParameters[$parameter];
+            }
+
+            if ($this->container instanceof SymfonyContainerInterface) {
+                $resolved = $this->container->getParameter($parameter);
+            } else {
+                $resolved = $this->container->get($parameter);
+            }
+
+            if (\is_string($resolved) || is_numeric($resolved)) {
+                $this->collectedParameters[$parameter] = $resolved;
+
+                return (string) $resolved;
+            }
+
+            throw new \RuntimeException(\sprintf('The container parameter "%s", used in the resource configuration value "%s", must be a string or numeric, but it is of type %s.', $parameter, $value, \gettype($resolved)));
+        }, $value);
+
+        return str_replace('%%', '%', $escapedValue);
+    }
+}

--- a/src/Metadata/Resource/Factory/CustomResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/CustomResourceMetadataCollectionFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\Extractor\ClosureExtractorInterface;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+final class CustomResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    use OperationDefaultsTrait;
+
+    public function __construct(
+        private readonly ClosureExtractorInterface $resourceClosureExtractor,
+        private readonly ?ResourceMetadataCollectionFactoryInterface $decorated = null,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
+        if ($this->decorated) {
+            $resourceMetadataCollection = $this->decorated->create($resourceClass);
+        }
+
+        $newMetadataCollection = new ResourceMetadataCollection($resourceClass);
+
+        foreach ($resourceMetadataCollection as $resource) {
+            foreach ($this->resourceClosureExtractor->getClosures() as $closure) {
+                $resource = $closure($resource);
+
+                $operations = [];
+                foreach ($resource->getOperations() as $operation) {
+                    [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
+                    $operations[$key] = $operation;
+                }
+
+                $resource = $resource->withOperations(new Operations($operations));
+            }
+
+            $newMetadataCollection[] = $resource;
+        }
+
+        return $newMetadataCollection;
+    }
+}

--- a/src/Metadata/Tests/Extractor/PhpFileResourceClosureExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/PhpFileResourceClosureExtractorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Extractor;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Extractor\PhpFileResourceClosureExtractor;
+use PHPUnit\Framework\TestCase;
+
+final class PhpFileResourceClosureExtractorTest extends TestCase
+{
+    public function testItGetsClosuresFromPhpFileThatReturnsAnApiResource(): void
+    {
+        $extractor = new PhpFileResourceClosureExtractor([__DIR__.'/php/valid_custom_resource_php_file.php']);
+
+        $expectedClosures = [static function (ApiResource $resource): ApiResource {
+            return $resource->withShortName('dummy');
+        }];
+
+        $this->assertEquals($expectedClosures, $extractor->getClosures());
+    }
+
+    public function testItExcludesClosuresFromPhpFileThatDoesNotReturnAnApiResource(): void
+    {
+        $extractor = new PhpFileResourceClosureExtractor([__DIR__.'/php/invalid_custom_php_file.php']);
+
+        $this->assertEquals([], $extractor->getClosures());
+    }
+}

--- a/src/Metadata/Tests/Extractor/php/invalid_custom_php_file.php
+++ b/src/Metadata/Tests/Extractor/php/invalid_custom_php_file.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+return static function (): void {};

--- a/src/Metadata/Tests/Extractor/php/valid_custom_resource_php_file.php
+++ b/src/Metadata/Tests/Extractor/php/valid_custom_resource_php_file.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\ApiResource;
+
+return static function (ApiResource $resource): ApiResource {
+    return $resource->withShortName('dummy');
+};

--- a/src/Metadata/Tests/Resource/Factory/CustomResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/CustomResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Resource\Factory;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Extractor\ClosureExtractorInterface;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\Resource\Factory\CustomResourceMetadataCollectionFactory;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use PHPUnit\Framework\TestCase;
+
+final class CustomResourceMetadataCollectionFactoryTest extends TestCase
+{
+    public function testCustomizeApiResource(): void
+    {
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceClosureExtractor = $this->createMock(ClosureExtractorInterface::class);
+        $resourceClass = \stdClass::class;
+        $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
+        $resourceMetadataCollection[] = (new ApiResource())->withClass($resourceClass);
+        $customResourceMetadataCollectionFactory = new CustomResourceMetadataCollectionFactory($resourceClosureExtractor, $decorated);
+
+        $decorated->expects($this->once())->method('create')->with($resourceClass)->willReturn(
+            $resourceMetadataCollection,
+        );
+        $resourceClosureExtractor->expects($this->once())->method('getClosures')->willReturn([
+            static function (ApiResource $resource): ApiResource {
+                if (\stdClass::class !== $resource->getClass()) {
+                    return $resource;
+                }
+
+                return $resource->withShortName('dummy');
+            },
+        ]);
+
+        $resourceMetadataCollection = $customResourceMetadataCollectionFactory->create($resourceClass);
+
+        $resource = $resourceMetadataCollection->getIterator()->current();
+        $this->assertInstanceOf(ApiResource::class, $resource);
+        $this->assertSame('dummy', $resource->getShortName());
+    }
+
+    public function testAddOperation(): void
+    {
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceClosureExtractor = $this->createMock(ClosureExtractorInterface::class);
+        $resourceClass = \stdClass::class;
+        $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
+        $resourceMetadataCollection[] = (new ApiResource(shortName: 'Speaker'))->withClass($resourceClass);
+        $customResourceMetadataCollectionFactory = new CustomResourceMetadataCollectionFactory($resourceClosureExtractor, $decorated);
+
+        $decorated->expects($this->once())->method('create')->with($resourceClass)->willReturn(
+            $resourceMetadataCollection,
+        );
+        $resourceClosureExtractor->expects($this->once())->method('getClosures')->willReturn([
+            static function (ApiResource $resource): ApiResource {
+                if (\stdClass::class !== $resource->getClass()) {
+                    return $resource;
+                }
+
+                $operations = $resource->getOperations() ?? new Operations();
+                $operations->add('_api_Speaker_put', new Put());
+
+                return $resource->withOperations($operations);
+            },
+        ]);
+
+        $resourceMetadataCollection = $customResourceMetadataCollectionFactory->create($resourceClass);
+
+        $resource = $resourceMetadataCollection->getIterator()->current();
+        $this->assertInstanceOf(ApiResource::class, $resource);
+        $this->assertTrue($resource->getOperations()->has('_api_Speaker_put'));
+
+        // Check the defaults have been applied
+        $putOperation = $resourceMetadataCollection->getOperation('_api_Speaker_put');
+        $this->assertSame($resource->getClass(), $putOperation->getClass());
+    }
+
+    public function testRemoveOperation(): void
+    {
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceClosureExtractor = $this->createMock(ClosureExtractorInterface::class);
+        $resourceClass = \stdClass::class;
+        $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
+
+        $operations = new Operations();
+        $operations->add('_api_Speaker_post', new Post());
+
+        $resourceMetadataCollection[] = (new ApiResource(shortName: 'Speaker'))
+            ->withClass($resourceClass)
+            ->withOperations($operations);
+
+        $customResourceMetadataCollectionFactory = new CustomResourceMetadataCollectionFactory($resourceClosureExtractor, $decorated);
+
+        $decorated->expects($this->once())->method('create')->with($resourceClass)->willReturn(
+            $resourceMetadataCollection,
+        );
+        $resourceClosureExtractor->expects($this->once())->method('getClosures')->willReturn([
+            static function (ApiResource $resource): ApiResource {
+                if (\stdClass::class !== $resource->getClass()) {
+                    return $resource;
+                }
+
+                $operations = $resource->getOperations() ?? new Operations();
+                $operations->remove('_api_Speaker_post');
+
+                return $resource->withOperations($operations);
+            },
+        ]);
+
+        $resourceMetadataCollection = $customResourceMetadataCollectionFactory->create($resourceClass);
+
+        $resource = $resourceMetadataCollection->getIterator()->current();
+        $this->assertInstanceOf(ApiResource::class, $resource);
+        $this->assertFalse($resource->getOperations()->has('_api_Speaker_post'));
+    }
+}

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -356,6 +356,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $container->getDefinition('api_platform.metadata.resource_extractor.php_file')->replaceArgument(0, $phpResources);
+        $container->getDefinition('api_platform.metadata.closure_extractor.php_file.resource')->replaceArgument(0, $phpResources);
     }
 
     private function getClassNameResources(): array

--- a/src/Symfony/Bundle/Resources/config/metadata/php.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/php.xml
@@ -9,5 +9,10 @@
             <argument type="collection" />
             <argument type="service" id="service_container" />
         </service>
+
+        <service id="api_platform.metadata.closure_extractor.php_file.resource" class="ApiPlatform\Metadata\Extractor\PhpFileResourceClosureExtractor" public="false">
+            <argument type="collection" />
+            <argument type="service" id="service_container" />
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.xml
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.xml
@@ -30,6 +30,11 @@
             <argument type="service" id="service_container" on-invalid="null" />
         </service>
 
+        <service id="api_platform.metadata.resource.metadata_collection_factory.custom" class="ApiPlatform\Metadata\Resource\Factory\CustomResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="800" public="false" >
+            <argument type="service" id="api_platform.metadata.closure_extractor.php_file.resource" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.custom.inner" />
+        </service>
+
         <service id="api_platform.metadata.resource.metadata_collection_factory.concerns" class="ApiPlatform\Metadata\Resource\Factory\ConcernsResourceMetadataCollectionFactory" decorates="api_platform.metadata.resource.metadata_collection_factory" decoration-priority="800" public="false">
             <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory.concerns.inner" />
         </service>

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -299,7 +299,11 @@ class ApiPlatformExtensionTest extends TestCase
         (new ApiPlatformExtension())->load($config, $this->container);
 
         $emptyPhpFile = realpath(__DIR__.'/php/empty_file.php');
+
         $this->assertContainerHasService('api_platform.metadata.resource_extractor.php_file');
         $this->assertSame([$emptyPhpFile], $this->container->getDefinition('api_platform.metadata.resource_extractor.php_file')->getArgument(0));
+
+        $this->assertContainerHasService('api_platform.metadata.closure_extractor.php_file.resource');
+        $this->assertSame([$emptyPhpFile], $this->container->getDefinition('api_platform.metadata.closure_extractor.php_file.resource')->getArgument(0));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

The idea of this feature is to allow customizing built-in endpoints from a third party API (ex Sylius E-commerce API).

```php
<?php

declare(strict_types=1);

use ApiPlatform\Metadata\Put;
use App\Entity\Speaker;
use ApiPlatform\Metadata\ApiResource;

return static function (ApiResource $resource): ApiResource {
    if (Speaker::class !== $resource->getClass()) {
        return $resource;
    }

    $operations = $resource->getOperations();

    $operations->add('_api_Speaker_put', new Put());
    $operations->remove('_api_Speaker_get_collection');

    return $resource->withOperations($operations)->withShortName('dummy');
};
```

![image](https://github.com/user-attachments/assets/223f289d-8e7d-4ba3-a0b8-0b73e5f097f7)

In this example, the get collection operation has been removed and the put has been added (dummies)