### PR TITLE
fix(json-schema): add missing argument to DefinitionNameFactory service definition

### DIFF
--- a/src/Symfony/Bundle/Resources/config/json_schema.xml
+++ b/src/Symfony/Bundle/Resources/config/json_schema.xml
@@ -33,8 +33,9 @@
             <argument type="service" id="api_platform.json_schema.backward_compatible_schema_factory.inner" />
         </service>
 
-        <service id="api_platform.json_schema.definition_name_factory" class="ApiPlatform\JsonSchema\DefinitionNameFactory"></service>
-
+        <service id="api_platform.json_schema.definition_name_factory" class="ApiPlatform\JsonSchema\DefinitionNameFactory">
+            <argument>%api_platform.formats%</argument>
+        </service>
     </services>
 
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7301
| License       | MIT
| Doc PR        | N/A

Fixes a service configuration issue in `json_schema.xml` where the `DefinitionNameFactory` service was missing a required constructor argument.

The error was:
```

Too few arguments to function ApiPlatform\JsonSchema\DefinitionNameFactory::__construct(), 0 passed ...

````

The fix adds the `%api_platform.formats%` argument to the service declaration:

```xml
<service id="api_platform.json_schema.definition_name_factory" class="ApiPlatform\JsonSchema\DefinitionNameFactory">
    <argument>%api_platform.formats%</argument>
</service>
````