### PR TITLE
feat(test): allow installing mongodb extension using php/pie

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,6 +119,7 @@
         "willdurand/negotiation": "^3.1"
     },
     "require-dev": {
+        "ext-mongodb": "^1.21 || ^2.0",
         "behat/behat": "^3.11",
         "behat/mink": "^1.9",
         "doctrine/cache": "^1.11 || ^2.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes N/A
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

php/pie v1.0 has been released! 🎉  It solely seems to install direct extension dependencies when running `pie install`, soadding the mongodb extension to the `require-dev` section will allow using pie to more easily allow running phpunit test suite locally.

Chose the version range from `mongodb-odm`'s own requirements.

## Before

<img width="930" alt="image" src="https://github.com/user-attachments/assets/06dbfb1e-900f-4975-8141-af3a7e210d66" />

## After

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/cc2f468a-13a0-4ed9-b282-ae28e41de5bd" />
