### PR TITLE
fix(serializer): deprecate SerializerAwareProviderInterface and SerializableProvider

### DIFF
--- a/src/State/SerializerAwareProviderInterface.php
+++ b/src/State/SerializerAwareProviderInterface.php
@@ -19,6 +19,8 @@ use Psr\Container\ContainerInterface;
  * Injects serializer in providers.
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @deprecated in 4.2, to be removed in 5.0 because it violates the dependency injection principle.
  */
 interface SerializerAwareProviderInterface
 {

--- a/src/State/SerializerAwareProviderTrait.php
+++ b/src/State/SerializerAwareProviderTrait.php
@@ -30,6 +30,13 @@ trait SerializerAwareProviderTrait
 
     public function setSerializerLocator(ContainerInterface $serializerLocator): void
     {
+        trigger_deprecation(
+            'api-platform/core',
+            '4.2',
+            'The "%s" interface is deprecated and will be removed in 5.0. It violates the dependency injection principle.',
+            SerializerAwareProviderInterface::class
+        );
+
         $this->serializerLocator = $serializerLocator;
     }
 

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -44,6 +44,7 @@ final class ApiPlatformBundle extends Bundle
     {
         parent::build($container);
 
+        // TODO: remove in 5.x
         $container->addCompilerPass(new DataProviderPass());
         // Run the compiler pass before the {@see ResolveInstanceofConditionalsPass} to allow autoconfiguration of generated filter definitions.
         $container->addCompilerPass(new AttributeFilterPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 101);

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php
@@ -21,10 +21,12 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Registers data providers.
  *
- * @internal
+ * @internal since 4.2
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * TODO: remove in 5.x
  */
 final class DataProviderPass implements CompilerPassInterface
 {

--- a/tests/Fixtures/TestBundle/State/SerializableProvider.php
+++ b/tests/Fixtures/TestBundle/State/SerializableProvider.php
@@ -20,6 +20,8 @@ use ApiPlatform\State\SerializerAwareProviderTrait;
 
 /**
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
+ *
+ * @deprecated in 4.2, to be removed in 5.0 because it violates the dependency injection principle.
  */
 class SerializableProvider implements ProviderInterface, SerializerAwareProviderInterface
 {

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -43,6 +43,7 @@ class ApiPlatformBundleTest extends TestCase
     public function testBuild(): void
     {
         $containerProphecy = $this->prophesize(ContainerBuilder::class);
+        // TODO: remove in 5.x
         $containerProphecy->addCompilerPass(Argument::type(DataProviderPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AttributeFilterPass::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, 101)->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AttributeResourcePass::class))->shouldBeCalled()->willReturn($containerProphecy->reveal())->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | `4.2`
| Tickets       | -
| License       | MIT

Made the deprecation before the removal made in #7314.

**Reason**: Direct access to private services is discouraged because this practice:
-  Violates the dependency injection principle, which is at the heart of Symfony's architecture.
- Creates a strong coupling between your code and the container, making it less modular.
- Makes your application more fragile and much more difficult to maintain and test.

That's why PHPStan reported an error, which is ignored by our PHPStan config here: https://github.com/vinceAmstoutz/api-platform-core/blob/9e382e01bb4529d4ae63dbbeda01839d1da2994a/phpstan.neon.dist#L107-L110.

**Historic reason**:

After looking at its history, it looks like a legacy code backported from version to version of api-platform/core for backward compatibility. As discussed with @soyuka, it might be possible this behavior (this interface + [DataProviderPass](https://github.com/api-platform/core/blob/main/src/Symfony/Bundle/DependencyInjection/Compiler/DataProviderPass.php)) was introduced long time ago to prevent a circular reference between any State Provider directly using the Serializer.