### PR TITLE
fix(test): replace `Collection|iterable` with `Collection` and add appropriate PHPDoc tags

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -47,7 +47,6 @@ parameters:
 			message: '#but database expects#'
 			paths:
 				- tests/Fixtures/TestBundle/Entity/
-		- '#Cannot call method add\(\) on iterable.#'
 		-
 			message: '#is never read, only written.#'
 			paths:

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -103,8 +103,11 @@ class Dummy
     #[ORM\ManyToOne(targetEntity: RelatedDummy::class)]
     public ?RelatedDummy $relatedDummy = null;
 
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ORM\ManyToMany(targetEntity: RelatedDummy::class)]
-    public Collection|iterable $relatedDummies;
+    public Collection$relatedDummies;
 
     /**
      * @var array|null serialize data
@@ -302,7 +305,10 @@ class Dummy
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/src/Doctrine/Common/Tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -82,9 +82,12 @@ class RelatedDummy extends ParentDummy implements \Stringable
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ?ThirdLevel $thirdLevel = null;
 
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ORM\OneToMany(targetEntity: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy')]
     #[Groups(['fakemanytomany', 'friends'])]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
 
     /**
      * @var bool|null A dummy bool
@@ -168,8 +171,10 @@ class RelatedDummy extends ParentDummy implements \Stringable
 
     /**
      * Get relatedToDummyFriend.
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/src/Doctrine/Odm/Tests/Fixtures/Document/Dummy.php
+++ b/src/Doctrine/Odm/Tests/Fixtures/Document/Dummy.php
@@ -76,8 +76,11 @@ class Dummy
     public $dummyPrice;
     #[ODM\ReferenceOne(targetDocument: RelatedDummy::class, storeAs: 'id', nullable: true)]
     public ?RelatedDummy $relatedDummy = null;
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
     #[ODM\ReferenceMany(targetDocument: RelatedDummy::class, storeAs: 'id', nullable: true)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
     #[ODM\Field(type: 'hash', nullable: true)]
     public array $jsonData = [];
     #[ODM\Field(type: 'collection', nullable: true)]

--- a/src/Doctrine/Odm/Tests/Fixtures/Document/RelatedDummy.php
+++ b/src/Doctrine/Odm/Tests/Fixtures/Document/RelatedDummy.php
@@ -42,8 +42,11 @@ class RelatedDummy extends ParentDummy implements \Stringable
     public $dummyDate;
     #[ODM\ReferenceOne(targetDocument: ThirdLevel::class, cascade: ['persist'], nullable: true, storeAs: 'id', inversedBy: 'relatedDummies')]
     public ?ThirdLevel $thirdLevel = null;
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ODM\ReferenceMany(targetDocument: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy', storeAs: 'id')]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
     #[ODM\Field(type: 'bool')]
     public ?bool $dummyBoolean = null;
     #[ODM\EmbedOne(targetDocument: EmbeddableDummy::class)]
@@ -120,8 +123,10 @@ class RelatedDummy extends ParentDummy implements \Stringable
 
     /**
      * Get relatedToDummyFriend.
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/src/Doctrine/Orm/Tests/Fixtures/Entity/Dummy.php
+++ b/src/Doctrine/Orm/Tests/Fixtures/Entity/Dummy.php
@@ -106,8 +106,11 @@ class Dummy
     #[ORM\ManyToOne(targetEntity: RelatedDummy::class)]
     public ?RelatedDummy $relatedDummy = null;
 
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ORM\ManyToMany(targetEntity: RelatedDummy::class)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var array|null serialize data
@@ -305,7 +308,10 @@ class Dummy
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/src/Doctrine/Orm/Tests/Fixtures/Entity/RelatedDummy.php
+++ b/src/Doctrine/Orm/Tests/Fixtures/Entity/RelatedDummy.php
@@ -90,9 +90,12 @@ class RelatedDummy extends ParentDummy implements \Stringable
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ?ThirdLevel $thirdLevel = null;
 
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ORM\OneToMany(targetEntity: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy')]
     #[Groups(['fakemanytomany', 'friends'])]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
 
     #[ORM\Column(enumType: DummyBackedEnum::class, nullable: true)]
     public DummyBackedEnum $dummyBackedEnum;
@@ -178,9 +181,11 @@ class RelatedDummy extends ParentDummy implements \Stringable
     }
 
     /**
-     * Get relatedToDummyFriend.
+     * Get relatedToDummyFriend
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/src/OpenApi/Tests/Fixtures/Dummy.php
+++ b/src/OpenApi/Tests/Fixtures/Dummy.php
@@ -15,6 +15,8 @@ namespace ApiPlatform\OpenApi\Tests\Fixtures;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * Dummy.
@@ -81,7 +83,7 @@ class Dummy
     #[ApiProperty(push: true)]
     public ?RelatedDummy $relatedDummy = null;
 
-    public iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var array|null serialize data
@@ -104,7 +106,7 @@ class Dummy
 
     public function __construct()
     {
-        $this->relatedDummies = [];
+        $this->relatedDummies = new ArrayCollection();
     }
 
     public function getId()
@@ -241,7 +243,7 @@ class Dummy
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): iterable
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/src/Serializer/Tests/Fixtures/ApiResource/Dummy.php
+++ b/src/Serializer/Tests/Fixtures/ApiResource/Dummy.php
@@ -83,7 +83,7 @@ class Dummy
     #[ApiProperty(push: true)]
     public ?RelatedDummy $relatedDummy = null;
 
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var Collection<int, RelatedDummy>
@@ -249,7 +249,7 @@ class Dummy
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/tests/Fixtures/TestBundle/Document/Answer.php
+++ b/tests/Fixtures/TestBundle/Document/Answer.php
@@ -43,9 +43,13 @@ class Answer
     #[Serializer\Groups(['foobar'])]
     #[ODM\ReferenceOne(targetDocument: Question::class, mappedBy: 'answer')]
     private ?Question $question = null;
+
+    /**
+     * @var Collection<int, Question>
+     */
     #[Serializer\Groups(['foobar'])]
     #[ODM\ReferenceMany(targetDocument: Question::class, mappedBy: 'answer')]
