### PR TITLE
fix(openapi): output `partial` query parameter to OpenAPI when `pagination_client_enabled` is true

### DIFF
--- a/features/openapi/docs.feature
+++ b/features/openapi/docs.feature
@@ -108,13 +108,13 @@ Feature: Documentation support
     #And the "isDummyBoolean" property exists for the OpenAPI class "DummyBoolean"
     #And the "isDummyBoolean" property is not read only for the OpenAPI class "DummyBoolean"
     # Filters
-    And the JSON node "paths./dummies.get.parameters[3].name" should be equal to "dummyBoolean"
-    And the JSON node "paths./dummies.get.parameters[3].in" should be equal to "query"
-    And the JSON node "paths./dummies.get.parameters[3].required" should be false
-    And the JSON node "paths./dummies.get.parameters[3].schema.type" should be equal to "boolean"
+    And the JSON node "paths./dummies.get.parameters[4].name" should be equal to "dummyBoolean"
+    And the JSON node "paths./dummies.get.parameters[4].in" should be equal to "query"
+    And the JSON node "paths./dummies.get.parameters[4].required" should be false
+    And the JSON node "paths./dummies.get.parameters[4].schema.type" should be equal to "boolean"
 
-    And the JSON node "paths./dummy_cars.get.parameters[8].name" should be equal to "foobar[]"
-    And the JSON node "paths./dummy_cars.get.parameters[8].description" should be equal to "Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: foobar[]={propertyName}&foobar[]={anotherPropertyName}&foobar[{nestedPropertyParent}][]={nestedProperty}"
+    And the JSON node "paths./dummy_cars.get.parameters[9].name" should be equal to "foobar[]"
+    And the JSON node "paths./dummy_cars.get.parameters[9].description" should be equal to "Allows you to reduce the response to contain only the properties you need. If your desired property is nested, you can address it using nested arrays. Example: foobar[]={propertyName}&foobar[]={anotherPropertyName}&foobar[{nestedPropertyParent}][]={nestedProperty}"
 
     # Webhook
     And the JSON node "webhooks.a.get.description" should be equal to "Something else here for example"
@@ -141,16 +141,16 @@ Feature: Documentation support
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[3].required" should be false
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[3].schema.type" should be equal to "boolean"
 
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[4].name" should be equal to "name"
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[4].in" should be equal to "query"
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[4].required" should be false
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[4].schema.type" should be equal to "string"
-
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[5].name" should be equal to "description"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[5].name" should be equal to "name"
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[5].in" should be equal to "query"
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[5].required" should be false
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[5].schema.type" should be equal to "string"
 
-    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 6 elements
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[6].name" should be equal to "description"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[6].in" should be equal to "query"
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters[6].required" should be false
+
+    And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.parameters" should have 7 elements
 
     # Subcollection - check schema
     And the JSON node "paths./related_dummies/{id}/related_to_dummy_friends.get.responses.200.content.application/ld+json.schema.properties.hydra:member.items.$ref" should be equal to "#/components/schemas/RelatedToDummyFriend.jsonld-fakemanytomany"

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -755,6 +755,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $parameters[] = new Parameter($this->paginationOptions->getPaginationClientEnabledParameterName(), 'query', 'Enable or disable pagination', false, false, true, ['type' => 'boolean']);
         }
 
+        if ($operation->getPaginationClientPartial() ?? $this->paginationOptions->isClientPartialPaginationEnabled()) {
+            $parameters[] = new Parameter($this->paginationOptions->getPartialPaginationParameterName(), 'query', 'Enable or disable partial pagination', false, false, true, ['type' => 'boolean']);
+        }
+
         return $parameters;
     }
 

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -182,6 +182,7 @@ class OpenApiFactoryTest extends TestCase
                 'paginatedDummyCollection' => (new GetCollection())->withUriTemplate('/paginated')
                     ->withPaginationClientEnabled(true)
                     ->withPaginationClientItemsPerPage(true)
+                    ->withPaginationClientPartial(true)
                     ->withPaginationItemsPerPage(20)
                     ->withPaginationMaximumItemsPerPage(80)
                     ->withOperation($baseOperation),
@@ -992,6 +993,9 @@ class OpenApiFactoryTest extends TestCase
                     'maximum' => 80,
                 ]),
                 new Parameter('pagination', 'query', 'Enable or disable pagination', false, false, true, [
+                    'type' => 'boolean',
+                ]),
+                new Parameter('partial', 'query', 'Enable or disable partial pagination', false, false, true, [
                     'type' => 'boolean',
                 ]),
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Currently, even if we set `pagination_client_enabled` to `true`, the `partial` query parameter is not automatically output to the OpenAPI document.

This PR makes it so that it is automatically output.

e.g.

```diff
  # config/packages/api_platform.yaml
  api_platform:
      title: Hello API Platform
      version: 1.0.0
      defaults:
          stateless: true
          cache_headers:
              vary: ['Content-Type', 'Authorization', 'Origin']
+         pagination_client_enabled: true
+         pagination_client_items_per_page: true
+         pagination_client_partial: true
```

| Before | After |
| --- | --- |
| ![](https://github.com/user-attachments/assets/8c3cfb78-f442-45ad-889d-8392f822ed6c) | ![](https://github.com/user-attachments/assets/b0beacd3-53d7-4bec-b74d-1c09a4df7dc9) |

## Related PRs

- #1292

