### PR TITLE
fix(httpcache): collection iri invalidation for mapped entities

### DIFF
--- a/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -132,8 +132,7 @@ final class PurgeHttpCacheListener
                 if ($purgeItem) {
                     $this->addTagForItem($entity);
                 }
-            } catch (OperationNotFoundException|InvalidArgumentException $e) {
-                dd($e);
+            } catch (OperationNotFoundException|InvalidArgumentException) {
             }
         }
     }

--- a/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -42,6 +42,8 @@ final class PurgeHttpCacheListener
     private readonly PropertyAccessorInterface $propertyAccessor;
     private array $tags = [];
 
+    private array $scheduledInsertions = [];
+
     public function __construct(private readonly PurgerInterface $purger,
         private readonly IriConverterInterface $iriConverter,
         private readonly ResourceClassResolverInterface $resourceClassResolver,
@@ -75,7 +77,7 @@ final class PurgeHttpCacheListener
     }
 
     /**
-     * Collects tags from inserted and deleted entities, including relations.
+     * Collects tags from updated and deleted entities, including relations.
      */
     public function onFlush(OnFlushEventArgs $eventArgs): void
     {
@@ -83,15 +85,8 @@ final class PurgeHttpCacheListener
         $em = method_exists($eventArgs, 'getObjectManager') ? $eventArgs->getObjectManager() : $eventArgs->getEntityManager();
         $uow = $em->getUnitOfWork();
 
-        foreach ($uow->getScheduledEntityInsertions() as $entity) {
-            // For new entities, only purge the collection IRI
-            try {
-                if ($this->resourceClassResolver->isResourceClass($this->getObjectClass($entity))) {
-                    $iri = $this->iriConverter->getIriFromResource($entity, UrlGeneratorInterface::ABS_PATH, new GetCollection());
-                    $this->tags[$iri] = $iri;
-                }
-            } catch (OperationNotFoundException|InvalidArgumentException) {
-            }
+        foreach ($this->scheduledInsertions = $uow->getScheduledEntityInsertions() as $entity) {
+            // inserts shouldn't add new related entities, we should be able to gather related tags already
             $this->gatherRelationTags($em, $entity);
         }
 
@@ -111,6 +106,11 @@ final class PurgeHttpCacheListener
      */
     public function postFlush(): void
     {
+        // since IRIs can't always be generated for new entities (missing auto-generated IDs), we need to gather the related IRIs after flush()
+        foreach ($this->scheduledInsertions as $entity) {
+            $this->gatherResourceAndItemTags($entity, false);
+        }
+
         if (empty($this->tags)) {
             return;
         }
@@ -132,7 +132,8 @@ final class PurgeHttpCacheListener
                 if ($purgeItem) {
                     $this->addTagForItem($entity);
                 }
-            } catch (OperationNotFoundException|InvalidArgumentException) {
+            } catch (OperationNotFoundException|InvalidArgumentException $e) {
+                dd($e);
             }
         }
     }

--- a/src/Symfony/Tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/src/Symfony/Tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\Symfony\Doctrine\EventListener\PurgeHttpCacheListener;
 use ApiPlatform\Symfony\Tests\Fixtures\MappedEntity;
+use ApiPlatform\Symfony\Tests\Fixtures\MappedResource;
 use ApiPlatform\Symfony\Tests\Fixtures\NotAResource;
 use ApiPlatform\Symfony\Tests\Fixtures\TestBundle\Entity\ContainNonResource;
 use ApiPlatform\Symfony\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -35,6 +36,7 @@ use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -215,7 +217,8 @@ class PurgeHttpCacheListenerTest extends TestCase
         $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'notAResource')->shouldBeCalled()->willReturn($nonResource1);
         $propertyAccessorProphecy->getValue(Argument::type(ContainNonResource::class), 'collectionOfNotAResource')->shouldBeCalled()->willReturn($collectionOfNotAResource);
 
-        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal());
+        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal());
         $listener->onFlush($eventArgs);
         $listener->postFlush();
     }
