### PR TITLE
fix(symony): ensure the kernel is booted before using `KernelBrowser::loginUser()`

### DIFF
--- a/src/Symfony/Bundle/Test/Client.php
+++ b/src/Symfony/Bundle/Test/Client.php
@@ -236,6 +236,8 @@ final class Client implements HttpClientInterface
 
     public function loginUser(UserInterface $user, string $firewallContext = 'main'): self
     {
+        $this->kernelBrowser->getKernel()->boot();
+
         $this->kernelBrowser->loginUser($user, $firewallContext);
 
         return $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Related to #6976 and #7007
| License       | MIT
| Doc PR        | N/A

As of #6976 and #7007, calling `createClient()` no longer boots the kernel when `$alwaysBootKernel = false` is set, as recommended.

If we use `Client::loginUser()` when the kernel has not been booted, no error will occur and we will simply remain in a non-logged in state.

So, this PR ensure that the kernel is booted before using `KernelBrowser::loginUser()`, and that `Client::loginUser()` always succeeds.