### PR TITLE
fix: fix boolean parameters type detection

### DIFF
--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -156,6 +156,8 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
                     $parameter = $parameter->withNativeType(Type::list(Type::string()));
                 } elseif ('string' === ($parameter->getSchema()['type'] ?? null)) {
                     $parameter = $parameter->withNativeType(Type::string());
+                } elseif ('boolean' === ($parameter->getSchema()['type'] ?? null)) {
+                    $parameter = $parameter->withNativeType(Type::bool());
                 } else {
                     $parameter = $parameter->withNativeType(Type::union(Type::string(), Type::list(Type::string())));
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Considering the following configuration:

```php
new GetCollection(
    // ...
    parameters: [
        'archivedOnly' => new QueryParameter(
            key: 'archivedOnly',
            schema: ['type' => 'boolean'],
            required: true,
            openApi: new Model\Parameter(
                name: 'archivedOnly',
                in: 'query',
                required: true,
            ),
        ),
    ],
),
```

The current code only supports `array` or `string` types, then fallback to `an array of strings` (cf. `ParameterResourceMetadataCollectionFactory` line 160), which seems then considered to an iterable by the validator (`All` validator is applied, which expects an `array` as value), leading to the following error:

> Symfony\Component\HttpClient\Exception\ClientException: An error occurred
>
> archivedOnly: This value should be of type iterable.

Supporting `boolean` type here fixes this issue.