### PR TITLE
feat(symfony): Add an option to `#[ApiResource]` to keep the class as service

### DIFF
--- a/src/Metadata/ApiResource.php
+++ b/src/Metadata/ApiResource.php
@@ -971,6 +971,14 @@ class ApiResource extends Metadata
         protected ?bool $hideHydraOperation = null,
         ?bool $jsonStream = null,
         protected array $extraProperties = [],
+
+        /**
+         * Let the resource class be registered as a service.
+         * Use it only if the class does not hold values.
+         *
+         * @var bool|null
+         */
+        public bool $registerAsController = false,
     ) {
         parent::__construct(
             shortName: $shortName,

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -189,10 +189,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             ->addTag('api_platform.uri_variables.transformer');
         $container->registerForAutoconfiguration(ParameterProviderInterface::class)
             ->addTag('api_platform.parameter_provider');
-        $container->registerAttributeForAutoconfiguration(ApiResource::class, static function (ChildDefinition $definition): void {
-            $definition->setAbstract(true)
-                ->addTag('api_platform.resource')
-                ->addTag('container.excluded', ['source' => 'by #[ApiResource] attribute']);
+        $container->registerAttributeForAutoconfiguration(ApiResource::class, static function (ChildDefinition $definition, ApiResource $attribute): void {
+            $definition->addTag('api_platform.resource');
+            if ($attribute->registerAsController) {
+                $definition->setAbstract(true)->addTag('container.excluded', ['source' => 'by #[ApiResource] attribute']);
+            };
         });
         $container->registerAttributeForAutoconfiguration(
             AsResourceMutator::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7402
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Since https://github.com/api-platform/core/pull/6943, classes with `#[ApiResource]` attribute are excluded from the Symfony DIC. But that was without considering that a resource class could be a controller service and not a DTO. With this new option on the attribute, you can enable or restore the old behavior for a class.

<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
