### PR TITLE
fix: handle generic schema in JsonSchema

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -29,6 +29,7 @@ use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\CompositeTypeInterface;
+use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 
@@ -349,11 +350,17 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                     $valueType = TypeHelper::getCollectionValueType($t);
                 }
 
-                if (!$valueType instanceof ObjectType) {
+                if (!$valueType instanceof ObjectType && !$valueType instanceof GenericType) {
                     continue;
                 }
 
-                $className = $valueType->getClassName();
+                if ($valueType instanceof ObjectType) {
+                    $className = $valueType->getClassName();
+                } else {
+                    // GenericType
+                    $className = $valueType->getWrappedType()->getClassName();
+                }
+
                 $subSchemaInstance = new Schema($version);
                 $subSchemaInstance->setDefinitions($schema->getDefinitions());
                 $subSchemaFactory = $this->schemaFactory ?: $this;

--- a/src/JsonSchema/Tests/Fixtures/GenericChild.php
+++ b/src/JsonSchema/Tests/Fixtures/GenericChild.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonSchema\Tests\Fixtures;
+
+/**
+ * @template T of object
+ */
+class GenericChild
+{
+    public string $property;
+}

--- a/src/JsonSchema/Tests/Fixtures/NotAResource.php
+++ b/src/JsonSchema/Tests/Fixtures/NotAResource.php
@@ -22,11 +22,15 @@ use Symfony\Component\Serializer\Attribute\Groups;
  */
 class NotAResource
 {
+    /**
+     * @param array<GenericChild<object>> $items
+     */
     public function __construct(
         #[Groups('contain_non_resource')]
         private $foo,
         #[Groups('contain_non_resource')]
         private $bar,
+        private array $items,
     ) {
     }
 
@@ -38,5 +42,13 @@ class NotAResource
     public function getBar()
     {
         return $this->bar;
+    }
+
+    /**
+     * @return array<GenericChild<object>>
+     */
+    public function getItems()
+    {
+        return $this->items;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | 
| License       | MIT
| Doc PR        | 


Fix schema generic generation with new `TypeInfo`component introduced in 4.2