-    private Collection|iterable $relatedQuestions;
+    private Collection $relatedQuestions;
 
     public function __construct()
     {
@@ -98,8 +102,10 @@ class Answer
 
     /**
      * Get related question.
+     *
+     * @return Collection<int, Question>
      */
-    public function getRelatedQuestions(): Collection|iterable
+    public function getRelatedQuestions(): Collection
     {
         return $this->relatedQuestions;
     }

--- a/tests/Fixtures/TestBundle/Document/CircularReference.php
+++ b/tests/Fixtures/TestBundle/Document/CircularReference.php
@@ -33,9 +33,13 @@ class CircularReference
     #[Groups(['circular'])]
     #[ODM\ReferenceOne(targetDocument: self::class, inversedBy: 'children')]
     public $parent;
+
+    /**
+     * @var Collection<int, self>
+     */
     #[Groups(['circular'])]
     #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'parent')]
-    public Collection|iterable $children;
+    public Collection $children;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Document/Customer.php
+++ b/tests/Fixtures/TestBundle/Document/Customer.php
@@ -29,9 +29,13 @@ class Customer
     #[Groups(['order_read'])]
     #[ODM\Field(type: 'string')]
     public $name;
+
+    /**
+     * @var Collection<int, Address>
+     */
     #[Groups(['order_read'])]
     #[ODM\ReferenceMany(targetDocument: Address::class)]
-    public Collection|iterable $addresses;
+    public Collection $addresses;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Document/Dummy.php
+++ b/tests/Fixtures/TestBundle/Document/Dummy.php
@@ -96,8 +96,12 @@ class Dummy
     public $dummyPrice;
     #[ODM\ReferenceOne(targetDocument: RelatedDummy::class, storeAs: 'id', nullable: true)]
     public ?RelatedDummy $relatedDummy = null;
+
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ODM\ReferenceMany(targetDocument: RelatedDummy::class, storeAs: 'id', nullable: true)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
     #[ODM\Field(type: 'hash', nullable: true)]
     public array $jsonData = [];
     #[ODM\Field(type: 'collection', nullable: true)]

--- a/tests/Fixtures/TestBundle/Document/DummyAggregateOffer.php
+++ b/tests/Fixtures/TestBundle/Document/DummyAggregateOffer.php
@@ -38,8 +38,12 @@ class DummyAggregateOffer
      */
     #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
     private ?int $id = null;
+
+    /**
+     * @var Collection<int, DummyOffer>
+     */
     #[ODM\ReferenceMany(targetDocument: DummyOffer::class, mappedBy: 'aggregate', cascade: ['persist'])]
-    private Collection|iterable $offers;
+    private Collection $offers;
     /**
      * @var DummyProduct The dummy product
      */
@@ -56,12 +60,18 @@ class DummyAggregateOffer
         $this->offers = new ArrayCollection();
     }
 