@@ -270,15 +273,30 @@ class PurgeHttpCacheListenerTest extends TestCase
     public function testMappedResources(): void
     {
         $mappedEntity = new MappedEntity();
+        $mappedEntity->setFirstName('first');
+        $mappedEntity->setlastName('last');
+
+        $mappedResource = new MappedResource();
+        $mappedResource->username = $mappedEntity->getFirstName().' '.$mappedEntity->getLastName();
 
         $purgerProphecy = $this->prophesize(PurgerInterface::class);
         $purgerProphecy->purge(['/mapped_ressources'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResource(Argument::type(MappedEntity::class), UrlGeneratorInterface::ABS_PATH, new GetCollection())->willReturn('/mapped_ressources')->shouldBeCalled();
+        // the entity is not a resource, shouldn't be called
+        $iriConverterProphecy->getIriFromResource(
+            Argument::type(MappedEntity::class), UrlGeneratorInterface::ABS_PATH, new GetCollection()
+        )->shouldNotBeCalled();
+        // this should be called instead
+        $iriConverterProphecy->getIriFromResource(
+            Argument::type(MappedResource::class), UrlGeneratorInterface::ABS_PATH, new GetCollection()
+        )->willReturn('/mapped_ressources')->shouldBeCalled();
 
         $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
-        $resourceClassResolverProphecy->isResourceClass(MappedEntity::class)->willReturn(true)->shouldBeCalled();
+        $resourceClassResolverProphecy->isResourceClass(MappedEntity::class)->willReturn(false)->shouldBeCalled();
+
+        $objectMapperProphecy = $this->prophesize(ObjectMapperInterface::class);
+        $objectMapperProphecy->map($mappedEntity, MappedResource::class)->shouldBeCalled()->willReturn($mappedResource);
 
         $uowProphecy = $this->prophesize(UnitOfWork::class);
         $uowProphecy->getScheduledEntityInsertions()->willReturn([$mappedEntity])->shouldBeCalled();
@@ -294,7 +312,10 @@ class PurgeHttpCacheListenerTest extends TestCase
 
         $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
 
-        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal());
+        $listener = new PurgeHttpCacheListener($purgerProphecy->reveal(), $iriConverterProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(),
+            $objectMapperProphecy->reveal()
+        );
         $listener->onFlush($eventArgs);
         $listener->postFlush();
     }

--- a/src/Symfony/Tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
+++ b/src/Symfony/Tests/Doctrine/EventListener/PurgeHttpCacheListenerTest.php
@@ -232,7 +232,7 @@ class PurgeHttpCacheListenerTest extends TestCase
         $collection = [$dummy1, $dummy2];
 
         $purgerProphecy = $this->prophesize(PurgerInterface::class);
-        $purgerProphecy->purge(['/dummies', '/dummies/1', '/dummies/2'])->shouldBeCalled();
+        $purgerProphecy->purge(['/dummies/1', '/dummies/2', '/dummies'])->shouldBeCalled();
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
         $iriConverterProphecy->getIriFromResource(Argument::type(Dummy::class), UrlGeneratorInterface::ABS_PATH, new GetCollection())->willReturn('/dummies')->shouldBeCalled();

--- a/src/Symfony/Tests/Fixtures/MappedEntity.php
+++ b/src/Symfony/Tests/Fixtures/MappedEntity.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Symfony\Tests\Fixtures;
 
-use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResource;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\ObjectMapper\Attribute\Map;
 

--- a/src/Symfony/Tests/Fixtures/MappedResource.php
+++ b/src/Symfony/Tests/Fixtures/MappedResource.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Tests\Fixtures;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    stateOptions: new Options(entityClass: MappedEntity::class),
+    normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+)]
+#[Map(target: MappedEntity::class)]
+final class MappedResource
+{
+    #[Map(if: false)]
+    public ?string $id = null;
+
+    #[Map(target: 'firstName', transform: [self::class, 'toFirstName'])]
+    #[Map(target: 'lastName', transform: [self::class, 'toLastName'])]
+    public string $username;
+
+    public static function toFirstName(string $v): string
+    {
+        return explode(' ', $v)[0];
+    }
+
+    public static function toLastName(string $v): string
+    {
+        return explode(' ', $v)[1];
+    }
+}

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -58,6 +58,7 @@
         "symfony/expression-language": "^6.4 || ^7.0",
         "symfony/intl": "^6.4 || ^7.0",
         "symfony/mercure-bundle": "*",
+        "symfony/object-mapper": "^7.0",
         "symfony/routing": "^6.4 || ^7.0",
         "symfony/type-info": "^7.3",
         "symfony/validator": "^6.4 || ^7.0",

--- a/tests/Behat/HttpCacheContext.php
+++ b/tests/Behat/HttpCacheContext.php
@@ -50,7 +50,14 @@ final class HttpCacheContext implements Context
     {
         $purger = $this->driverContainer->get('test.api_platform.http_cache.purger');
 
-        $purgedIris = implode(',', $purger->getIris());
+        $iris = explode(',', $iris);
+        sort($iris);
+        $iris = implode(',', $iris);
+
+        $purgedIris = $purger->getIris();
+        sort($purgedIris);
+        $purgedIris = implode(',', $purgedIris);
+
         $purger->clear();
 
         if ($iris !== $purgedIris) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7347
| License       | MIT

Followup on #7345. This version waits for the doctrine flush() before trying to map the inserted entites to resources, which should ensure we invalidate the related resource collections correctly.

The related test was also reworked, it didn't do what it should. On that point i'm not sure whether it's correct to prophesize the ObjectMapper...the test would be better with a real instance IMO, but i can't (yet?) figure out how to do that easily.