### PR TITLE
fix(jsonld): various json streamer fixes

### DIFF
--- a/src/Symfony/Bundle/Resources/config/json_streamer/common.xml
+++ b/src/Symfony/Bundle/Resources/config/json_streamer/common.xml
@@ -19,6 +19,8 @@
         <service id="api_platform.jsonld.json_streamer.write.property_metadata_loader" class="ApiPlatform\JsonLd\JsonStreamer\WritePropertyMetadataLoader">
             <argument type="service" id="json_streamer.write.property_metadata_loader" />
             <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.metadata.property.name_collection_factory" />
+            <argument type="service" id="api_platform.metadata.property.metadata_factory" />
         </service>
 
         <service id="api_platform.jsonld.json_streamer.write.value_transformer.iri" class="ApiPlatform\JsonLd\JsonStreamer\ValueTransformer\IriValueTransformer">
@@ -27,6 +29,8 @@
         </service>
 
         <service id="api_platform.jsonld.json_streamer.write.value_transformer.type" class="ApiPlatform\JsonLd\JsonStreamer\ValueTransformer\TypeValueTransformer">
+            <argument type="service" id="api_platform.resource_class_resolver" />
+            <argument type="service" id="api_platform.metadata.resource.metadata_collection_factory" />
             <tag name="json_streamer.value_transformer"/>
         </service>
 

--- a/tests/Fixtures/TestBundle/ApiResource/AggregateRating.php
+++ b/tests/Fixtures/TestBundle/ApiResource/AggregateRating.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(types: 'https://schema.org/AggregateRating', operations: [])]
+final class AggregateRating
+{
+    public function __construct(
+        #[ApiProperty(iris: ['https://schema.org/ratingValue'])]
+        public float $ratingValue,
+        #[ApiProperty(iris: ['https://schema.org/reviewCount'])]
+        public int $reviewCount,
+    ) {
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Product.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Product.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+
+#[Get(
+    types: ['https://schema.org/Product'],
+    uriTemplate: '/json-stream-products/{code}',
+    uriVariables: ['code'],
+    provider: [self::class, 'provide'],
+    jsonStream: true
+)]
+class Product
+{
+    #[ApiProperty(identifier: true)]
+    public string $code;
+
+    #[ApiProperty(genId: false, iris: ['https://schema.org/aggregateRating'])]
+    public AggregateRating $aggregateRating;
+
+    #[ApiProperty(property: 'name', iris: ['https://schema.org/name'])]
+    public string $name;
+
+    public static function provide()
+    {
+        $s = new self();
+        $s->code = 'test';
+        $s->name = 'foo';
+        $s->aggregateRating = new AggregateRating(1.0, 2);
+
+        return $s;
+    }
+}

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Configuration;
 use Doctrine\ORM\OptimisticLockException;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -74,7 +75,7 @@ class ConfigurationTest extends TestCase
         $this->assertEquals([
             'title' => 'title',
             'description' => 'description',
-            'enable_json_streamer' => class_exists(JsonStreamWriter::class),
+            'enable_json_streamer' => class_exists(ControllerHelper::class) && class_exists(JsonStreamWriter::class),
             'version' => '1.0.0',
             'show_webby' => true,
             'formats' => [


### PR DESCRIPTION
Needs test:

```
<?php

namespace App\ApiResource;

use ApiPlatform\Metadata\ApiProperty;
use ApiPlatform\Metadata\Get;
use App\Entity\Product\Product as EntityProduct;
use App\State\GetProductBySlugProvider;
use Symfony\Component\ObjectMapper\Attribute\Map;

#[Get(
    types: ['https://schema.org/Product'],
    uriTemplate: '/products/{code}',
    uriVariables: ['code'],
    provider: GetProductBySlugProvider::class,
    // jsonStream: true
)]
class Product
{
    public string $id;
    #[ApiProperty(identifier: true)]
    public string $code;

    #[Map(source: 'averageRating', transform: [self::class, 'getAggregateRating'])]
    #[ApiProperty(genId: false, iris: ['https://schema.org/aggregateRating'])]
    public AggregateRating $aggregateRating;

    #[ApiProperty(property: 'name', iris: ['https://schema.org/name'])]
    public string $name;

    /**
     * @param EntityProduct $source
     */
    public static function getAggregateRating(mixed $value, object $source, ?object $target): AggregateRating
    {
        return new AggregateRating($value, \count($source->getReviews()));
    }
}

```