### PR TITLE
fix(validation): moving dependence from require-dev to require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "symfony/serializer": "^6.4 || ^7.0",
         "symfony/translation-contracts": "^3.3",
         "symfony/type-info": "^7.2",
+        "symfony/validator": "^6.4 || ^7.1",
         "symfony/web-link": "^6.4 || ^7.1",
         "willdurand/negotiation": "^3.1"
     },

--- a/src/Validator/composer.json
+++ b/src/Validator/composer.json
@@ -24,15 +24,15 @@
     "require": {
         "php": ">=8.2",
         "api-platform/metadata": "^4.1.11",
+        "symfony/http-kernel": "^6.4 || ^7.1",
+        "symfony/serializer": "^6.4 || ^7.1",
         "symfony/type-info": "^7.2",
+        "symfony/validator": "^6.4 || ^7.1",
         "symfony/web-link": "^6.4 || ^7.1"
     },
     "require-dev": {
         "phpspec/prophecy-phpunit": "^2.2",
-        "symfony/serializer": "^6.4 || ^7.0",
-        "phpunit/phpunit": "11.5.x-dev",
-        "symfony/validator": "^6.4 || ^7.0",
-        "symfony/http-kernel": "^6.4 || ^7.0"
+        "phpunit/phpunit": "11.5.x-dev"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since this PR : https://github.com/api-platform/core/pull/6923/files#diff-1e3988d369806deb771b741779b2cdb48b7ec158be64bb552ee2dee481b43b3e the (https://github.com/api-platform/core/blob/4.1/src/Validator/Exception/ValidationException.php#L23-L27) class is defined as error resource (for OpenAPI) and this class need these dependencies. 

Spotted here : https://github.com/lexik/LexikJWTAuthenticationBundle/actions/runs/15939374300/job/44965098430 