### PR TITLE
fix(serializer): Allow nested denormalization when allow_extra_attributes=false

### DIFF
--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -107,4 +107,14 @@ class ItemNormalizer extends AbstractItemNormalizer
 
         return $uriVariables;
     }
+
+    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+    {
+        $allowedAttributes = parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
+        if (\is_array($allowedAttributes) && ($context['api_denormalize'] ?? false)) {
+            $allowedAttributes = array_merge($allowedAttributes, ['id']);
+        }
+
+        return $allowedAttributes;
+    }
 }

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -68,6 +68,17 @@ class ItemNormalizer extends AbstractItemNormalizer
             }
         }
 
+        // See https://github.com/api-platform/core/pull/7270 - id may be an allowed attribute due to being added in the
+        // overridden getAllowedAttributes below, in order to allow updating a nested item via ID. But in this case it
+        // may not "really" be an allowed attribute, ie we don't want to actually use it in denormalization. In this
+        // scenario it will not be present in parent::getAllowedAttributes
+        if (isset($data['id'], $context['resource_class'])) {
+            $parentAllowedAttributes = parent::getAllowedAttributes($class, $context, true);
+            if (is_array($parentAllowedAttributes) && !in_array('id', $parentAllowedAttributes)) {
+                unset($data['id']);
+            }
+        }
+
         return parent::denormalize($data, $class, $format, $context);
     }
 

--- a/src/Serializer/ItemNormalizer.php
+++ b/src/Serializer/ItemNormalizer.php
@@ -74,7 +74,7 @@ class ItemNormalizer extends AbstractItemNormalizer
         // scenario it will not be present in parent::getAllowedAttributes
         if (isset($data['id'], $context['resource_class'])) {
             $parentAllowedAttributes = parent::getAllowedAttributes($class, $context, true);
-            if (is_array($parentAllowedAttributes) && !in_array('id', $parentAllowedAttributes)) {
+            if (\is_array($parentAllowedAttributes) && !\in_array('id', $parentAllowedAttributes, true)) {
                 unset($data['id']);
             }
         }

--- a/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
@@ -40,7 +40,7 @@ class Bar6225
     private Uuid $id;
 
     #[ORM\OneToOne(mappedBy: 'bar', cascade: ['persist', 'remove'])]
-    private Foo6225 $foo;
+    private ?Foo6225 $foo;
 
     #[ORM\Column(length: 255)]
     #[Groups(['Foo:Write', 'Foo:Read'])]

--- a/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
@@ -14,13 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
-use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\Metadata\Link;
-use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Uid\Uuid;
 
@@ -56,7 +50,8 @@ class Bar6225
         return $this->foo;
     }
 
-    public function setFoo(Foo6225 $foo): static {
+    public function setFoo(Foo6225 $foo): static
+    {
         $this->foo = $foo;
 
         return $this;
@@ -67,7 +62,8 @@ class Bar6225
         return $this->someProperty;
     }
 
-    public function setSomeProperty(string $someProperty): static {
+    public function setSomeProperty(string $someProperty): static
+    {
         $this->someProperty = $someProperty;
 
         return $this;

--- a/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6225/Bar6225.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'bar6225')]
+#[ApiResource]
+class Bar6225
+{
+    public function __construct()
+    {
+        $this->id = Uuid::v7();
+    }
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'symfony_uuid', unique: true)]
+    #[Groups(['Foo:Read'])]
+    private Uuid $id;
+
+    #[ORM\OneToOne(mappedBy: 'bar', cascade: ['persist', 'remove'])]
+    private Foo6225 $foo;
+
+    #[ORM\Column(length: 255)]
+    #[Groups(['Foo:Write', 'Foo:Read'])]
+    private string $someProperty;
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getFoo(): Foo6225
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(Foo6225 $foo): static {
+        $this->foo = $foo;
+
+        return $this;
+    }
+
+    public function getSomeProperty(): string
+    {
+        return $this->someProperty;
+    }
+
+    public function setSomeProperty(string $someProperty): static {
+        $this->someProperty = $someProperty;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue6225/Foo6225.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6225/Foo6225.php
@@ -14,12 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
-use ApiPlatform\Metadata\Put;
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Uid\Uuid;
 

--- a/tests/Fixtures/TestBundle/Entity/Issue6225/Foo6225.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue6225/Foo6225.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Put;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Uid\Uuid;
+
+#[ORM\Entity()]
+#[ORM\Table(name: 'foo6225')]
+#[ApiResource(
+    operations: [
+        new Post(),
+        new Patch(),
+    ],
+    normalizationContext: [
+        'groups' => ['Foo:Read'],
+    ],
+    denormalizationContext: [
+        'allow_extra_attributes' => false,
+        'groups' => ['Foo:Write'],
+    ],
+)]
+class Foo6225
+{
+    public function __construct()
+    {
+        $this->id = Uuid::v7();
+    }
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'symfony_uuid', unique: true)]
+    #[Groups(['Foo:Read'])]
+    private Uuid $id;
+
+    #[ORM\OneToOne(inversedBy: 'foo', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(nullable: false)]
+    #[Groups(['Foo:Write', 'Foo:Read'])]
+    private Bar6225 $bar;
+
+    public function getId(): Uuid
+    {
+        return $this->id;
+    }
+
+    public function getBar(): Bar6225
+    {
+        return $this->bar;
+    }
+
+    public function setBar(Bar6225 $bar): static
+    {
+        $this->bar = $bar;
+
+        return $this;
+    }
+}

