### PR TITLE
fix(state): object-mapper reuse related entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,7 +181,7 @@
         "symfony/maker-bundle": "^1.24",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^6.4 || ^7.0",
-        "symfony/object-mapper": "^7.3",
+        "symfony/object-mapper": "7.4.x-dev",
         "symfony/routing": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
         "symfony/security-core": "^6.4 || ^7.0",

--- a/src/State/ObjectMapper/ClearObjectMapInterface.php
+++ b/src/State/ObjectMapper/ClearObjectMapInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\ObjectMapper;
+
+/**
+ * @internal
+ */
+interface ClearObjectMapInterface
+{
+    /**
+     * Clear object map to free memory.
+     */
+    public function clearObjectMap(): void;
+}

--- a/src/State/ObjectMapper/ObjectMapper.php
+++ b/src/State/ObjectMapper/ObjectMapper.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\ObjectMapper;
+
+use Symfony\Component\ObjectMapper\ObjectMapperAwareInterface;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+
+final class ObjectMapper implements ObjectMapperInterface, ClearObjectMapInterface
+{
+    private ?\SplObjectStorage $objectMap = null;
+
+    public function __construct(private ObjectMapperInterface $decorated)
+    {
+        if (null === $this->objectMap) {
+            $this->objectMap = new \SplObjectStorage();
+        }
+
+        if ($this->decorated instanceof ObjectMapperAwareInterface) {
+            $this->decorated = $this->decorated->withObjectMapper($this);
+        }
+    }
+
+    public function map(object $source, object|string|null $target = null): object
+    {
+        if (!\is_object($target) && isset($this->objectMap[$source])) {
+            $target = $this->objectMap[$source];
+        }
+        $mapped = $this->decorated->map($source, $target);
+        $this->objectMap[$mapped] = $source;
+
+        return $mapped;
+    }
+
+    public function clearObjectMap(): void
+    {
+        foreach ($this->objectMap as $k) {
+            $this->objectMap->detach($k);
+        }
+    }
+}

--- a/src/State/Processor/ObjectMapperProcessor.php
+++ b/src/State/Processor/ObjectMapperProcessor.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\State\Processor;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ObjectMapper\ClearObjectMapInterface;
 use ApiPlatform\State\ProcessorInterface;
 use Symfony\Component\ObjectMapper\Attribute\Map;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
@@ -42,6 +43,12 @@ final class ObjectMapperProcessor implements ProcessorInterface
             return $this->decorated->process($data, $operation, $uriVariables, $context);
         }
 
-        return $this->objectMapper->map($this->decorated->process($this->objectMapper->map($data), $operation, $uriVariables, $context), $operation->getClass());
+        $data = $this->objectMapper->map($this->decorated->process($this->objectMapper->map($data), $operation, $uriVariables, $context), $operation->getClass());
+
+        if ($this->objectMapper instanceof ClearObjectMapInterface) {
+            $this->objectMapper->clearObjectMap();
+        }
+
+        return $data;
     }
 }

--- a/src/Symfony/Bundle/Resources/config/state/object_mapper.xml
+++ b/src/Symfony/Bundle/Resources/config/state/object_mapper.xml
@@ -4,13 +4,27 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="api_platform.state_provider.object_mapper" class="ApiPlatform\State\Provider\ObjectMapperProvider" decorates="api_platform.state_provider.read">
-            <argument type="service" id="object_mapper" on-invalid="null" />
+        <service id="api_platform.object_mapper.metadata_factory" class="Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory">
+        </service>
+
+        <service id="api_platform.object_mapper" class="Symfony\Component\ObjectMapper\ObjectMapper">
+            <argument type="service" id="api_platform.object_mapper.metadata_factory" />
+            <argument type="service" id="property_accessor" on-invalid="null" />
+            <argument type="tagged_locator" tag="object_mapper.transform_callable"/>
+            <argument type="tagged_locator" tag="object_mapper.condition_callable"/>
+        </service>
+
+        <service id="api_platform.object_mapper.relation" class="ApiPlatform\State\ObjectMapper\ObjectMapper" decorates="api_platform.object_mapper" decoration-priority="-255">
+            <argument type="service" id="api_platform.object_mapper.relation.inner" />
+        </service>
+
+        <service id="api_platform.state_provider.object_mapper" class="ApiPlatform\State\Provider\ObjectMapperProvider" decorates="api_platform.state_provider.locator">
+            <argument type="service" id="api_platform.object_mapper" on-invalid="null" />
             <argument type="service" id="api_platform.state_provider.object_mapper.inner" />
         </service>
 
         <service id="api_platform.state_processor.object_mapper" class="ApiPlatform\State\Processor\ObjectMapperProcessor" decorates="api_platform.state_processor.locator">
-            <argument type="service" id="object_mapper" on-invalid="null" />
+            <argument type="service" id="api_platform.object_mapper" on-invalid="null" />
             <argument type="service" id="api_platform.state_processor.object_mapper.inner" />
         </service>
     </services>

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Put;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedResourceWithRelationEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    stateOptions: new Options(entityClass: MappedResourceWithRelationEntity::class),
+    normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+    extraProperties: [
+        'standard_put' => true,
+    ],
+    operations: [
+        new Get(),
+        new Put(allowCreate: true),
+    ]
+)]
+#[Map(target: MappedResourceWithRelationEntity::class)]
+class MappedResourceWithRelation
+{
+    public ?string $id = null;
+    #[Map(if: false)]
+    public ?string $relationName = null;
+    #[Map(target: 'related')]
+    public ?MappedResourceWithRelationRelated $relation = null;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelationRelated.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelationRelated.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\NotExposed;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedResourceWithRelationRelatedEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    operations: [
+        new NotExposed(
+            stateOptions: new Options(entityClass: MappedResourceWithRelationRelatedEntity::class),
+            normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+        ),
+    ],
+    graphQlOperations: []
+)]
+#[Map(target: MappedResourceWithRelationRelatedEntity::class)]
+class MappedResourceWithRelationRelated
+{
+    #[Map(if: false)]
+    public string $id;
+
+    public string $name;
+}

--- a/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceWithRelation;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ORM\Entity]
+#[Map(target: MappedResourceWithRelation::class)]
+class MappedResourceWithRelationEntity
+{
+    #[ORM\Id, ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: MappedResourceWithRelationRelatedEntity::class)]
+    #[Map(target: 'relation')]
+    #[Map(target: 'relationName', transform: [self::class, 'transformRelation'])]
+    private ?MappedResourceWithRelationRelatedEntity $related = null;
+
+    public static function transformRelation($value, $source)
+    {
+        return $source->getRelated()->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id = null)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getRelated(): ?MappedResourceWithRelationRelatedEntity
+    {
+        return $this->related;
+    }
+
+    public function setRelated(?MappedResourceWithRelationRelatedEntity $related): self
+    {
+        $this->related = $related;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationRelatedEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationRelatedEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceWithRelationRelated;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ORM\Entity]
+#[Map(target: MappedResourceWithRelationRelated::class)]
+class MappedResourceWithRelationRelatedEntity
+{
+    #[ORM\Id, ORM\Column, ORM\GeneratedValue]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    public string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Fixes an issue where we keep fetched relations so that we don't create new entities instead of persisting the existing one. Check the test and the issue at https://github.com/symfony/symfony/issues/61119. 

This needs https://github.com/symfony/symfony/pull/61145 to work. 