-    public function getOffers(): Collection|iterable
+    /**
+     * @return Collection<int, DummyOffer>
+     */
+    public function getOffers(): Collection
     {
         return $this->offers;
     }
 
-    public function setOffers(Collection|iterable $offers): void
+    /**
+     * @param Collection<int, DummyOffer> $offers
+     */
+    public function setOffers(Collection $offers): void
     {
         $this->offers = $offers;
     }

--- a/tests/Fixtures/TestBundle/Document/DummyProduct.php
+++ b/tests/Fixtures/TestBundle/Document/DummyProduct.php
@@ -37,15 +37,23 @@ class DummyProduct
      */
     #[ODM\Id(strategy: 'None', type: 'int')]
     private ?int $id = null;
+
+    /**
+     * @var Collection<int, DummyAggregateOffer>
+     */
     #[ODM\ReferenceMany(targetDocument: DummyAggregateOffer::class, mappedBy: 'product', cascade: ['persist'])]
-    private Collection|iterable $offers;
+    private Collection $offers;
     /**
      * @var string The tour name
      */
     #[ODM\Field]
     private string $name;
+
+    /**
+     * @var Collection<int, self>
+     */
     #[ODM\ReferenceMany(targetDocument: self::class, mappedBy: 'parent')]
-    private Collection|iterable $relatedProducts;
+    private Collection $relatedProducts;
     #[ODM\ReferenceOne(targetDocument: self::class, inversedBy: 'relatedProducts')]
     private $parent;
 
@@ -55,12 +63,18 @@ class DummyProduct
         $this->relatedProducts = new ArrayCollection();
     }
 
-    public function getOffers(): Collection|iterable
+    /**
+     * @return Collection<int, DummyAggregateOffer>
+     */
+    public function getOffers(): Collection
     {
         return $this->offers;
     }
 
-    public function setOffers(Collection|iterable $offers): void
+    /**
+     * @param Collection<int, DummyAggregateOffer> $offers
+     */
+    public function setOffers(Collection $offers): void
     {
         $this->offers = $offers;
     }
@@ -91,12 +105,18 @@ class DummyProduct
         $this->name = $name;
     }
 
-    public function getRelatedProducts(): Collection|iterable
+    /**
+     * @return Collection<int, self>
+     */
+    public function getRelatedProducts(): Collection
     {
         return $this->relatedProducts;
     }
 
-    public function setRelatedProducts(Collection|iterable $relatedProducts): void
+    /**
+     * @param Collection<int, self> $relatedProducts
+     */
+    public function setRelatedProducts(Collection $relatedProducts): void
     {
         $this->relatedProducts = $relatedProducts;
     }

