### PR TITLE
Fix usage of deprecated AdvancedNameConverterInterface

### DIFF
--- a/src/Hydra/Serializer/HydraPrefixNameConverter.php
+++ b/src/Hydra/Serializer/HydraPrefixNameConverter.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Hydra\Serializer;
 
 use ApiPlatform\JsonLd\ContextBuilder;
-use Symfony\Component\Serializer\NameConverter\AdvancedNameConverterInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
-final readonly class HydraPrefixNameConverter implements NameConverterInterface, AdvancedNameConverterInterface
+final readonly class HydraPrefixNameConverter implements NameConverterInterface
 {
     /**
      * @param array<string,mixed> $defaultContext


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | current stable
| Tickets       | Closes #6948
| License       | MIT

Hello,

As discussed after merging https://github.com/api-platform/core/pull/6956, it seems there was an oversight on a file and the deprecation is still present in 4.1.

This PR aims to fix it
