### PR TITLE
chore: disable treat phpdoc type as certain for phpstan

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ parameters:
 		- tests
 		- tests/Fixtures/app/console
 	inferPrivatePropertyTypeFromConstructor: true
+	treatPhpDocTypesAsCertain: false
 	symfony:
 		containerXmlPath: tests/Fixtures/app/var/cache/test/AppKernelTestDebugContainer.xml
 		constantHassers: false
@@ -113,10 +114,6 @@ parameters:
 		-
 		    identifier: varTag.nativeType
 		-
-		    identifier: isset.offset
-		-
 		    identifier: trait.unused
-		-
-		    identifier: instanceof.alwaysTrue
 		-
 		    identifier: catch.neverThrown

--- a/src/Doctrine/Odm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Odm/State/LinksHandlerTrait.php
@@ -20,7 +20,6 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Util\StateOptionsTrait;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -93,10 +92,6 @@ trait LinksHandlerTrait
         }
 
         $classMetadata = $manager->getClassMetadata($aggregationClass);
-
-        if (!$classMetadata instanceof ClassMetadata) {
-            throw new RuntimeException(\sprintf('The class metadata for "%s" must be an instance of "%s".', $aggregationClass, ClassMetadata::class));
-        }
 
         $aggregation = $previousAggregationBuilder;
         if ($aggregationClass !== $previousAggregationClass) {

--- a/src/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
+++ b/src/Doctrine/Orm/Metadata/Property/DoctrineOrmPropertyMetadataFactory.php
@@ -70,7 +70,7 @@ final class DoctrineOrmPropertyMetadataFactory implements PropertyMetadataFactor
 
         if ($doctrineClassMetadata instanceof ClassMetadata && \in_array($property, $doctrineClassMetadata->getFieldNames(), true)) {
             $fieldMapping = $doctrineClassMetadata->getFieldMapping($property);
-            if (class_exists(FieldMapping::class) && $fieldMapping instanceof FieldMapping) {
+            if (class_exists(FieldMapping::class)) {
                 $propertyMetadata = $propertyMetadata->withDefault($fieldMapping->default ?? $propertyMetadata->getDefault());
             } else {
                 $propertyMetadata = $propertyMetadata->withDefault($fieldMapping['options']['default'] ?? $propertyMetadata->getDefault());

--- a/src/Doctrine/Orm/State/CollectionProvider.php
+++ b/src/Doctrine/Orm/State/CollectionProvider.php
@@ -56,7 +56,7 @@ final class CollectionProvider implements ProviderInterface
         $manager = $this->managerRegistry->getManagerForClass($entityClass);
 
         $repository = $manager->getRepository($entityClass);
-        if (!method_exists($repository, 'createQueryBuilder')) { // @phpstan-ignore-line function.alreadyNarrowedType
+        if (!method_exists($repository, 'createQueryBuilder')) {
             throw new RuntimeException('The repository class must have a "createQueryBuilder" method.');
         }
 

--- a/src/Doctrine/Orm/State/ItemProvider.php
+++ b/src/Doctrine/Orm/State/ItemProvider.php
@@ -65,7 +65,7 @@ final class ItemProvider implements ProviderInterface
         }
 
         $repository = $manager->getRepository($entityClass);
-        if (!method_exists($repository, 'createQueryBuilder')) { // @phpstan-ignore-line function.alreadyNarrowedType
+        if (!method_exists($repository, 'createQueryBuilder')) {
             throw new RuntimeException('The repository class must have a "createQueryBuilder" method.');
         }
 

--- a/src/Elasticsearch/State/ItemProvider.php
+++ b/src/Elasticsearch/State/ItemProvider.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Elasticsearch\State;
 
 use ApiPlatform\Elasticsearch\Serializer\DocumentNormalizer;
-use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\InflectorInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Util\Inflector;
@@ -49,9 +48,9 @@ final class ItemProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
     {
         $resourceClass = $operation->getClass();
-        $options = $operation->getStateOptions() instanceof Options ? $operation->getStateOptions() : new Options(index: $this->getIndex($operation));
+        $options = $operation->getStateOptions();
         if (!$options instanceof Options) {
-            throw new RuntimeException(\sprintf('The "%s" provider was called without "%s".', self::class, Options::class));
+            $options = new Options(index: $this->getIndex($operation));
         }
 
         $params = [

--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -1026,7 +1026,7 @@ class ApiResource extends Metadata
     }
 
     /**
-     * @return Operations<HttpOperation>
+     * @return Operations<HttpOperation>|null
      */
     public function getOperations(): ?Operations
     {

--- a/src/Metadata/Tests/Resource/OperationTest.php
+++ b/src/Metadata/Tests/Resource/OperationTest.php
@@ -36,7 +36,7 @@ final class OperationTest extends TestCase
 
         $this->assertSame($operation->getShortName(), 'test');
         $this->assertSame($operation->canRead(), false);
-        $this->assertSame($operation instanceof CollectionOperationInterface, true);
+        $this->assertInstanceOf(CollectionOperationInterface::class, $operation);
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('operationProvider')]

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -186,7 +186,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $openapiAttribute = $operation->getOpenapi();
 
             // Operation ignored from OpenApi
-            if ($operation instanceof HttpOperation && false === $openapiAttribute) {
+            if (false === $openapiAttribute) {
                 continue;
             }
 
@@ -386,7 +386,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $existingResponses = $openapiOperation->getResponses() ?: [];
             $overrideResponses = $operation->getExtraProperties()[self::OVERRIDE_OPENAPI_RESPONSES] ?? $this->openApiOptions->getOverrideResponses();
             $errors = null;
-            if ($operation instanceof HttpOperation && null !== ($errors = $operation->getErrors())) {
+            if (null !== ($errors = $operation->getErrors())) {
                 /** @var array<class-string|string, Error> */
                 $errorOperations = [];
                 foreach ($errors as $error) {
@@ -629,7 +629,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                 }
 
                 // Operation ignored from OpenApi
-                if ($operation instanceof HttpOperation && (false === $operation->getOpenapi() || $operation->getOpenapi() instanceof Webhook)) {
+                if (false === $operation->getOpenapi() || $operation->getOpenapi() instanceof Webhook) {
                     continue;
                 }
 

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -909,7 +909,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
                 $data = $this->normalizeCollectionOfRelations($propertyMetadata, $attributeValue, $resourceClass, $format, $childContext);
                 $context['data'] = $data;
-                $context['type'] = ($nullable && $type instanceof Type) ? Type::nullable($type) : $type;
+                $context['type'] = $nullable ? Type::nullable($type) : $type;
 
                 if ($this->tagCollector) {
                     $this->tagCollector->collect($context);

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1204,7 +1204,7 @@ class AbstractItemNormalizerTest extends TestCase
         $errors = [];
         $actual = $normalizer->denormalize($data, Dummy::class, null, ['not_normalizable_value_exceptions' => &$errors]);
         $this->assertEmpty($actual->relatedDummies);
-        $this->assertCount(1, $errors); // @phpstan-ignore-line method.impossibleType (false positive)
+        $this->assertCount(1, $errors);
         $this->assertInstanceOf(NotNormalizableValueException::class, $errors[0]);
         $this->assertSame('relatedDummies[0]', $errors[0]->getPath());
         $this->assertSame('Invalid IRI "wrong".', $errors[0]->getMessage());

--- a/src/State/Provider/DeserializeProvider.php
+++ b/src/State/Provider/DeserializeProvider.php
@@ -75,7 +75,7 @@ final class DeserializeProvider implements ProviderInterface
             throw new UnsupportedMediaTypeHttpException('Format not supported.');
         }
 
-        if ($operation instanceof HttpOperation && null === ($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE] ?? null)) {
+        if (null === ($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE] ?? null)) {
             $method = $operation->getMethod();
             $assignObjectToPopulate = 'POST' === $method
                 || 'PATCH' === $method

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -629,7 +629,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $loader->load('graphql.xml');
 
-        // @phpstan-ignore-next-line because PHPStan uses the container of the test env cache and in test the parameter kernel.bundles always contains the key TwigBundle
         if (!class_exists(Environment::class) || !isset($container->getParameter('kernel.bundles')['TwigBundle'])) {
             if ($graphiqlEnabled) {
                 throw new RuntimeException(\sprintf('GraphiQL interfaces depend on Twig. Please activate TwigBundle for the %s environnement or disable GraphiQL.', $container->getParameter('kernel.environment')));

--- a/src/Symfony/Controller/MainController.php
+++ b/src/Symfony/Controller/MainController.php
@@ -49,7 +49,7 @@ final class MainController
     {
         $operation = $this->initializeOperation($request);
 
-        if (!$operation || !$operation instanceof HttpOperation) {
+        if (!$operation instanceof HttpOperation) {
             throw new RuntimeException('Not an HTTP API operation.');
         }
 

--- a/src/Symfony/EventListener/DeserializeListener.php
+++ b/src/Symfony/EventListener/DeserializeListener.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\EventListener;
 
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\SerializerContextBuilderInterface;
@@ -62,7 +61,7 @@ final class DeserializeListener
             return;
         }
 
-        if (null === $operation->canDeserialize() && $operation instanceof HttpOperation) {
+        if (null === $operation->canDeserialize()) {
             $operation = $operation->withDeserialize(\in_array($method, ['POST', 'PUT', 'PATCH'], true));
         }
 

--- a/src/Symfony/EventListener/ReadListener.php
+++ b/src/Symfony/EventListener/ReadListener.php
@@ -15,7 +15,6 @@ namespace ApiPlatform\Symfony\EventListener;
 
 use ApiPlatform\Metadata\Exception\InvalidIdentifierException;
 use ApiPlatform\Metadata\Exception\InvalidUriVariableException;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\UriVariablesConverterInterface;
 use ApiPlatform\Metadata\Util\CloneTrait;
@@ -73,7 +72,7 @@ final class ReadListener
         }
 
         $uriVariables = [];
-        if (!$request->attributes->has('exception') && $operation instanceof HttpOperation) {
+        if (!$request->attributes->has('exception')) {
             try {
                 $uriVariables = $this->getOperationUriVariables($operation, $request->attributes->all(), $operation->getClass());
             } catch (InvalidIdentifierException|InvalidUriVariableException $e) {

--- a/src/Symfony/EventListener/WriteListener.php
+++ b/src/Symfony/EventListener/WriteListener.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\Symfony\EventListener;
 use ApiPlatform\Metadata\Error;
 use ApiPlatform\Metadata\Exception\InvalidIdentifierException;
 use ApiPlatform\Metadata\Exception\InvalidUriVariableException;
-use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\UriVariablesConverterInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
@@ -70,7 +69,7 @@ final class WriteListener
         }
 
         $uriVariables = $request->attributes->get('_api_uri_variables') ?? [];
-        if (!$uriVariables && !$operation instanceof Error && $operation instanceof HttpOperation) {
+        if (!$uriVariables && !$operation instanceof Error) {
             try {
                 $uriVariables = $this->getOperationUriVariables($operation, $request->attributes->all(), $operation->getClass());
             } catch (InvalidIdentifierException|InvalidUriVariableException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

I was fixing the `identifier: instanceof.alwaysTrue` errors and ends up with code like 
```
 if (null === $parameter->getOpenApi() && ($openApi = $description[$key]['openapi'] ?? null) && $openApi instanceof OpenApiParameter) {
```
=> Here the  `$openApi instanceof OpenApiParameter` check is reported as useless but the type is coming from phpdoc and there is a test which check what happen if the phpdoc is not respected

or 
```
$repository = $manager->getRepository($documentClass);
if (!$repository instanceof DocumentRepository) {
```
Same here, instanceof DocumentRepository is reported as useless but, it's your right to not trust the getRepository phpdoc.

That's the purpose of `treatPhpDocTypesAsCertain: false`
https://phpstan.org/config-reference#treatphpdoctypesascertain ; this allows you to add extra safety check when the information is coming from the phpdoc (but report it as useless when the information is coming from a real native type).

This is useful for open source lib which extra safety check and allow you
- To solve some phpstan issues
- To remove some phpstan-ignore