--- a/tests/Fixtures/TestBundle/Document/OptionalRequiredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/OptionalRequiredDummy.php
@@ -48,9 +48,12 @@ class OptionalRequiredDummy
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ThirdLevel $thirdLevelRequired;
 
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ODM\ReferenceMany(targetDocument: RelatedToDummyFriend::class, mappedBy: 'relatedDummy')]
     #[Groups(['fakemanytomany', 'friends'])]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
 
     public function __construct()
     {
@@ -89,8 +92,10 @@ class OptionalRequiredDummy
 
     /**
      * Get relatedToDummyFriend.
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/tests/Fixtures/TestBundle/Document/Person.php
+++ b/tests/Fixtures/TestBundle/Document/Person.php
@@ -46,12 +46,18 @@ class Person
     #[Groups(['people.pets'])]
     public array $academicGrades = [];
 
+    /**
+     * @var Collection<int, PersonToPet>
+     */
     #[Groups(['people.pets'])]
     #[ODM\ReferenceMany(targetDocument: PersonToPet::class, mappedBy: 'person')]
-    public Collection|iterable $pets;
+    public Collection $pets;
 
+    /**
+     * @var Collection<int, Greeting>
+     */
     #[ODM\ReferenceMany(targetDocument: Greeting::class, mappedBy: 'sender')]
-    public Collection|iterable|null $sentGreetings = null;
+    public Collection $sentGreetings;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Document/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Document/RelatedDummy.php
@@ -74,9 +74,13 @@ class RelatedDummy extends ParentDummy implements \Stringable
     #[Groups(['barcelona', 'chicago', 'friends'])]
     #[ODM\ReferenceOne(targetDocument: ThirdLevel::class, cascade: ['persist'], nullable: true, storeAs: 'id', inversedBy: 'relatedDummies')]
     public ?ThirdLevel $thirdLevel = null;
+
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[Groups(['fakemanytomany', 'friends'])]
     #[ODM\ReferenceMany(targetDocument: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy', storeAs: 'id')]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
     #[Groups(['friends'])]
     #[ODM\Field(type: 'bool')]
     public ?bool $dummyBoolean = null;
@@ -155,8 +159,10 @@ class RelatedDummy extends ParentDummy implements \Stringable
 
     /**
      * Get relatedToDummyFriend.
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/tests/Fixtures/TestBundle/Document/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Document/SecuredDummy.php
@@ -90,9 +90,13 @@ class SecuredDummy
     #[ODM\Field]
     private ?string $owner = null;
 
+
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ApiProperty(security: "is_granted('ROLE_ADMIN')")]
     #[ODM\ReferenceMany(targetDocument: RelatedDummy::class, storeAs: 'id', nullable: true)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var RelatedDummy
@@ -102,11 +106,13 @@ class SecuredDummy
     protected $relatedDummy;
 
     /**
-     * A collection of dummies that only users can access. The security on RelatedSecuredDummy shouldn't be run.
+     *  A collection of dummies that only users can access. The security on RelatedSecuredDummy shouldn't be run.
+     *
+     * @var Collection<int, RelatedSecuredDummy>
      */
     #[ApiProperty(security: "is_granted('ROLE_USER')")]
     #[ODM\ReferenceMany(targetDocument: RelatedSecuredDummy::class, storeAs: 'id', nullable: true)]
-    public Collection|iterable $relatedSecuredDummies;
+    public Collection $relatedSecuredDummies;
 
     /**
      * A dummy that only users can access. The security on RelatedSecuredDummy shouldn't be run.
@@ -118,9 +124,11 @@ class SecuredDummy
     protected $relatedSecuredDummy;
     /**
      * Collection of dummies that anyone can access. There is no ApiProperty security, and the security on RelatedSecuredDummy shouldn't be run.
+     *
+     * @var Collection<int, RelatedSecuredDummy>
      */
     #[ODM\ReferenceMany(targetDocument: RelatedSecuredDummy::class, storeAs: 'id', nullable: true)]
-    public Collection|iterable $publicRelatedSecuredDummies;
+    public Collection $publicRelatedSecuredDummies;
     /**
      * A dummy that anyone can access. There is no ApiProperty security, and the security on RelatedSecuredDummy shouldn't be run.
      *
@@ -206,7 +214,10 @@ class SecuredDummy
         $this->relatedDummies->add($relatedDummy);
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }
@@ -226,7 +237,10 @@ class SecuredDummy
         $this->relatedSecuredDummies->add($relatedSecuredDummy);
     }
 
-    public function getRelatedSecuredDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedSecuredDummy>
+     */
+    public function getRelatedSecuredDummies(): Collection
     {
         return $this->relatedSecuredDummies;
     }
@@ -246,7 +260,10 @@ class SecuredDummy
         $this->publicRelatedSecuredDummies->add($publicRelatedSecuredDummy);
     }
 
-    public function getPublicRelatedSecuredDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedSecuredDummy>
+     */
+    public function getPublicRelatedSecuredDummies(): Collection
     {
         return $this->publicRelatedSecuredDummies;
     }

--- a/tests/Fixtures/TestBundle/Entity/CircularReference.php
+++ b/tests/Fixtures/TestBundle/Entity/CircularReference.php
@@ -35,9 +35,13 @@ class CircularReference
     #[ORM\ManyToOne(targetEntity: self::class, inversedBy: 'children')]
     #[Groups(['circular'])]
     public $parent;
+
+    /**
+     * @var Collection<int, self>
+     */
     #[ORM\OneToMany(targetEntity: self::class, mappedBy: 'parent')]
     #[Groups(['circular'])]
-    public Collection|iterable $children;
+    public Collection $children;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Entity/Customer.php
+++ b/tests/Fixtures/TestBundle/Entity/Customer.php
@@ -31,10 +31,14 @@ class Customer
     #[ORM\Column(type: 'string')]
     #[Groups(['order_read'])]
     public $name;
+
+    /**
+     * @var Collection<int, Address>
+     */
     #[ORM\ManyToMany(targetEntity: Address::class)]
     #[ORM\JoinColumn(nullable: false)]
     #[Groups(['order_read'])]
-    public Collection|iterable $addresses;
+    public Collection $addresses;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Entity/Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Dummy.php
@@ -113,8 +113,11 @@ class Dummy
     #[ORM\ManyToOne(targetEntity: RelatedDummy::class)]
     public ?RelatedDummy $relatedDummy = null;
 
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ORM\ManyToMany(targetEntity: RelatedDummy::class)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var array|null serialize data
@@ -318,7 +321,10 @@ class Dummy
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/tests/Fixtures/TestBundle/Entity/DummyProblem.php
+++ b/tests/Fixtures/TestBundle/Entity/DummyProblem.php
@@ -100,8 +100,11 @@ class DummyProblem
     #[ORM\ManyToOne(targetEntity: RelatedDummy::class)]
     public ?RelatedDummy $relatedDummy = null;
 
+    /**
+     * @var Collection<int, RelatedDummy>
+     */
     #[ORM\ManyToMany(targetEntity: RelatedDummy::class)]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * @var array|null serialize data
@@ -296,7 +299,10 @@ class DummyProblem
         return $this->dummy;
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }

--- a/tests/Fixtures/TestBundle/Entity/OptionalRequiredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/OptionalRequiredDummy.php
@@ -51,9 +51,13 @@ class OptionalRequiredDummy
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ThirdLevel $thirdLevelRequired;
 
