### PR TITLE
fix(hydra): match Caddy in making docs.jsonld Link header URI relative

### DIFF
--- a/src/Hydra/State/HydraLinkProcessor.php
+++ b/src/Hydra/State/HydraLinkProcessor.php
@@ -45,7 +45,7 @@ final class HydraLinkProcessor implements ProcessorInterface
             return $this->decorated->process($data, $operation, $uriVariables, $context);
         }
 
-        $apiDocUrl = $this->urlGenerator->generate('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_URL);
+        $apiDocUrl = $this->urlGenerator->generate('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_PATH);
         $linkProvider = $request->attributes->get('_api_platform_links') ?? new GenericLinkProvider();
 
         foreach ($operation->getLinks() ?? [] as $link) {

--- a/src/Hydra/Tests/State/HydraLinkProcessorTest.php
+++ b/src/Hydra/Tests/State/HydraLinkProcessorTest.php
@@ -42,7 +42,12 @@ class HydraLinkProcessorTest extends TestCase
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
-        $urlGenerator->expects($this->once())->method('generate')->with('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_URL)->willReturn('/docs');
+        $urlGenerator
+            ->expects($this->once())
+            ->method('generate')
+            ->with('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_PATH)
+            ->willReturn('/docs')
+        ;
         (new HydraLinkProcessor($decorated, $urlGenerator))->process($data, $operation, [], $context);
     }
 }


### PR DESCRIPTION
This makes the client responsible of matching the original request's protocol.

| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Relates to https://github.com/api-platform/admin/issues/631
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 3.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

The HydraLinkProcessor includes an absolute URI as Link header, but as the Psr\Link\LinkInterface prescribes it is allowed to have a relative URI as well.

* Caddy also serves a relative URI for the documentation Link in it's default config:  https://github.com/api-platform/api-platform/blob/main/api/frankenphp/Caddyfile#L42
* Applications can use http as protocol behind a proxy, resulting in the UrlGenerator based on internal framework requests render a http URL (while the actual client is on https). When using HSTS this will lead in a crashing frontend application (see related issue). 