### PR TITLE
fix(openapi): Improve response override

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -504,12 +504,15 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         $noOutput = \is_array($operation?->getOutput()) && null === $operation->getOutput()['class'];
 
         $response = $existingResponses[$status] ?? new Response($description);
+        if (null === $response->getDescription()) {
+            $response = $response->withDescription($description);
+        }
 
-        if (!$response->getContent() && $responseMimeTypes && $operationOutputSchemas && !$noOutput) {
+        if (null === $response->getContent() && $responseMimeTypes && $operationOutputSchemas && !$noOutput) {
             $response = $response->withContent($this->buildContent($responseMimeTypes, $operationOutputSchemas));
         }
 
-        if (!$response->getLinks() && $resourceMetadataCollection && $operation) {
+        if (null === $response->getLinks() && $resourceMetadataCollection && $operation) {
             $response = $response->withLinks($this->getLinks($resourceMetadataCollection, $operation));
         }
 

--- a/src/OpenApi/Model/Response.php
+++ b/src/OpenApi/Model/Response.php
@@ -17,11 +17,11 @@ final class Response
 {
     use ExtensionTrait;
 
-    public function __construct(private string $description = '', private ?\ArrayObject $content = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $links = null)
+    public function __construct(private ?string $description = null, private ?\ArrayObject $content = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $links = null)
     {
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->description;
     }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -262,6 +262,18 @@ class OpenApiFactoryTest extends TestCase
                         ),
                     ],
                 )),
+                'postDummyItemWithEmptyResponse' => (new Post())->withUriTemplate('/dummyitems/noresponse')->withOperation($baseOperation)->withOpenapi(new OpenApiOperation(
+                    responses: [
+                        '201' => new OpenApiResponse(
+                            description: '',
+                            content: new \ArrayObject(),
+                            headers: new \ArrayObject(),
+                            links: new \ArrayObject(),
+                        ),
+                        '400' => new OpenApiResponse(),
+                    ],
+                    requestBody: new RequestBody(''),
+                )),
                 'postDummyItemWithoutInput' => (new Post())->withUriTemplate('/dummyitem/noinput')->withOperation($baseOperation)->withInput(false),
                 'getDummyCollectionWithErrors' => (new GetCollection())->withUriTemplate('erroredDummies')->withErrors([DummyErrorResource::class])->withOperation($baseOperation),
             ])
@@ -1208,6 +1220,40 @@ class OpenApiFactoryTest extends TestCase
                 ]),
             ]
         ), $dummyItemPath->getGet());
+
+        $emptyReponsePath = $paths->getPath('/dummyitems/noresponse');
+        $this->assertEquals(new Operation(
+            'postDummyItemWithEmptyResponse',
+            ['Dummy'],
+            [
+                '201' => new Response(
+                    '',
+                    new \ArrayObject(),
+                    new \ArrayObject(),
+                    new \ArrayObject()
+                ),
+                '400' => new Response(
+                    'Invalid input',
+                    content: new \ArrayObject(['application/problem+json' => new MediaType(schema: new \ArrayObject(['$ref' => '#/components/schemas/Error']))]),
+                    links: new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
+                ),
+                '422' => new Response(
+                    'Unprocessable entity',
+                    content: new \ArrayObject(['application/problem+json' => new MediaType(schema: new \ArrayObject(['$ref' => '#/components/schemas/Error']))]),
+                    links: new \ArrayObject(['getDummyItem' => new Model\Link('getDummyItem', new \ArrayObject(['id' => '$response.body#/id']), null, 'This is a dummy')])
+                ),
+            ],
+            'Creates a Dummy resource.',
+            'Creates a Dummy resource.',
+            null,
+            [],
+            new RequestBody(
+                '',
+                content: new \ArrayObject([
+                    'application/ld+json' => new MediaType(new \ArrayObject(['$ref' => '#/components/schemas/Dummy.jsonld'])),
+                ]),
+            ),
+        ), $emptyReponsePath->getPost());
 
         $emptyRequestBodyPath = $paths->getPath('/dummyitem/noinput');
         $this->assertEquals(new Operation(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 like https://github.com/api-platform/core/pull/7412 ?
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

cc @soyuka This is a followed up of https://github.com/api-platform/core/pull/7412 to have a 100% consistent behavior with the RequestBody override.

When you override the RequestBody:
- Without description, it use the default one
- With a `''` description, it use `''`

After https://github.com/api-platform/core/pull/7412
- If you override the response without a description, it use `''`
- If you override the response with an explicit `''`, it use `''`

So you cannot rely on the default description provided by the OpenAiFactory.
On the opposite, just adding
```
if (!$response->getDescription()) {
     $response = $response->withDescription($description);
}
```
will remove the ability to "hide" the description by voluntary setting `''`. Feature which is possible on RequestBody.

So the only way is to use a nullable description on Response (same way it's nullable on RequestBody).
- Null means use the defaut value from OpenAiFactory
- `''` means use nothing