### PR TITLE
Do not fail if phpstan/phpdoc-parser is missing

### DIFF
--- a/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
@@ -138,6 +138,10 @@ final class PhpDocResourceMetadataCollectionFactory implements ResourceMetadataC
             return null;
         }
 
+        if (!class_exists(TokenIterator::class)) {
+            return null;
+        }
+
         $tokens = new TokenIterator($this->lexer->tokenize($rawDocNode));
         $phpDocNode = $this->phpDocParser->parse($tokens);
         $tokens->consumeTokenType(Lexer::TOKEN_END);

--- a/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
@@ -133,12 +133,11 @@ final class PhpDocResourceMetadataCollectionFactory implements ResourceMetadataC
         }
 
         $rawDocNode = $reflectionClass->getDocComment();
-
         if (!$rawDocNode) {
             return null;
         }
 
-        if (!class_exists(TokenIterator::class)) {
+        if (!$this->phpDocParser || !$this->lexer) {
             return null;
         }
 

--- a/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php
@@ -126,6 +126,10 @@ final class PhpDocResourceMetadataCollectionFactory implements ResourceMetadataC
             return $this->docBlocks[$class];
         }
 
+        if (!$this->phpDocParser || !$this->lexer) {
+            return null;
+        }
+
         try {
             $reflectionClass = new \ReflectionClass($class);
         } catch (\ReflectionException) {
@@ -134,10 +138,6 @@ final class PhpDocResourceMetadataCollectionFactory implements ResourceMetadataC
 
         $rawDocNode = $reflectionClass->getDocComment();
         if (!$rawDocNode) {
-            return null;
-        }
-
-        if (!$this->phpDocParser || !$this->lexer) {
             return null;
         }
 

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -29,6 +29,7 @@
     "require": {
         "php": ">=8.2",
         "doctrine/inflector": "^2.0",
+        "phpstan/phpdoc-parser": "^1.29 || ^2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/property-info": "^6.4 || ^7.1",
@@ -40,7 +41,6 @@
         "api-platform/openapi": "^4.1.11",
         "api-platform/state": "^4.1.11",
         "phpspec/prophecy-phpunit": "^2.2",
-        "phpstan/phpdoc-parser": "^1.29 || ^2.0",
         "phpunit/phpunit": "11.5.x-dev",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/routing": "^6.4 || ^7.0",

--- a/src/Metadata/composer.json
+++ b/src/Metadata/composer.json
@@ -29,18 +29,18 @@
     "require": {
         "php": ">=8.2",
         "doctrine/inflector": "^2.0",
-        "phpstan/phpdoc-parser": "^1.29 || ^2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/property-info": "^6.4 || ^7.1",
         "symfony/string": "^6.4 || ^7.0",
-        "symfony/type-info": "^7.2"
+        "symfony/type-info": "^7.3"
     },
     "require-dev": {
         "api-platform/json-schema": "^4.1.11",
         "api-platform/openapi": "^4.1.11",
         "api-platform/state": "^4.1.11",
         "phpspec/prophecy-phpunit": "^2.2",
+        "phpstan/phpdoc-parser": "^1.29 || ^2.0",
         "phpunit/phpunit": "11.5.x-dev",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/routing": "^6.4 || ^7.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | Closes #7275
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Not fully sure about this one @soyuka but
- I assume the issue https://github.com/api-platform/core/issues/7275 is related to https://github.com/api-platform/core/pull/7204/files#diff-a74b749ab4aa559ca58d9087c4f2c9193ca78bc87ac65ab9a6a09f2d8b799581 which does not require phpstan/doc-parser since 4.18.
- Lot of PHPStan\PhpDocParser classes are used in PhpDocResourceMetadataCollectionFactory. (like https://github.com/api-platform/core/blob/d3b98b5354213937f96143c5d8819f98e2e66640/src/Metadata/Resource/Factory/PhpDocResourceMetadataCollectionFactory.php#L141)

So since phpDocParser/lexer will be null when PhpDocParser is not installed, a null check might be enough.