### PR TITLE
test(symfony): mock uses Application::addCommand instead of add

### DIFF
--- a/tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
+++ b/tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
@@ -37,7 +37,11 @@ class DebugResourceCommandTest extends TestCase
         $application->setCatchExceptions(false);
         $application->setAutoExit(false);
 
-        $application->add(new DebugResourceCommand(new AttributesResourceMetadataCollectionFactory(), new VarCloner(), $dumper ?? new CliDumper()));
+        if (method_exists($application, 'addCommand')) {
+            $application->addCommand(new DebugResourceCommand(new AttributesResourceMetadataCollectionFactory(), new VarCloner(), $dumper ?? new CliDumper()));
+        } else {
+            $application->add(new DebugResourceCommand(new AttributesResourceMetadataCollectionFactory(), new VarCloner(), $dumper ?? new CliDumper()));
+        }
 
         $command = $application->find('debug:api-resource');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| License       | MIT

