### PR TITLE
 refactor(metadata): cascade resource to operation 

### DIFF
--- a/src/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactory.php
+++ b/src/Doctrine/Odm/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactory.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Doctrine\Odm\Metadata\Resource;
 use ApiPlatform\Doctrine\Odm\State\CollectionProvider;
 use ApiPlatform\Doctrine\Odm\State\ItemProvider;
 use ApiPlatform\Doctrine\Odm\State\Options;
-use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\DeleteOperationInterface;
 use ApiPlatform\Metadata\Operation;
@@ -41,12 +40,10 @@ final class DoctrineMongoDbOdmResourceCollectionMetadataFactory implements Resou
     {
         $resourceMetadataCollection = $this->decorated->create($resourceClass);
 
-        /** @var ApiResource $resourceMetadata */
         foreach ($resourceMetadataCollection as $i => $resourceMetadata) {
             $operations = $resourceMetadata->getOperations();
 
             if ($operations) {
-                /** @var Operation $operation */
                 foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
                     $documentClass = $this->getStateOptionsClass($operation, $operation->getClass(), Options::class);
                     if (!$this->managerRegistry->getManagerForClass($documentClass) instanceof DocumentManager) {

--- a/src/Doctrine/Odm/Tests/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest.php
+++ b/src/Doctrine/Odm/Tests/Metadata/Resource/DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest.php
@@ -21,7 +21,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -34,7 +34,7 @@ final class DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest extends Test
 {
     use ProphecyTrait;
 
-    private function getResourceMetadataCollectionFactory(Operation $operation)
+    private function getResourceMetadataCollectionFactory(HttpOperation $operation)
     {
         if (!class_exists(DocumentManager::class)) {
             $this->markTestSkipped('ODM not installed');
@@ -71,7 +71,7 @@ final class DoctrineMongoDbOdmResourceCollectionMetadataFactoryTest extends Test
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('operationProvider')]
-    public function testWithProvider(Operation $operation, ?string $expectedProvider = null, ?string $expectedProcessor = null): void
+    public function testWithProvider(HttpOperation $operation, ?string $expectedProvider = null, ?string $expectedProcessor = null): void
     {
         if (!class_exists(DocumentManager::class)) {
             $this->markTestSkipped('ODM not installed');

--- a/src/Doctrine/Orm/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactory.php
+++ b/src/Doctrine/Orm/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactory.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Doctrine\Orm\Metadata\Resource;
 use ApiPlatform\Doctrine\Orm\State\CollectionProvider;
 use ApiPlatform\Doctrine\Orm\State\ItemProvider;
 use ApiPlatform\Doctrine\Orm\State\Options;
-use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\DeleteOperationInterface;
 use ApiPlatform\Metadata\Operation;
@@ -41,12 +40,10 @@ final class DoctrineOrmResourceCollectionMetadataFactory implements ResourceMeta
     {
         $resourceMetadataCollection = $this->decorated->create($resourceClass);
 
-        /** @var ApiResource $resourceMetadata */
         foreach ($resourceMetadataCollection as $i => $resourceMetadata) {
             $operations = $resourceMetadata->getOperations();
 
             if ($operations) {
-                /** @var Operation $operation */
                 foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
                     $entityClass = $this->getStateOptionsClass($operation, $operation->getClass(), Options::class);
 

--- a/src/Doctrine/Orm/Tests/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactoryTest.php
+++ b/src/Doctrine/Orm/Tests/Metadata/Resource/DoctrineOrmResourceCollectionMetadataFactoryTest.php
@@ -21,7 +21,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -34,7 +34,7 @@ class DoctrineOrmResourceCollectionMetadataFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    private function getResourceMetadataCollectionFactory(Operation $operation)
+    private function getResourceMetadataCollectionFactory(HttpOperation $operation)
     {
         $resourceMetadataCollectionFactory = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
         $resourceMetadataCollectionFactory->create($operation->getClass())->willReturn(new ResourceMetadataCollection($operation->getClass(), [
@@ -63,7 +63,7 @@ class DoctrineOrmResourceCollectionMetadataFactoryTest extends TestCase
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('operationProvider')]
-    public function testWithProvider(Operation $operation, ?string $expectedProvider = null, ?string $expectedProcessor = null): void
+    public function testWithProvider(HttpOperation $operation, ?string $expectedProvider = null, ?string $expectedProcessor = null): void
     {
         $objectManager = $this->prophesize(EntityManagerInterface::class);
         $managerRegistry = $this->prophesize(ManagerRegistry::class);

--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -61,7 +61,7 @@ final class EntrypointNormalizer implements NormalizerInterface
                     }
 
                     try {
-                        $entrypoint[$key] = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, $operation); // @phpstan-ignore-line phpstan issue as type is CollectionOperationInterface & Operation
+                        $entrypoint[$key] = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_PATH, $operation);
                     } catch (InvalidArgumentException|OperationNotFoundException) {
                         // Ignore resources without GET operations
                     }

--- a/src/JsonApi/Serializer/EntrypointNormalizer.php
+++ b/src/JsonApi/Serializer/EntrypointNormalizer.php
@@ -53,7 +53,7 @@ final class EntrypointNormalizer implements NormalizerInterface
                     }
 
                     try {
-                        $iri = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_URL, $operation); // @phpstan-ignore-line phpstan issue as type is CollectionOperationInterface & Operation
+                        $iri = $this->iriConverter->getIriFromResource($resourceClass, UrlGeneratorInterface::ABS_URL, $operation);
                         $entrypoint['links'][lcfirst($resource->getShortName())] = $iri;
                     } catch (InvalidArgumentException) {
                         // Ignore resources without GET operations

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -31,20 +31,24 @@ use ApiPlatform\State\OptionsInterface;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class ApiResource extends Metadata
 {
+    use CascadeToOperationsTrait;
     use WithResourceTrait;
 
+    /**
+     * @var Operations<HttpOperation>
+     */
     protected ?Operations $operations;
 
     /**
-     * @param array<int, HttpOperation>|array<string, HttpOperation>|Operations|null $operations   Operations is a list of HttpOperation
-     * @param array<string, Link>|array<string, mixed[]>|string[]|string|null        $uriVariables
-     * @param array<string, string>                                                  $headers
-     * @param string|callable|null                                                   $provider
-     * @param string|callable|null                                                   $processor
-     * @param mixed|null                                                             $mercure
-     * @param mixed|null                                                             $messenger
-     * @param mixed|null                                                             $input
-     * @param mixed|null                                                             $output
+     * @param list<HttpOperation>|array<string, HttpOperation>|Operations<HttpOperation>|null $operations   Operations is a list of HttpOperation
+     * @param array<string, Link>|array<string, mixed[]>|string[]|string|null                 $uriVariables
+     * @param array<string, string>                                                           $headers
+     * @param string|callable|null                                                            $provider
+     * @param string|callable|null                                                            $processor
+     * @param mixed|null                                                                      $mercure
+     * @param mixed|null                                                                      $messenger
+     * @param mixed|null                                                                      $input
+     * @param mixed|null                                                                      $output
      */
     public function __construct(
         /**
@@ -1012,6 +1016,7 @@ class ApiResource extends Metadata
             extraProperties: $extraProperties
         );
 
+        /* @var Operations<HttpOperation> $operations> */
         $this->operations = null === $operations ? null : new Operations($operations);
         $this->provider = $provider;
         $this->processor = $processor;
@@ -1020,11 +1025,17 @@ class ApiResource extends Metadata
         }
     }
 
+    /**
+     * @return Operations<HttpOperation>
+     */
     public function getOperations(): ?Operations
     {
         return $this->operations;
     }
 
+    /**
+     * @param Operations<HttpOperation> $operations
+     */
     public function withOperations(Operations $operations): static
     {
         $self = clone $this;

--- a/src/Metadata/CascadeFromResource.php
+++ b/src/Metadata/CascadeFromResource.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+/**
+ * @internal
+ *
+ * @phpstan-require-extends Operation
+ */
+trait CascadeFromResource
+{
+    use WithResourceTrait;
+
+    public function cascadeFromResource(ApiResource $apiResource, array $ignoredOptions = []): static
+    {
+        return $this->copyFrom($apiResource, $ignoredOptions);
+    }
+}

--- a/src/Metadata/CascadeToOperationsTrait.php
+++ b/src/Metadata/CascadeToOperationsTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata;
+
+use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+
+/**
+ * @internal
+ *
+ * @phpstan-require-extends ApiResource
+ */
+trait CascadeToOperationsTrait
+{
+    public function cascadeToOperations(): static
+    {
+        if (!$this instanceof ApiResource) {
+            throw new RuntimeException('Not an API resource');
+        }
+
+        if (!($operations = $this->getOperations() ?? [])) {
+            return $this;
+        }
+
+        return (clone $this)->withOperations(
+            new Operations($this->getMutatedOperations($operations, $this)),
+        );
+    }
+
+    public function cascadeToGraphQlOperations(): static
+    {
+        if (!$this instanceof ApiResource) {
+            throw new RuntimeException('Not an API resource');
+        }
+
+        if (!($operations = $this->getGraphQlOperations() ?? [])) {
+            return $this;
+        }
+
+        return (clone $this)->withGraphQlOperations(
+            $this->getMutatedOperations($operations, $this),
+        );
+    }
+
+    /**
+     * @param Operations<HttpOperation>|list<GraphQlOperation> $operations
+     *
+     * @return array[string, HttpOperation]|list<GraphQlOperation>
+     */
+    private function getMutatedOperations(iterable $operations, ApiResource $apiResource): iterable
+    {
+        $modifiedOperations = [];
+        foreach ($operations as $key => $operation) {
+            $modifiedOperations[$key] = $operation->cascadeFromResource($apiResource);
+        }
+
+        return $modifiedOperations;
+    }
+}

--- a/src/Metadata/Operation.php
+++ b/src/Metadata/Operation.php
@@ -20,6 +20,7 @@ use ApiPlatform\State\OptionsInterface;
  */
 abstract class Operation extends Metadata
 {
+    use CascadeFromResource;
     use WithResourceTrait;
 
     /**
@@ -861,7 +862,7 @@ abstract class Operation extends Metadata
         );
     }
 
-    public function withOperation($operation)
+    public function withOperation(self $operation): static
     {
         return $this->copyFrom($operation);
     }

--- a/src/Metadata/Operations.php
+++ b/src/Metadata/Operations.php
@@ -15,13 +15,18 @@ namespace ApiPlatform\Metadata;
 
 /**
  * An Operation dictionnary.
+ *
+ * @template-covariant T of Operation
  */
 final class Operations implements \IteratorAggregate, \Countable
 {
+    /**
+     * @var list<array{0: string, 1: T}>
+     */
     private array $operations = [];
 
     /**
-     * @param array<string|int, Operation> $operations
+     * @param list<T>|array<string, T> $operations
      */
     public function __construct(array $operations = [])
     {
@@ -42,6 +47,9 @@ final class Operations implements \IteratorAggregate, \Countable
         $this->sort();
     }
 
+    /**
+     * @return \Iterator<string, T>
+     */
     public function getIterator(): \Traversable
     {
         return (function (): \Generator {
@@ -97,7 +105,7 @@ final class Operations implements \IteratorAggregate, \Countable
 
     public function sort(): self
     {
-        usort($this->operations, fn ($a, $b): int|float => $a[1]->getPriority() - $b[1]->getPriority());
+        usort($this->operations, fn ($a, $b): int => $a[1]->getPriority() - $b[1]->getPriority());
 
         return $this;
     }

--- a/src/Metadata/Resource/Factory/FormatsResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/FormatsResourceMetadataCollectionFactory.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\ErrorResource;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 
@@ -67,6 +68,9 @@ final class FormatsResourceMetadataCollectionFactory implements ResourceMetadata
         return $resourceMetadataCollection;
     }
 
+    /**
+     * @param Operations<HttpOperation> $operations
+     */
     private function normalize(array $resourceInputFormats, array $resourceOutputFormats, Operations $operations): Operations
     {
         $newOperations = [];

--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -70,8 +70,7 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
 
         // No item operation has been found on all resources for resource class: generate one on the last resource
         // Helpful to generate an IRI for a resource without declaring the Get operation
-        /** @var HttpOperation $operation */
-        [$key, $operation] = $this->getOperationWithDefaults(resource: $resource, operation: new NotExposed(), generated: true, ignoredOptions: ['uriTemplate', 'uriVariables']); // @phpstan-ignore-line $resource is defined if count > 0
+        [$key, $operation] = $this->getOperationWithDefaults($resource, new NotExposed(), true, ['uriTemplate', 'uriVariables']); // @phpstan-ignore-line $resource is defined if count > 0
 
         if (!$this->linkFactory->createLinksFromIdentifiers($operation)) {
             $operation = $operation->withUriTemplate(self::$skolemUriTemplate);

--- a/src/Metadata/Resource/ResourceMetadataCollection.php
+++ b/src/Metadata/Resource/ResourceMetadataCollection.php
@@ -59,7 +59,7 @@ final class ResourceMetadataCollection extends \ArrayObject
             if (!$forceGraphQl) {
                 foreach ($metadata->getOperations() ?? [] as $name => $operation) {
                     $isCollection = $operation instanceof CollectionOperationInterface;
-                    $method = $operation->getMethod() ?? 'GET';
+                    $method = $operation->getMethod();
                     $isGetOperation = 'GET' === $method || 'OPTIONS' === $method || 'HEAD' === $method;
                     if ('' === $operationName && $isGetOperation && ($forceCollection ? $isCollection : !$isCollection)) {
                         return $this->operationCache[$httpCacheKey] = $operation;

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -71,13 +71,25 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
                     provider: AttributeResourceProvider::class,
                     operations: [
                         '_api_AttributeResource_get' => new Get(
-                            shortName: 'AttributeResource', class: AttributeResource::class, normalizationContext: ['skip_null_values' => true], priority: 1, provider: AttributeResourceProvider::class,
+                            shortName: 'AttributeResource',
+                            class: AttributeResource::class,
+                            normalizationContext: ['skip_null_values' => true],
+                            priority: 1,
+                            provider: AttributeResourceProvider::class,
                         ),
                         '_api_AttributeResource_put' => new Put(
-                            shortName: 'AttributeResource', class: AttributeResource::class, normalizationContext: ['skip_null_values' => true], priority: 2, provider: AttributeResourceProvider::class,
+                            shortName: 'AttributeResource',
+                            class: AttributeResource::class,
+                            normalizationContext: ['skip_null_values' => true],
+                            priority: 2,
+                            provider: AttributeResourceProvider::class,
                         ),
                         '_api_AttributeResource_delete' => new Delete(
-                            shortName: 'AttributeResource', class: AttributeResource::class, normalizationContext: ['skip_null_values' => true], priority: 3, provider: AttributeResourceProvider::class,
+                            shortName: 'AttributeResource',
+                            class: AttributeResource::class,
+                            normalizationContext: ['skip_null_values' => true],
+                            priority: 3,
+                            provider: AttributeResourceProvider::class,
                         ),
                     ],
                     graphQlOperations: $this->getDefaultGraphqlOperations('AttributeResource', AttributeResource::class, AttributeResourceProvider::class)

--- a/src/Metadata/WithResourceTrait.php
+++ b/src/Metadata/WithResourceTrait.php
@@ -13,15 +13,19 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata;
 
+/**
+ * @internal since api-platform/metadata 4.2
+ */
 trait WithResourceTrait
 {
-    protected function copyFrom(Metadata $resource): static
+    protected function copyFrom(Metadata $resource, array $ignoredOptions = []): static
     {
         $self = clone $this;
         foreach (get_class_methods($resource) as $method) {
             if (
                 method_exists($self, $method)
                 && preg_match('/^(?:get|is|can)(.*)/', (string) $method, $matches)
+                && (!$ignoredOptions || !\in_array(lcfirst($matches[1]), $ignoredOptions, true))
                 && null === $self->{$method}()
                 && null !== $val = $resource->{$method}()
             ) {

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -214,7 +214,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             }
 
             $path = $this->getPath($path);
-            $method = $operation->getMethod() ?? 'GET';
+            $method = $operation->getMethod();
 
             if (!\in_array($method, PathItem::$methods, true)) {
                 continue;
@@ -618,7 +618,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         foreach ($resourceMetadataCollection as $resource) {
             foreach ($resource->getOperations() as $operationName => $operation) {
                 $parameters = [];
-                $method = $operation instanceof HttpOperation ? $operation->getMethod() : 'GET';
+                $method = $operation->getMethod();
                 if (
                     $operationName === $operation->getName()
                     || isset($links[$operationName])

--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -103,7 +103,7 @@ final class ApiLoader extends Loader
                         $operation->getOptions() ?? [],
                         $operation->getHost() ?? '',
                         $operation->getSchemes() ?? [],
-                        [$operation->getMethod() ?? 'GET'],
+                        [$operation->getMethod()],
                         $operation->getCondition() ?? ''
                     );
 

--- a/tests/Fixtures/TestBundle/Entity/AttributeResource.php
+++ b/tests/Fixtures/TestBundle/Entity/AttributeResource.php
@@ -31,7 +31,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\State\AttributeResourceProvider;
 #[Put]
 #[Delete]
 #[ApiResource(
-    '/dummy/{dummyId}/attribute_resources/{identifier}{._format}',
+    uriTemplate: '/dummy/{dummyId}/attribute_resources/{identifier}{._format}',
     inputFormats: ['json' => ['application/merge-patch+json']],
     status: 301,
     provider: AttributeResourceProvider::class,


### PR DESCRIPTION
Also related to https://github.com/api-platform/core/pull/7213 

Adds a way to update your operations without having to do it manually (only when values are null but are set on the api resource).

This code would also make a refactoring possible inside our current metadata factories. 