### PR TITLE
feat(metadata): add support for stateOptions in YAML and XML for Doctrine ORM/ODM

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Extractor;
 
-use ApiPlatform\Elasticsearch\State\Options;
+use ApiPlatform\Doctrine\Odm\State\Options as OdmOptions;
+use ApiPlatform\Doctrine\Orm\State\Options as OrmOptions;
+use ApiPlatform\Elasticsearch\State\Options as ElasticsearchOptions;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HeaderParameter;
@@ -454,14 +456,24 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
         if (!$stateOptions) {
             return null;
         }
-        $elasticsearchOptions = $stateOptions->elasticsearchOptions ?? null;
-        if ($elasticsearchOptions) {
-            if (class_exists(Options::class)) {
-                return new Options(
-                    isset($elasticsearchOptions['index']) ? (string) $elasticsearchOptions['index'] : null,
-                    isset($elasticsearchOptions['type']) ? (string) $elasticsearchOptions['type'] : null,
-                );
-            }
+
+        if (isset($stateOptions->elasticsearchOptions) && class_exists(ElasticsearchOptions::class)) {
+            return new ElasticsearchOptions(
+                isset($stateOptions->elasticsearchOptions['index']) ? (string) $stateOptions->elasticsearchOptions['index'] : null,
+                isset($stateOptions->elasticsearchOptions['type']) ? (string) $stateOptions->elasticsearchOptions['type'] : null,
+            );
+        }
+
+        if (isset($stateOptions->doctrineOdmOptions) && class_exists(OdmOptions::class)) {
+            return new OdmOptions(
+                isset($stateOptions->doctrineOdmOptions['documentClass']) ? (string) $stateOptions->doctrineOdmOptions['documentClass'] : null,
+            );
+        }
+
+        if (isset($stateOptions->doctrineOrmOptions) && class_exists(OrmOptions::class)) {
+            return new OrmOptions(
+                isset($stateOptions->doctrineOrmOptions['entityClass']) ? (string) $stateOptions->doctrineOrmOptions['entityClass'] : null,
+            );
         }
 
         return null;

--- a/src/Metadata/Extractor/YamlResourceExtractor.php
+++ b/src/Metadata/Extractor/YamlResourceExtractor.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Extractor;
 
-use ApiPlatform\Elasticsearch\State\Options;
+use ApiPlatform\Doctrine\Odm\State\Options as OdmOptions;
+use ApiPlatform\Doctrine\Orm\State\Options as OrmOptions;
+use ApiPlatform\Elasticsearch\State\Options as ElasticsearchOptions;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HeaderParameter;
@@ -418,9 +420,20 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
         $configuration = reset($stateOptions);
         switch (key($stateOptions)) {
             case 'elasticsearchOptions':
-                if (class_exists(Options::class)) {
-                    return new Options($configuration['index'] ?? null, $configuration['type'] ?? null);
+                if (class_exists(ElasticsearchOptions::class)) {
+                    return new ElasticsearchOptions($configuration['index'] ?? null, $configuration['type'] ?? null);
                 }
+                break;
+            case 'doctrineOdmOptions':
+                if (class_exists(OdmOptions::class)) {
+                    return new OdmOptions($configuration['documentClass'] ?? null);
+                }
+                break;
+            case 'doctrineOrmOptions':
+                if (class_exists(OrmOptions::class)) {
+                    return new OrmOptions($configuration['entityClass'] ?? null);
+                }
+                break;
         }
 
         return null;

--- a/src/Metadata/Extractor/schema/resources.xsd
+++ b/src/Metadata/Extractor/schema/resources.xsd
@@ -386,6 +386,8 @@
     <xsd:complexType name="stateOptions">
         <xsd:choice>
             <xsd:element ref="elasticsearchOptions"/>
+            <xsd:element ref="doctrineOdmOptions"/>
+            <xsd:element ref="doctrineOrmOptions"/>
         </xsd:choice>
     </xsd:complexType>
 
@@ -393,6 +395,18 @@
         <xsd:complexType>
             <xsd:attribute name="index" type="xsd:string"/>
             <xsd:attribute name="type" type="xsd:string"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="doctrineOdmOptions">
+        <xsd:complexType>
+            <xsd:attribute name="documentClass" type="xsd:string"/>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:element name="doctrineOrmOptions">
+        <xsd:complexType>
+            <xsd:attribute name="entityClass" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I recently discovered stateOptions parameter (https://github.com/api-platform/core/issues/7211#issuecomment-2974693230) but it's impossible to use it with YAML or XML to configure Doctrine entity/document class.
It doesn't resolve my linked issue but at least now it's possible to configure stateOptions more easily :)