### PR TITLE
fix(symfony): explicitly set the target when mapping entities to resources

### DIFF
--- a/src/State/Processor/ObjectMapperProcessor.php
+++ b/src/State/Processor/ObjectMapperProcessor.php
@@ -42,6 +42,6 @@ final class ObjectMapperProcessor implements ProcessorInterface
             return $this->decorated->process($data, $operation, $uriVariables, $context);
         }
 
-        return $this->objectMapper->map($this->decorated->process($this->objectMapper->map($data), $operation, $uriVariables, $context));
+        return $this->objectMapper->map($this->decorated->process($this->objectMapper->map($data), $operation, $uriVariables, $context), $operation->getClass());
     }
 }

--- a/src/State/Provider/ObjectMapperProvider.php
+++ b/src/State/Provider/ObjectMapperProvider.php
@@ -64,9 +64,9 @@ final class ObjectMapperProvider implements ProviderInterface
         }
 
         if ($data instanceof PaginatorInterface) {
-            $data = new ArrayPaginator(array_map(fn ($v) => $this->objectMapper->map($v), iterator_to_array($data)), 0, \count($data));
+            $data = new ArrayPaginator(array_map(fn ($v) => $this->objectMapper->map($v, $operation->getClass()), iterator_to_array($data)), 0, \count($data));
         } else {
-            $data = $this->objectMapper->map($data);
+            $data = $this->objectMapper->map($data, $operation->getClass());
         }
 
         $request?->attributes->set('data', $data);

--- a/tests/Fixtures/TestBundle/ApiResource/FirstResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/FirstResource.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SameEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    shortName: 'First',
+    operations: [new GetCollection()],
+    stateOptions: new Options(entityClass: SameEntity::class)
+)]
+#[Map(target: SameEntity::class)]
+final class FirstResource
+{
+    #[Map(if: false)]
+    public ?int $id = null;
+
+    public string $name;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/SecondResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/SecondResource.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\SameEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    shortName: 'Second',
+    operations: [new GetCollection()],
+    stateOptions: new Options(entityClass: SameEntity::class)
+)]
+#[Map(target: SameEntity::class)]
+final class SecondResource
+{
+    #[Map(if: false)]
+    public ?int $id = null;
+
+    public string $name;
+
+    public string $extra = 'field';
+}

--- a/tests/Fixtures/TestBundle/Entity/SameEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/SameEntity.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\FirstResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\SecondResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ORM\Entity]
+#[Map(target: FirstResource::class)]
+#[Map(target: SecondResource::class)]
+class SameEntity
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    private string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #7310 

Small fix to force the correct target mapping when an entity is mapped to multiple resources.