### PR TITLE
feat(doctrine): add SearchFilter STRATEGY_PATTERN

### DIFF
--- a/src/Doctrine/Common/Filter/SearchFilterInterface.php
+++ b/src/Doctrine/Common/Filter/SearchFilterInterface.php
@@ -70,4 +70,14 @@ interface SearchFilterInterface
      * @var string Finds fields that are starting with the word case-insensitive
      */
     public const STRATEGY_IWORD_START = 'iword_start';
+
+    /**
+     * @var string Finds fields that match the user-specified pattern
+     */
+    public const STRATEGY_PATTERN = 'pattern';
+
+    /**
+     * @var string Finds fields that match the user-specified pattern case-insensitive
+     */
+    public const STRATEGY_IPATTERN = 'ipattern';
 }

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -276,6 +276,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
             self::STRATEGY_START => new Regex("^$quotedValue", $caseSensitive ? '' : 'i'),
             self::STRATEGY_END => new Regex("$quotedValue$", $caseSensitive ? '' : 'i'),
             self::STRATEGY_WORD_START => new Regex("(^$quotedValue.*|.*\s$quotedValue.*)", $caseSensitive ? '' : 'i'),
+            self::STRATEGY_PATTERN => throw new InvalidArgumentException(\sprintf('strategy %s is not implemented.', $strategy)),
             default => throw new InvalidArgumentException(\sprintf('strategy %s does not exist.', $strategy)),
         };
     }

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -334,6 +334,10 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
                         $wrapCase((string) $queryBuilder->expr()->concat("'% '", $keyValueParameter, "'%'"))
                     )
                 ),
+                self::STRATEGY_PATTERN => $queryBuilder->expr()->like(
+                    $wrapCase($aliasedField),
+                    $wrapCase($keyValueParameter)
+                ),
                 default => throw new InvalidArgumentException(\sprintf('strategy %s does not exist.', $strategy)),
             };
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Current ORM\SearchFilter is missing the search strategy that I need the most. There is no way to select a strategy that makes `LIKE` query without automatically adding wildcards. So far, the only solution has been to implement my own SearchFilter, which is annoying.

This PR adds a strategy, that will make `LIKE` query, but will let user decide, if and where to add wildcards.
