### PR TITLE
fix(openapi): command options mode (`InputOption::VALUE_REQUIRED`)

### DIFF
--- a/src/OpenApi/Command/OpenApiCommand.php
+++ b/src/OpenApi/Command/OpenApiCommand.php
@@ -43,8 +43,8 @@ final class OpenApiCommand extends Command
         $this
             ->setDescription('Dump the Open API documentation')
             ->addOption('yaml', 'y', InputOption::VALUE_NONE, 'Dump the documentation in YAML')
-            ->addOption('output', 'o', InputOption::VALUE_OPTIONAL, 'Write output to file')
-            ->addOption('spec-version', null, InputOption::VALUE_OPTIONAL, 'Open API version to use (2 or 3) (2 is deprecated)', '3')
+            ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Write output to file')
+            ->addOption('spec-version', null, InputOption::VALUE_REQUIRED, 'Open API version to use (2 or 3) (2 is deprecated)', '3')
             ->addOption('api-gateway', null, InputOption::VALUE_NONE, 'Enable the Amazon API Gateway compatibility mode')
             ->addOption('filter-tags', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Filter only matching x-apiplatform-tag operations', null);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | 
| License       | MIT
| Doc PR        | 

Options are always optional. But when using these options, a value is required.