### PR TITLE
fix(laravel): Allow `LinksHandler` to handle polymorphic relationships

### DIFF
--- a/src/Laravel/Eloquent/State/LinksHandler.php
+++ b/src/Laravel/Eloquent/State/LinksHandler.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 
 /**
  * @implements LinksHandlerInterface<Model>
@@ -103,6 +104,13 @@ final class LinksHandler implements LinksHandlerInterface
         if ($from = $link->getFromProperty()) {
             $relation = $this->application->make($link->getFromClass());
             $relationQuery = $relation->{$from}();
+
+            if ($relationQuery instanceof MorphOneOrMany) {
+                return $builder
+                    ->where($relationQuery->getForeignKeyName(), $identifier)
+                    ->where($relationQuery->getMorphType(), $relationQuery->getMorphClass());
+            }
+
             if (!method_exists($relationQuery, 'getQualifiedForeignKeyName') && method_exists($relationQuery, 'getQualifiedForeignPivotKeyName')) {
                 return $builder->getModel()
                     ->join(

--- a/src/Laravel/Eloquent/State/LinksHandler.php
+++ b/src/Laravel/Eloquent/State/LinksHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Laravel\Eloquent\State;
 
 use ApiPlatform\Metadata\Exception\OperationNotFoundException;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\GraphQl\Operation;
 use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\HttpOperation;
@@ -22,7 +23,11 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasOneOrMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**
  * @implements LinksHandlerInterface<Model>
@@ -102,41 +107,44 @@ final class LinksHandler implements LinksHandlerInterface
         }
 
         if ($from = $link->getFromProperty()) {
-            $relation = $this->application->make($link->getFromClass());
-            $relationQuery = $relation->{$from}();
+            /** @var Model $relatedInstance */
+            $relatedInstance = $this->application->make($link->getFromClass());
+            $relatedInstance->setAttribute($relatedInstance->getKeyName(), $identifier);
+            $relatedInstance->exists = true;
 
-            if ($relationQuery instanceof MorphOneOrMany) {
-                return $builder
-                    ->where($relationQuery->getForeignKeyName(), $identifier)
-                    ->where($relationQuery->getMorphType(), $relationQuery->getMorphClass());
+            /** @var Relation<Model, Model, mixed> $relation */
+            $relation = $relatedInstance->{$from}();
+
+            if ($relation instanceof MorphTo) {
+                throw new RuntimeException('Cannot query directly from a MorphTo relationship.');
             }
 
-            if (!method_exists($relationQuery, 'getQualifiedForeignKeyName') && method_exists($relationQuery, 'getQualifiedForeignPivotKeyName')) {
+            if ($relation instanceof BelongsTo) {
                 return $builder->getModel()
                     ->join(
-                        $relationQuery->getTable(), // @phpstan-ignore-line
-                        $relationQuery->getQualifiedRelatedPivotKeyName(), // @phpstan-ignore-line
-                        $builder->getModel()->getQualifiedKeyName()
-                    )
-                    ->where(
-                        $relationQuery->getQualifiedForeignPivotKeyName(), // @phpstan-ignore-line
+                        $relation->getParent()->getTable(),
+                        $relation->getParent()->getQualifiedKeyName(),
                         $identifier
-                    )
-                    ->select($builder->getModel()->getTable().'.*');
+                    );
             }
 
-            if (method_exists($relationQuery, 'dissociate')) {
-                return $builder->getModel()
-                       ->join(
-                           $relationQuery->getParent()->getTable(), // @phpstan-ignore-line
-                           $relationQuery->getParent()->getQualifiedKeyName(), // @phpstan-ignore-line
-                           $identifier
-                       );
+            if ($relation instanceof HasOneOrMany || $relation instanceof BelongsToMany) {
+                return $relation->getQuery();
             }
 
-            return $builder->getModel()->where($relationQuery->getQualifiedForeignKeyName(), $identifier);
+            if (method_exists($relation, 'getQualifiedForeignKeyName')) {
+                return $relation->getQuery()->where(
+                    $relation->getQualifiedForeignKeyName(),
+                    $identifier
+                );
+            }
+
+            throw new RuntimeException(\sprintf('Unhandled or unknown relationship type: %s for property %s on %s', $relation::class, $from, $relatedInstance::class));
         }
 
-        return $builder->where($builder->getModel()->qualifyColumn($link->getIdentifiers()[0]), $identifier);
+        return $builder->where(
+            $builder->getModel()->qualifyColumn($link->getIdentifiers()[0]),
+            $identifier
+        );
     }
 }

--- a/src/Laravel/Tests/EloquentTest.php
+++ b/src/Laravel/Tests/EloquentTest.php
@@ -447,6 +447,17 @@ class EloquentTest extends TestCase
         $this->assertEquals($json['sons'][0], '/api/grand_sons/1');
     }
 
