### PR TITLE
chore(metadata): expand `phpstan-return` type annotations 

### DIFF
--- a/src/State/SerializerContextBuilderInterface.php
+++ b/src/State/SerializerContextBuilderInterface.php
@@ -34,7 +34,31 @@ interface SerializerContextBuilderInterface
      *
      * @return array<string, mixed>
      *
-     * @phpstan-return array<string, mixed>
+     * @phpstan-return array{
+     *    groups?: string[]|string,
+     *    operation_name?: string,
+     *    operation?: HttpOperation,
+     *    resource_class?: class-string,
+     *    skip_null_values?: bool,
+     *    iri_only?: bool,
+     *    request_uri?: string,
+     *    uri?: string,
+     *    input?: array{class: class-string|null},
+     *    output?: array{class: class-string|null},
+     *    item_uri_template?: string,
+     *    types?: string[],
+     *    uri_variables?: array<string, string>,
+     *    force_resource_class?: class-string,
+     *    api_allow_update?: bool,
+     *    deep_object_to_populate?: bool,
+     *    collect_denormalization_errors?: bool,
+     *    exclude_from_cache_key?: string[],
+     *    api_included?: bool,
+     *    attributes?: string[],
+     *    deserializer_type?: string,
+     *    api_assign_object_to_populate?: bool,
+     *    ...<string, mixed>
+     *  }
      *
      * @psalm-return array{
      *   groups?: string[]|string,


### PR DESCRIPTION
| Q | A |
|--------|--------|
| Branch? | main |
| Tickets | Closes #7471 |
| License | MIT |

In `src/State/SerializerContextBuilderInterface.php`

Phpstan annotation return type need to define some special key or phpstan throw error because he cannot access to offset like 'groups'.
<img width="576" height="226" alt="image" src="https://github.com/user-attachments/assets/c53815fb-985c-4d46-af3d-8a4cbad96404" />

[https://api-platform.com/docs/core/serialization/#changing-the-serialization-context-dynamically](https://api-platform.com/docs/core/serialization/#changing-the-serialization-context-dynamically)

```php
//  File AbstractAdminContextBuilder.php who implements SerializerContextBuilderInterface
#[\Override]
public function createFromRequest(Request $request, bool $normalization, ?array $extractedAttributes = null): array
{
    $context = $this->decorated->createFromRequest($request, $normalization, $extractedAttributes);
    $resourceClass = $context['resource_class'] ?? null;
    $operation = $context['operation'] ?? null;
    $isItemOperation = $operation instanceof Get
        || $operation instanceof Patch
        || $operation instanceof Put;

    if ($resourceClass === $this->getApplicableResourceClass()) {
        if (!isset($context['groups'])) {
            $context['groups'] = [];
        }
        if (is_string($context['groups'])) {
            $context['groups'] = [$context['groups']];
        }
        if ($this->authorizationChecker->isGranted('ROLE_INVITED_USER')) {
            if ($normalization) {
                $context['groups'][] = 'timestamp:read';
                $context['groups'][] = 'blamable:read';
                $context['groups'][] = 'thing:read:user';
                $context['groups'][] = $this->getBaseSerializationGroup().':read:user';
                if ($isItemOperation) {
                    $context['groups'][] = 'thing:single:read:user';
                    $context['groups'][] = $this->getBaseSerializationGroup().':single:read:user';
                }
...
```