### PR TITLE
fix(state): transform uri variable using ReadLinkParameterProvider

### DIFF
--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -89,6 +89,12 @@ final class ReadLinkParameterProvider implements ParameterProviderInterface
 
         $context['request']?->attributes->set($securityObjectName, $relation);
 
+        if ($parameter instanceof Link) {
+            $uriVariables = $operation->getUriVariables();
+            $uriVariables[$parameter->getKey()] = $parameter;
+            $operation = $operation->withUriVariables($uriVariables);
+        }
+
         return $operation;
     }
 

--- a/tests/Fixtures/TestBundle/ApiResource/LinkParameterProviderResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/LinkParameterProviderResource.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ParameterProvider\ReadLinkParameterProvider;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+
+#[Get(
+    uriTemplate: '/link_parameter_provider_resources/{id}',
+    uriVariables: [
+        'id' => new Link(
+            provider: ReadLinkParameterProvider::class,
+            fromClass: Dummy::class
+        ),
+    ],
+    provider: [self::class, 'provide']
+)]
+class LinkParameterProviderResource
+{
+    public string $id;
+    public Dummy $dummy;
+
+    /**
+     * @param HttpOperation $operation
+     */
+    public static function provide(Operation $operation, array $uriVariables = [])
+    {
+        $d = new self();
+        $d->id = '1';
+        $d->dummy = $operation->getUriVariables()['id']->getValue();
+
+        return $d;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Employee.php
+++ b/tests/Fixtures/TestBundle/Entity/Employee.php
@@ -20,7 +20,7 @@ use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Post;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints\IdenticalTo;
+use Symfony\Component\Validator\Constraints\Expression;
 
 #[ApiResource]
 #[Post]
@@ -49,7 +49,11 @@ use Symfony\Component\Validator\Constraints\IdenticalTo;
             toProperty: 'company',
             security: 'company.name == "Test" or company.name == "NotTest"',
             extraProperties: ['uri_template' => '/company-by-name/{name}'],
-            constraints: [new IdenticalTo('Test')]
+            constraints: [
+                new Expression(
+                    'value.getName() == "Test"',
+                ),
+            ]
         ),
     ],
 )]

--- a/tests/Functional/Parameters/LinkProviderParameterTest.php
+++ b/tests/Functional/Parameters/LinkProviderParameterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Functional\Parameters;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\LinkParameterProviderResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WithParameter;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Company;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
@@ -35,7 +36,7 @@ final class LinkProviderParameterTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [WithParameter::class, Dummy::class, Employee::class, Company::class];
+        return [WithParameter::class, Dummy::class, Employee::class, Company::class, LinkParameterProviderResource::class];
     }
 
     /**
@@ -161,5 +162,24 @@ final class LinkProviderParameterTest extends ApiTestCase
 
         $response = self::createClient()->request('GET', '/companies-by-name/NotTest/employees');
         self::assertEquals(422, $response->getStatusCode());
+    }
+
+    public function testUriVariableHasDummy(): void
+    {
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $manager = $this->getManager();
+        $dummy = new Dummy();
+        $dummy->setName('hi');
+        $manager->persist($dummy);
+        $manager->flush();
+
+        self::createClient()->request('GET', '/link_parameter_provider_resources/'.$dummy->getId());
+
+        $this->assertJsonContains([
+            'dummy' => '/dummies/1',
+        ]);
     }
 }


### PR DESCRIPTION
```php
#[Get(
    uriTemplate: '/link_parameter_provider_resources/{id}',
    uriVariables: [
        'id' => new Link(
            provider: ReadLinkParameterProvider::class,
            fromClass: Dummy::class
        ),
    ],
    provider: [self::class, 'provide']
)]
class LinkParameterProviderResource
{
    public string $id;
    public Dummy $dummy;
    public Dummy $dummyFromOperation;

    /**
     * @param HttpOperation $operation
     */
    public static function provide(Operation $operation, array $uriVariables = [])
    {
        $d = new self();
        $d->id = '1';
        $d->dummyFromOperation = $operation->getUriVariables()['id']->getValue();
        $d->dummy = $uriVariables['id'];

        return $d;
    }
}
```