### PR TITLE
fix(openapi): sync typehints between properties and getter/canner for…

### DIFF
--- a/src/OpenApi/Model/Parameter.php
+++ b/src/OpenApi/Model/Parameter.php
@@ -53,12 +53,12 @@ final class Parameter
         return $this->deprecated;
     }
 
-    public function canAllowEmptyValue(): bool
+    public function canAllowEmptyValue(): ?bool
     {
         return $this->allowEmptyValue;
     }
 
-    public function getAllowEmptyValue(): bool
+    public function getAllowEmptyValue(): ?bool
     {
         return $this->allowEmptyValue;
     }
@@ -83,12 +83,12 @@ final class Parameter
         return $this->explode;
     }
 
-    public function canAllowReserved(): bool
+    public function canAllowReserved(): ?bool
     {
         return $this->allowReserved;
     }
 
-    public function getAllowReserved(): bool
+    public function getAllowReserved(): ?bool
     {
         return $this->allowReserved;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

After merged https://github.com/api-platform/core/pull/7315 and compared the code with the main branch i realized that getter and canner return type are not ISO with property type hint
