### PR TITLE
Add Error:setDescription

### DIFF
--- a/src/State/ApiResource/Error.php
+++ b/src/State/ApiResource/Error.php
@@ -136,6 +136,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
         ?\Throwable $previous = null,
         private ?array $meta = null,
         private ?array $source = null,
+        private ?string $description = null,
     ) {
         parent::__construct($title, $status, $previous);
 
@@ -186,7 +187,12 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
     #[ApiProperty(writable: false, initializable: false)]
     public function getDescription(): ?string
     {
-        return $this->detail;
+        return $this->description ?? $this->detail;
+    }
+
+    public function setDescription(?string $description = null): void
+    {
+        $this->description = $description;
     }
 
     public static function createFromException(\Exception|\Throwable $exception, int $status): self


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Currently, when setting the details, it set both the description and the details since the `getDescription` returns 
```
public function getDescription(): ?string
    {
        return $this->detail;
    }
```

So I feel like we're missing a `setDescription`, this way:
- To override both description and detail, we use `setDetails`
- To just override the description, we use `setDescription` 

And both field now might have a different value.