### PR TITLE
Remove internal from Metadata

### DIFF
--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -15,6 +15,9 @@ namespace ApiPlatform\Metadata;
 
 use ApiPlatform\State\OptionsInterface;
 
+/**
+ * @psalm-inheritors ApiResource|Operation
+ */
 abstract class Metadata
 {
     protected ?Parameters $parameters = null;

--- a/src/Metadata/Metadata.php
+++ b/src/Metadata/Metadata.php
@@ -15,9 +15,6 @@ namespace ApiPlatform\Metadata;
 
 use ApiPlatform\State\OptionsInterface;
 
-/**
- * @internal
- */
 abstract class Metadata
 {
     protected ?Parameters $parameters = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #...
| License       | MIT
| Doc PR        | api-platform/docs#...

Hi @soyuka,

When using `Operation::getExtraProperties`, phpstan report
```
 Call to method getExtraProperties() of internal class          
         ApiPlatform\Metadata\Metadata from outside its root namespace  
         ApiPlatform
```

This is because those getter are defined in Metadata which is marked as internal.
You can see a reproducer on phpstan.org with https://phpstan.org/r/ec5a2ab4-eac7-4814-836d-0edf97ccee25

Since all Metadata setter/getter shouldn't be considered as internal ; I feel like the simplest solution would be to remove the `@internal` tag from the abstract class.

Would be nice if it could be added before the 4.2 release. 🙏 