+    public function testHasMany(): void
+    {
+        GrandSonFactory::new()->count(1)->create();
+
+        $res = $this->get('/api/grand_fathers/1/grand_sons', ['Accept' => ['application/ld+json']]);
+        $json = $res->json();
+        $this->assertEquals($json['@id'], '/api/grand_fathers/1/grand_sons');
+        $this->assertEquals($json['totalItems'], 1);
+        $this->assertEquals($json['member'][0]['@id'], '/api/grand_sons/1');
+    }
+
     public function testRelationIsHandledOnCreateWithNestedData(): void
     {
         $cartData = [

--- a/src/Laravel/workbench/app/Models/CommentMorph.php
+++ b/src/Laravel/workbench/app/Models/CommentMorph.php
@@ -14,12 +14,40 @@ declare(strict_types=1);
 namespace Workbench\App\Models;
 
 use ApiPlatform\Metadata\ApiProperty;
-use ApiPlatform\Metadata\NotExposed;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Symfony\Component\Serializer\Attribute\Groups;
 
-#[NotExposed]
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/post_with_morph_manies/{id}/comments',
+            uriVariables: [
+                'id' => new Link(
+                    fromProperty: 'comments',
+                    fromClass: PostWithMorphMany::class,
+                ),
+            ]
+        ),
+        new Get(
+            uriTemplate: '/post_with_morph_manies/{postId}/comments/{id}',
+            uriVariables: [
+                'postId' => new Link(
+                    fromProperty: 'comments',
+                    fromClass: PostWithMorphMany::class,
+                ),
+                'id' => new Link(
+                    fromClass: CommentMorph::class,
+                ),
+            ]
+        ),
+    ]
+)]
+#[ApiProperty(identifier: true, serialize: new Groups(['comments']), property: 'id')]
 #[ApiProperty(serialize: new Groups(['comments']), property: 'content')]
 class CommentMorph extends Model
 {

--- a/src/Laravel/workbench/database/factories/CommentFactory.php
+++ b/src/Laravel/workbench/database/factories/CommentFactory.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Workbench\App\Models\Comment;
 
 /**
- * @template TModel of \Workbench\App\Models\Author
+ * @template TModel of \Workbench\App\Models\Comment
  *
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
  */

--- a/src/Laravel/workbench/database/factories/CommentMorphFactory.php
+++ b/src/Laravel/workbench/database/factories/CommentMorphFactory.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Workbench\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Workbench\App\Models\Post;
+use Workbench\App\Models\CommentMorph;
 
 /**
- * @template TModel of \Workbench\App\Models\Post
+ * @template TModel of \Workbench\App\Models\CommentMorph
  *
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
  */
-class PostFactory extends Factory
+class CommentMorphFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var class-string<TModel>
      */
-    protected $model = Post::class;
+    protected $model = CommentMorph::class;
 
     /**
      * Define the model's default state.
@@ -37,10 +37,10 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->unique()->sentence(10);
-
         return [
-            'title' => $title,
+            'commentable_id' => PostWithMorphManyFactory::new(),
+            'commentable_type' => PostWithMorphManyFactory::class,
+            'content' => fake()->text(),
         ];
     }
 }

--- a/src/Laravel/workbench/database/factories/PostWithMorphManyFactory.php
+++ b/src/Laravel/workbench/database/factories/PostWithMorphManyFactory.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Workbench\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Workbench\App\Models\Post;
+use Workbench\App\Models\PostWithMorphMany;
 
 /**
- * @template TModel of \Workbench\App\Models\Post
+ * @template TModel of \Workbench\App\Models\PostWithMorphMany
  *
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
  */
-class PostFactory extends Factory
+class PostWithMorphManyFactory extends Factory
 {
     /**
      * The name of the factory's corresponding model.
      *
      * @var class-string<TModel>
      */
-    protected $model = Post::class;
+    protected $model = PostWithMorphMany::class;
 
     /**
      * Define the model's default state.
@@ -37,10 +37,9 @@ class PostFactory extends Factory
      */
     public function definition(): array
     {
-        $title = fake()->unique()->sentence(10);
-
         return [
-            'title' => $title,
+            'title' => fake()->unique()->sentence(10),
+            'content' => fake()->sentences(10, true),
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | #7227 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

This PR adds support for polymorphic relationships from within the `LinksHandler`.

Previously:

This would result in bad query formation where the model type was not taken into account and you could have multiple model types returned with the same IDs:.

```select * from `attachments` where `attachments`.`model_id` = ?```

```
new GetCollection(
    uriTemplate: '/projects/{id}/attachments',
    uriVariables: [
        'id' => new Link(
            fromProperty: 'attachments',
            fromClass: Project::class,
        ),
    ],
),
```

Now:

```
select * from `attachments` where `attachments`.`model_type` = ? and `attachments`.`model_id` = ? and `attachments`.`model_id` is not null
```

We now properly scope the query to the model class as well.
