### PR TITLE
fix: IriConverter does not return `null` anywhere

### DIFF
--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -91,7 +91,7 @@ class IriConverter implements IriConverterInterface
     /**
      * @param array<string, mixed> $context
      */
-    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string
+    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): string
     {
         $resourceClass = $context['force_resource_class'] ?? (\is_string($resource) ? $resource : $this->getObjectClass($resource));
         if ($resource instanceof Relation) {

--- a/src/Metadata/IriConverterInterface.php
+++ b/src/Metadata/IriConverterInterface.php
@@ -45,5 +45,5 @@ interface IriConverterInterface
      * @throws InvalidArgumentException
      * @throws RuntimeException
      */
-    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): ?string;
+    public function getIriFromResource(object|string $resource, int $referenceType = UrlGeneratorInterface::ABS_PATH, ?Operation $operation = null, array $context = []): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While making an userland implementation that leverages the IriConverter, static analysis showed that none of the interface's implementation's return statements actually is able to return `null`.

So, although making the return type more tight on the interface is a BC break, this might be something to proceed with. The main reason is that an Iri converter actually should never return `null`, and we should instead rely on the exceptions that are implemented on the interface signature already.