### PR TITLE
fix: pagination via cursor on ApiResource operations

### DIFF
--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -221,6 +221,7 @@ class HttpOperation extends Operation
             paginationClientPartial: $paginationClientPartial,
             paginationFetchJoinCollection: $paginationFetchJoinCollection,
             paginationUseOutputWalkers: $paginationUseOutputWalkers,
+            paginationViaCursor: $paginationViaCursor,
             order: $order,
             description: $description,
             normalizationContext: $normalizationContext,

--- a/src/Metadata/Tests/Resource/OperationTest.php
+++ b/src/Metadata/Tests/Resource/OperationTest.php
@@ -60,4 +60,13 @@ final class OperationTest extends TestCase
         yield [new Mutation(...$args)];
         yield [new Subscription(...$args)];
     }
+
+    public function testPaginationViaCursor(): void
+    {
+        $operation = (new GetCollection())->withPaginationViaCursor(true);
+        $this->assertTrue($operation->canPaginateViaCursor());
+
+        $operation = (new GetCollection())->withPaginationViaCursor(false);
+        $this->assertFalse($operation->canPaginateViaCursor());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

When adding an operation to an ApiResource, setting `paginationViaCursor` has no effect because the parent constructor of `HttpOperation` is missing the`paginationViaCursor` parameter.

```
#[ApiResource(
    // this works
    paginationViaCursor: [ 
        [
            'field' => 'newId',
            'direction' => 'DESC',
        ]
    ],
    operations: [
        new GetCollection(
            uriTemplate: '/users',
            // this does not
            paginationViaCursor: [
                [
                    'field' => 'id',
                    'direction' => 'DESC',
                ]
            ],
        ),
    ],
)]
```