### PR TITLE
fix(openapi): define items type for HydraCollectionBaseSchema hydra:m…

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -190,6 +190,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 'type' => 'object',
                 'required' => [
                     $hydraPrefix.'member',
+                    'items' => ['type' => 'object'],
                 ],
                 'properties' => [
                     $hydraPrefix.'member' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes [#7418](https://github.com/api-platform/core/issues/7418)
| License       | MIT
| Doc PR        | NA

Define a default items type `object` for hydra:member, ensuring the component alone produces a valid specification
