### PR TITLE
 fix: phpdoc for HttpOperation paginationViaCursor parameter 

### DIFF
--- a/src/Metadata/HttpOperation.php
+++ b/src/Metadata/HttpOperation.php
@@ -58,10 +58,10 @@ class HttpOperation extends Operation
      *     stale-if-error?: int,
      * }|null $cacheHeaders {@see https://api-platform.com/docs/core/performance/#setting-custom-http-cache-headers}
      * @param array<string, string>|null $headers
-     * @param array{
+     * @param list<array{
      *     field: string,
      *     direction: string,
-     * }|null $paginationViaCursor {@see https://api-platform.com/docs/core/pagination/#cursor-based-pagination}
+     * }>|null $paginationViaCursor {@see https://api-platform.com/docs/core/pagination/#cursor-based-pagination}
      * @param array|null $normalizationContext   {@see https://api-platform.com/docs/core/serialization/#using-serialization-groups}
      * @param array|null $denormalizationContext {@see https://api-platform.com/docs/core/serialization/#using-serialization-groups}
      * @param array|null $hydraContext           {@see https://api-platform.com/docs/core/extending-jsonld-context/#hydra}


### PR DESCRIPTION
…) (#7365)| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Tickets       | none
| License       | MIT
| Doc PR        | none

This PR adapt the PHPDoc of `$paginationViaCursor` parameter of `HttpOperation` constructor according to the documentation : https://api-platform.com/docs/core/pagination/#cursor-based-pagination