### PR TITLE
Only set name_converter for the default serializer

### DIFF
--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -49,7 +49,7 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new ElasticsearchClientPass());
         $container->addCompilerPass(new GraphQlTypePass());
         $container->addCompilerPass(new GraphQlResolverPass());
-        $container->addCompilerPass(new MetadataAwareNameConverterPass());
+        $container->addCompilerPass(new MetadataAwareNameConverterPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100);
         $container->addCompilerPass(new TestClientPass());
         $container->addCompilerPass(new TestMercureHubPass());
         $container->addCompilerPass(new AuthenticatorManagerPass());

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPass.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -31,6 +32,7 @@ final class MetadataAwareNameConverterPass implements CompilerPassInterface
      * {@inheritdoc}
      *
      * @throws RuntimeException
+     * @throws InvalidArgumentException
      */
     public function process(ContainerBuilder $container): void
     {
@@ -38,22 +40,11 @@ final class MetadataAwareNameConverterPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->getDefinition('serializer.name_converter.metadata_aware');
-        $key = '$fallbackNameConverter';
-        $arguments = $definition->getArguments();
-        if (false === \array_key_exists($key, $arguments)) {
-            $key = 1;
-        }
-
         if ($container->hasAlias('api_platform.name_converter')) {
-            $nameConverter = new Reference((string) $container->getAlias('api_platform.name_converter'));
+            $nameConverter = (string) $container->getAlias('api_platform.name_converter');
 
-            // old symfony versions
-            if (false === \array_key_exists($key, $arguments)) {
-                $definition->addArgument($nameConverter);
-            } elseif (null === $definition->getArgument($key)) {
-                $definition->setArgument($key, $nameConverter);
-            }
+            $container->setParameter('.serializer.name_converter', $nameConverter);
+            $container->getDefinition('serializer.name_converter.metadata_aware')->setArgument(1, new Reference($nameConverter));
         }
 
         $container->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware');

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -47,7 +47,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(ElasticsearchClientPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(GraphQlTypePass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(GraphQlResolverPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
-        $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(MetadataAwareNameConverterPass::class), PassConfig::TYPE_BEFORE_OPTIMIZATION, 100)->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestClientPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(TestMercureHubPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/MetadataAwareNameConverterPassTest.php
@@ -34,24 +34,6 @@ class MetadataAwareNameConverterPassTest extends TestCase
         $this->assertInstanceOf(CompilerPassInterface::class, new MetadataAwareNameConverterPass());
     }
 
-    public function testProcessFirstArgumentConfigured(): void
-    {
-        $pass = new MetadataAwareNameConverterPass();
-
-        $definition = $this->prophesize(Definition::class);
-        $definition->getArguments()->willReturn([0, 1])->shouldBeCalled();
-        $definition->getArgument(1)->willReturn(new Reference('app.name_converter'))->shouldBeCalled();
-
-        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(true);
-        $containerBuilderProphecy->getAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(new Alias('api_platform.name_converter'));
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->willReturn($definition)->shouldBeCalled();
-        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
-
-        $pass->process($containerBuilderProphecy->reveal());
-    }
-
     public function testProcessWithNameConverter(): void
     {
         $pass = new MetadataAwareNameConverterPass();
@@ -59,8 +41,6 @@ class MetadataAwareNameConverterPassTest extends TestCase
         $reference = new Reference('app.name_converter');
 
         $definition = $this->prophesize(Definition::class);
-        $definition->getArguments()->willReturn([0, 1])->shouldBeCalled();
-        $definition->getArgument(1)->willReturn(null)->shouldBeCalled();
         $definition->setArgument(1, $reference)->shouldBeCalled()->willReturn($definition);
 
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
@@ -68,6 +48,19 @@ class MetadataAwareNameConverterPassTest extends TestCase
         $containerBuilderProphecy->getAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(new Alias('app.name_converter'));
         $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn(true);
         $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn($definition);
+        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
+        $containerBuilderProphecy->setParameter('.serializer.name_converter', 'app.name_converter')->shouldBeCalled();
+
+        $pass->process($containerBuilderProphecy->reveal());
+    }
+
+    public function testProcessWithoutNameConverter(): void
+    {
+        $pass = new MetadataAwareNameConverterPass();
+
+        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
+        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->willReturn(false)->shouldBeCalled();
+        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn(true);
         $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
 
         $pass->process($containerBuilderProphecy->reveal());
@@ -80,43 +73,6 @@ class MetadataAwareNameConverterPassTest extends TestCase
         $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
         $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(false)->shouldBeCalled();
         $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldNotBeCalled();
-
-        $pass->process($containerBuilderProphecy->reveal());
-    }
-
-    public function testProcessOnlyOneArg(): void
-    {
-        $pass = new MetadataAwareNameConverterPass();
-
-        $definition = $this->prophesize(Definition::class);
-        $definition->getArguments()->willReturn([0])->shouldBeCalled();
-        $definition->addArgument(new Reference('app.name_converter'))->willReturn($definition)->shouldBeCalled();
-
-        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(true);
-        $containerBuilderProphecy->getAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(new Alias('app.name_converter'));
-        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
-        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn($definition);
-
-        $pass->process($containerBuilderProphecy->reveal());
-    }
-
-    public function testProcessWithAbstractMetadataAware(): void
-    {
-        $pass = new MetadataAwareNameConverterPass();
-
-        $definition = $this->prophesize(Definition::class);
-        $definition->getArguments()->willReturn(['$metadataFactory' => [], '$fallbackNameConverter' => null])->shouldBeCalled();
-        $definition->getArgument('$fallbackNameConverter')->willReturn(null)->shouldBeCalled();
-        $definition->setArgument('$fallbackNameConverter', new Reference('app.name_converter'))->willReturn($definition)->shouldBeCalled();
-
-        $containerBuilderProphecy = $this->prophesize(ContainerBuilder::class);
-        $containerBuilderProphecy->hasDefinition('serializer.name_converter.metadata_aware')->willReturn(true)->shouldBeCalled();
-        $containerBuilderProphecy->hasAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(true);
-        $containerBuilderProphecy->getAlias('api_platform.name_converter')->shouldBeCalled()->willReturn(new Alias('app.name_converter'));
-        $containerBuilderProphecy->setAlias('api_platform.name_converter', 'serializer.name_converter.metadata_aware')->shouldBeCalled();
-        $containerBuilderProphecy->getDefinition('serializer.name_converter.metadata_aware')->shouldBeCalled()->willReturn($definition);
 
         $pass->process($containerBuilderProphecy->reveal());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #6101 
| License       | MIT
| Doc PR        | n/a

If set, the name_converter in api_platform was being applied to any serializer defined in framework.yaml. The PR moves MetadataAwareNameConverterPass before Symfony's own SerializerPass and configures the container parameters as Symfony would expect.

Tested only with SF 7.3.

/cc @soyuka 