+
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ORM\OneToMany(targetEntity: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy')]
     #[Groups(['fakemanytomany', 'friends'])]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
 
     public function __construct()
     {
@@ -91,9 +95,11 @@ class OptionalRequiredDummy
     }
 
     /**
-     * Get relatedToDummyFriend.
+     *  Get relatedToDummyFriend.
+     *
+     * @return Collection<int, RelatedToDummyFriend>
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/tests/Fixtures/TestBundle/Entity/Person.php
+++ b/tests/Fixtures/TestBundle/Entity/Person.php
@@ -48,12 +48,18 @@ class Person
     #[Groups(['people.pets'])]
     public array $academicGrades = [];
 
+    /**
+     * @var Collection<int, PersonToPet>
+     */
     #[ORM\OneToMany(targetEntity: PersonToPet::class, mappedBy: 'person')]
     #[Groups(['people.pets'])]
-    public Collection|iterable $pets;
+    public Collection $pets;
 
+    /**
+     * @var Collection<int, Greeting>
+     */
     #[ORM\OneToMany(targetEntity: Greeting::class, mappedBy: 'sender')]
-    public Collection|iterable|null $sentGreetings = null;
+    public Collection $sentGreetings;
 
     public function __construct()
     {

--- a/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/RelatedDummy.php
@@ -90,9 +90,12 @@ class RelatedDummy extends ParentDummy implements \Stringable
     #[Groups(['barcelona', 'chicago', 'friends'])]
     public ?ThirdLevel $thirdLevel = null;
 
+    /**
+     * @var Collection<int, RelatedToDummyFriend>
+     */
     #[ORM\OneToMany(targetEntity: RelatedToDummyFriend::class, cascade: ['persist'], mappedBy: 'relatedDummy')]
     #[Groups(['fakemanytomany', 'friends'])]
-    public Collection|iterable $relatedToDummyFriend;
+    public Collection $relatedToDummyFriend;
 
     /**
      * @var bool|null A dummy bool
@@ -176,8 +179,11 @@ class RelatedDummy extends ParentDummy implements \Stringable
 
     /**
      * Get relatedToDummyFriend.
+     *
+     * @return  Collection<int, RelatedToDummyFriend>
+     *
      */
-    public function getRelatedToDummyFriend(): Collection|iterable
+    public function getRelatedToDummyFriend(): Collection
     {
         return $this->relatedToDummyFriend;
     }

--- a/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/SecuredDummy.php
@@ -108,11 +108,13 @@ class SecuredDummy
 
     /**
      * A collection of dummies that only admins can access.
+     *
+     * @var Collection<int, RelatedDummy>
      */
     #[ApiProperty(security: "is_granted('ROLE_ADMIN')")]
     #[ORM\ManyToMany(targetEntity: RelatedDummy::class)]
     #[ORM\JoinTable(name: 'secured_dummy_related_dummy')]
-    public Collection|iterable $relatedDummies;
+    public Collection $relatedDummies;
 
     /**
      * A dummy that only admins can access.
@@ -126,11 +128,13 @@ class SecuredDummy
 
     /**
      * A collection of dummies that only users can access. The security on RelatedSecuredDummy shouldn't be run.
+     *
+     * @var Collection<int, RelatedSecuredDummy>
      */
     #[ApiProperty(security: "is_granted('ROLE_USER')")]
     #[ORM\ManyToMany(targetEntity: RelatedSecuredDummy::class)]
     #[ORM\JoinTable(name: 'secured_dummy_related_secured_dummy')]
-    public Collection|iterable $relatedSecuredDummies;
+    public Collection $relatedSecuredDummies;
 
     /**
      * A dummy that only users can access. The security on RelatedSecuredDummy shouldn't be run.
@@ -144,10 +148,12 @@ class SecuredDummy
 
     /**
      * Collection of dummies that anyone can access. There is no ApiProperty security, and the security on RelatedSecuredDummy shouldn't be run.
+     *
+     * @var Collection<int, RelatedSecuredDummy>
      */
     #[ORM\ManyToMany(targetEntity: RelatedSecuredDummy::class)]
     #[ORM\JoinTable(name: 'secured_dummy_public_related_secured_dummy')]
-    public Collection|iterable $publicRelatedSecuredDummies;
+    public Collection $publicRelatedSecuredDummies;
 
     /**
      * A dummy that anyone can access. There is no ApiProperty security, and the security on RelatedSecuredDummy shouldn't be run.
@@ -235,7 +241,10 @@ class SecuredDummy
         $this->relatedDummies->add($relatedDummy);
     }
 
-    public function getRelatedDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedDummy>
+     */
+    public function getRelatedDummies(): Collection
     {
         return $this->relatedDummies;
     }
@@ -255,7 +264,10 @@ class SecuredDummy
         $this->relatedSecuredDummies->add($relatedSecuredDummy);
     }
 
-    public function getRelatedSecuredDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedSecuredDummy>
+     */
+    public function getRelatedSecuredDummies(): Collection
     {
         return $this->relatedSecuredDummies;
     }
@@ -275,7 +287,10 @@ class SecuredDummy
         $this->publicRelatedSecuredDummies->add($publicRelatedSecuredDummy);
     }
 
-    public function getPublicRelatedSecuredDummies(): Collection|iterable
+    /**
+     * @return Collection<int, RelatedSecuredDummy>
+     */
+    public function getPublicRelatedSecuredDummies(): Collection
     {
         return $this->publicRelatedSecuredDummies;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `main`
| Tickets       | -
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Fixes several phpstan errors ignored in the config