--- a/tests/Functional/NestedPatchTest.php
+++ b/tests/Functional/NestedPatchTest.php
@@ -21,6 +21,10 @@ class NestedPatchTest extends ApiTestCase
 
     public function testIssue6225(): void
     {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
         $this->recreateSchema(self::getResources());
 
         $response = self::createClient()->request('POST', '/foo6225s', [

--- a/tests/Functional/NestedPatchTest.php
+++ b/tests/Functional/NestedPatchTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225\Bar6225;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6225\Foo6225;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+class NestedPatchTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    public static function getResources(): array {
+        return [Foo6225::class, Bar6225::class];
+    }
+
+    public function testIssue6225(): void
+    {
+        $this->recreateSchema(self::getResources());
+
+        $response = self::createClient()->request('POST', '/foo6225s', [
+            'json' => [
+                'bar' => [
+                    'someProperty' => 'abc'
+                ]
+            ],
+            'headers' => [
+                'accept' => 'application/json'
+            ]
+        ]);
+        static::assertResponseIsSuccessful();
+        $responseContent = json_decode($response->getContent(), true);
+        $createdFooId = $responseContent['id'];
+        $createdBarId = $responseContent['bar']['id'];
+
+        $patchResponse = self::createClient()->request('PATCH', '/foo6225s/'.$createdFooId, [
+            'json' => [
+                'bar' => [
+                    'id' => $createdBarId,
+                    'someProperty' => 'def'
+                ]
+            ],
+            'headers' => [
+                'accept' => 'application/json',
+                'content-type' => 'application/merge-patch+json'
+            ]
+        ]);
+        static::assertResponseIsSuccessful();
+        static::assertEquals([
+            'id' => $createdFooId,
+            'bar' => [
+                'id' => $createdBarId,
+                'someProperty' => 'def'
+            ]
+        ], json_decode($patchResponse->getContent(), true));
+    }
+}

--- a/tests/Functional/NestedPatchTest.php
+++ b/tests/Functional/NestedPatchTest.php
@@ -1,5 +1,16 @@
 <?php
 
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
 namespace ApiPlatform\Tests\Functional;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
@@ -15,7 +26,8 @@ class NestedPatchTest extends ApiTestCase
 
     protected static ?bool $alwaysBootKernel = false;
 
-    public static function getResources(): array {
+    public static function getResources(): array
+    {
         return [Foo6225::class, Bar6225::class];
     }
 
@@ -30,12 +42,12 @@ class NestedPatchTest extends ApiTestCase
         $response = self::createClient()->request('POST', '/foo6225s', [
             'json' => [
                 'bar' => [
-                    'someProperty' => 'abc'
-                ]
+                    'someProperty' => 'abc',
+                ],
             ],
             'headers' => [
-                'accept' => 'application/json'
-            ]
+                'accept' => 'application/json',
+            ],
         ]);
         static::assertResponseIsSuccessful();
         $responseContent = json_decode($response->getContent(), true);
@@ -46,21 +58,21 @@ class NestedPatchTest extends ApiTestCase
             'json' => [
                 'bar' => [
                     'id' => $createdBarId,
-                    'someProperty' => 'def'
-                ]
+                    'someProperty' => 'def',
+                ],
             ],
             'headers' => [
                 'accept' => 'application/json',
-                'content-type' => 'application/merge-patch+json'
-            ]
+                'content-type' => 'application/merge-patch+json',
+            ],
         ]);
         static::assertResponseIsSuccessful();
         static::assertEquals([
             'id' => $createdFooId,
             'bar' => [
                 'id' => $createdBarId,
-                'someProperty' => 'def'
-            ]
+                'someProperty' => 'def',
+            ],
         ], json_decode($patchResponse->getContent(), true));
     }
 }

--- a/tests/Functional/NestedPatchTest.php
+++ b/tests/Functional/NestedPatchTest.php
@@ -13,6 +13,8 @@ class NestedPatchTest extends ApiTestCase
     use RecreateSchemaTrait;
     use SetupClassResourcesTrait;
 
+    protected static ?bool $alwaysBootKernel = false;
+
     public static function getResources(): array {
         return [Foo6225::class, Bar6225::class];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Resolves https://github.com/api-platform/core/issues/6225
| License       | MIT

The linked issue was resolved for JSON LD format with https://github.com/api-platform/core/pull/6451 but not for standard JSON, so this PR implements the same change in the standard ItemNormalizer.

The included test file demonstrates the expected behaviour, it should be possible to alter the Bar entity's `someProperty` via a PATCH request to edit its parent `Foo` object.

This test passes with the ItemNormalizer change, but fails without it due to `Extra attributes are not allowed (\"id\" is unknown).`.

First contribution so let me know if I've done things correctly or if I've missed anything needed for approval!