### PR TITLE
feat: MCP support for api platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -181,8 +181,10 @@
         "symfony/intl": "^6.4 || ^7.0",
         "symfony/json-streamer": "7.4.x-dev",
         "symfony/maker-bundle": "^1.24",
+        "symfony/mcp-bundle": "dev-main",
         "symfony/mercure-bundle": "*",
         "symfony/messenger": "^6.4 || ^7.0",
+        "symfony/monolog-bundle": "4.x-dev",
         "symfony/object-mapper": "7.4.x-dev",
         "symfony/routing": "^6.4 || ^7.0",
         "symfony/security-bundle": "^6.4 || ^7.0",
@@ -218,5 +220,6 @@
     "type": "library",
     "repositories": [
         {"type": "vcs", "url": "https://github.com/soyuka/phpunit"}
-    ]
+    ],
+    "minimum-stability": "dev"
 }

--- a/src/Mcp/Factory/McpCapabilityFactoryInterface.php
+++ b/src/Mcp/Factory/McpCapabilityFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Factory;
+
+/**
+ * Creates MCP capability definitions from various sources.
+ *
+ * @internal
+ */
+interface McpCapabilityFactoryInterface
+{
+    /**
+     * Creates and yields MCP capability definitions.
+     *
+     * @return \Generator<array{type: string, definition: array}>
+     */
+    public function create(): \Generator;
+}

--- a/src/Mcp/Factory/McpDocumentationFactory.php
+++ b/src/Mcp/Factory/McpDocumentationFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Factory;
+
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Creates MCP Resource definitions for API Platform's documentation endpoints.
+ *
+ * @internal
+ */
+final readonly class McpDocumentationFactory implements McpCapabilityFactoryInterface
+{
+    public function __construct(
+        private RequestContext $requestContext,
+    ) {
+    }
+
+    /**
+     * @return \Generator<array{type: string, definition: array}>
+     */
+    public function create(): \Generator
+    {
+        $prefix = \sprintf('%s://%s/', $this->requestContext->getScheme(), $this->requestContext->getHost());
+
+        // API Documentation Resources
+        yield [
+            'type' => 'resource',
+            'definition' => [
+                'uri' => $prefix.'docs.jsonopenapi',
+                'name' => 'openapi_spec',
+                'description' => 'The OpenAPI specification for this API.',
+                'mimeType' => 'application/vnd.openapi+json',
+            ],
+        ];
+        yield [
+            'type' => 'resource',
+            'definition' => [
+                'uri' => $prefix.'docs.jsonld',
+                'name' => 'hydra_docs',
+                'description' => 'The Hydra documentation for this API.',
+                'mimeType' => 'application/ld+json',
+            ],
+        ];
+
+        // Entrypoint Resource
+        yield [
+            'type' => 'resource',
+            'definition' => [
+                'uri' => $prefix.'entrypoint',
+                'name' => 'api_entrypoint',
+                'description' => 'The main entrypoint for the API.',
+                'mimeType' => 'application/ld+json',
+            ],
+        ];
+
+        // JSON-LD Context Resource Template
+        yield [
+            'type' => 'resource_template',
+            'definition' => [
+                'uriTemplate' => $prefix.'contexts/{shortName}',
+                'name' => 'jsonld_context',
+                'description' => 'The JSON-LD context for a given resource short name.',
+                'mimeType' => 'application/ld+json',
+            ],
+        ];
+    }
+}

--- a/src/Mcp/Factory/McpOperationFactory.php
+++ b/src/Mcp/Factory/McpOperationFactory.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Factory;
+
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * Creates MCP capability definitions from API Platform operations.
+ *
+ * @internal
+ */
+final readonly class McpOperationFactory implements McpCapabilityFactoryInterface
+{
+    public function __construct(
+        private ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
+        private ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
+        private RequestContext $requestContext,
+        private SchemaFactoryInterface $schemaFactory,
+    ) {
+    }
+
+    /**
+     * Creates and yields MCP capability definitions.
+     *
+     * @return \Generator<array{type: string, definition: array}>
+     */
+    public function create(): \Generator
+    {
+        foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
+            $resourceMetadataCollection = $this->resourceMetadataFactory->create($resourceClass);
+            foreach ($resourceMetadataCollection as $resource) {
+                foreach ($resource->getOperations() as $operation) {
+                    // TODO: A dedicated `$operation->getMcp() === false` property would be the ideal way to control inclusion.
+                    if (!$operation instanceof HttpOperation) {
+                        continue;
+                    }
+
+                    $mcpName = $operation->getExtraProperties()['mcp_name'] ?? null;
+                    if (!$mcpName) {
+                        continue;
+                    }
+
+                    // TBD: To support multiple formats, we could iterate over `getOutputFormats`
+                    // and yield a tool for each, suffixing the name with the format,
+                    // e.g., "api_books_get_collection_jsonld", "api_books_get_collection_json".
+                    // The handler would then parse this name to set the correct `Accept` header.
+                    $method = strtoupper($operation->getMethod());
+
+                    if (!$operation->getUriTemplate()) {
+                        continue;
+                    }
+
+                    $mimeType = current($operation->getInputFormats())[0] ?? 'application/json';
+
+                    if ('GET' === $method) {
+                        $uri = \sprintf('%s://%s/%s', $this->requestContext->getScheme(), $this->requestContext->getHost(), ltrim(str_replace('{._format}', '', $operation->getUriTemplate()), '/'));
+
+                        if (!$operation->getUriVariables()) {
+                            yield [
+                                'type' => 'resource',
+                                'definition' => [
+                                    'uri' => $uri,
+                                    'name' => $mcpName,
+                                    'description' => $operation->getDescription(),
+                                    'mimeType' => $mimeType,
+                                ],
+                            ];
+
+                            continue;
+                        }
+
+                        yield [
+                            'type' => 'resource_template',
+                            'definition' => [
+                                'uriTemplate' => $uri,
+                                'name' => $mcpName,
+                                'description' => $operation->getDescription(),
+                                'mimeType' => $mimeType,
+                            ],
+                        ];
+                        continue;
+                    }
+
+                    yield [
+                        'type' => 'tool',
+                        'definition' => [
+                            'name' => $mcpName,
+                            'description' => $operation->getDescription(),
+                            'inputSchema' => $this->buildInputSchema($operation),
+                        ],
+                    ];
+                }
+            }
+        }
+    }
+
+    private function buildInputSchema(HttpOperation $operation): ?array
+    {
+        $schema = [
+            'type' => 'object',
+            'properties' => [],
+            'required' => [],
+        ];
+
+        // 1. Add properties from the request body for relevant methods
+        if (\in_array($operation->getMethod(), ['POST', 'PUT', 'PATCH'], true)) {
+            $bodySchema = $this->schemaFactory->buildSchema($operation->getClass(), 'json', Schema::TYPE_INPUT, $operation);
+            $rootDefinitionKey = $bodySchema->getRootDefinitionKey();
+
+            if (null !== $rootDefinitionKey && isset($bodySchema->getDefinitions()[$rootDefinitionKey])) {
+                $bodyDefinition = $bodySchema->getDefinitions()[$rootDefinitionKey]->getArrayCopy();
+                if (isset($bodyDefinition['properties'])) {
+                    $schema['properties'] = array_merge($schema['properties'], $bodyDefinition['properties']);
+                }
+                if (isset($bodyDefinition['required'])) {
+                    $schema['required'] = array_merge($schema['required'], $bodyDefinition['required']);
+                }
+            }
+        }
+
+        // 2. Add properties from URI variables
+        foreach ($operation->getUriVariables() as $parameterName => $uriVariable) {
+            $schema['properties'][$parameterName] = $uriVariable->getSchema() ?? ['type' => 'string'];
+            if ($uriVariable->getRequired() ?? true) {
+                $schema['required'][] = $parameterName;
+            }
+        }
+
+        if (empty($schema['properties'])) {
+            return null;
+        }
+
+        if (empty($schema['required'])) {
+            unset($schema['required']);
+        } else {
+            // Ensure unique values
+            $schema['required'] = array_values(array_unique($schema['required']));
+        }
+
+        return $schema;
+    }
+}

--- a/src/Mcp/Metadata/Factory/Operation/McpOperationMetadataFactory.php
+++ b/src/Mcp/Metadata/Factory/Operation/McpOperationMetadataFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Metadata\Factory\Operation;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+
+/**
+ * Finds an operation by its sanitized MCP name.
+ *
+ * @internal
+ */
+final readonly class McpOperationMetadataFactory implements OperationMetadataFactoryInterface
+{
+    public function __construct(
+        private ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
+        private ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+    ) {
+    }
+
+    public function create(string $mcpName, array $context = []): ?Operation
+    {
+        foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
+            $resourceMetadataCollection = $this->resourceMetadataCollectionFactory->create($resourceClass);
+            foreach ($resourceMetadataCollection as $resource) {
+                foreach ($resource->getOperations() as $operation) {
+                    $candidateMcpName = $operation->getExtraProperties()['mcp_name'] ?? null;
+                    if ($candidateMcpName === $mcpName) {
+                        return $operation;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Mcp/Metadata/Factory/Resource/McpNameResourceMetadataCollectionFactory.php
+++ b/src/Mcp/Metadata/Factory/Resource/McpNameResourceMetadataCollectionFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Metadata\Factory\Resource;
+
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * Adds a sanitized, MCP-compliant name to each operation's metadata.
+ *
+ * @internal
+ */
+final readonly class McpNameResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(private ResourceMetadataCollectionFactoryInterface $decorated)
+    {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $i => $resource) {
+            if (!$operations = $resource->getOperations()) {
+                continue;
+            }
+
+            $newOperations = new Operations();
+            foreach ($operations as $operation) {
+                if (!$operation instanceof HttpOperation) {
+                    continue;
+                }
+
+                if ($mcpName = $this->getMcpName($operation)) {
+                    $operation = $operation->withExtraProperties(array_merge($operation->getExtraProperties(), ['mcp_name' => $mcpName]));
+                }
+                $newOperations->add($operation->getName(), $operation);
+            }
+
+            $resourceMetadataCollection[$i] = $resource->withOperations($newOperations);
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    private function getMcpName(HttpOperation $operation): string
+    {
+        return strtolower($operation->getShortName()).
+            '_'.$this->getHttpMethodName($operation->getMethod()).
+            ($operation instanceof CollectionOperationInterface ? '_list' : '').
+            ($operation->getUriVariables() ? '_by_'.implode('_', array_keys($operation->getUriVariables())) : '');
+    }
+
+    private function getHttpMethodName(?string $method): string
+    {
+        return match (strtolower($method)) {
+            'post' => 'create',
+            'put' => 'upsert',
+            'patch' => 'update',
+            'delete' => 'delete',
+            default => 'retrieve',
+        };
+    }
+}

--- a/src/Mcp/Schema/Result/StructuredContentResult.php
+++ b/src/Mcp/Schema/Result/StructuredContentResult.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Schema\Result;
+
+use Mcp\Schema\JsonRpc\ResultInterface;
+
+class StructuredContentResult implements ResultInterface
+{
+    /**
+     * Create a new StructuredContentResult.
+     *
+     * @param array           $structuredContent The JSON content
+     * @param ResultInterface $result            A traditional result
+     */
+    public function __construct(
+        public array $structuredContent,
+        public readonly ?ResultInterface $result = null,
+    ) {
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return ['structuredContent' => $this->structuredContent] + ($this->result?->jsonSerialize() ?? []);
+    }
+}

--- a/src/Mcp/Server/Builder.php
+++ b/src/Mcp/Server/Builder.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Server;
+
+use ApiPlatform\Mcp\Factory\McpCapabilityFactoryInterface;
+use Mcp\Server;
+use Mcp\Server\Builder as McpBuilder;
+use Mcp\Server\Handler\Request\RequestHandlerInterface;
+
+/**
+ * Decorates the original MCP Server Builder to add capabilities from API Platform.
+ *
+ * @internal
+ */
+final class Builder
+{
+    /**
+     * @param iterable<McpCapabilityFactoryInterface> $factories
+     * @param iterable<RequestHandlerInterface>       $requestHandlers
+     */
+    public function __construct(
+        private readonly McpBuilder $decorated,
+        private readonly iterable $factories,
+        private readonly iterable $requestHandlers,
+    ) {
+    }
+
+    public function build(): Server
+    {
+        foreach ($this->requestHandlers as $requestHandler) {
+            $this->decorated->addRequestHandler($requestHandler);
+        }
+
+        foreach ($this->factories as $factory) {
+            foreach ($factory->create() as ['type' => $type, 'definition' => $definition]) {
+                $definition['handler'] = fn () => null; // dummy handler we call it inside our CallToolHandler
+                match ($type) {
+                    'tool' => $this->decorated->addTool(...$definition),
+                    'resource' => $this->decorated->addResource(...$definition),
+                    'resource_template' => $this->decorated->addResourceTemplate(...$definition),
+                    default => null,
+                };
+            }
+        }
+
+        return $this->decorated->build();
+    }
+
+    public function __call(string $name, array $arguments): mixed
+    {
+        return $this->decorated->{$name}(...$arguments);
+    }
+}

--- a/src/Mcp/Server/Handler/Request/CallToolHandler.php
+++ b/src/Mcp/Server/Handler/Request/CallToolHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Server\Handler\Request;
+
+use ApiPlatform\Mcp\Schema\Result\StructuredContentResult;
+use ApiPlatform\Metadata\Exception\OperationNotFoundException;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Request as McpRequest;
+use Mcp\Schema\JsonRpc\Response as McpResponse;
+use Mcp\Schema\Request\CallToolRequest;
+use Mcp\Schema\Result\CallToolResult;
+use Mcp\Server\Handler\Request\RequestHandlerInterface;
+use Mcp\Server\Session\SessionInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+final class CallToolHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly HttpKernelInterface $kernel,
+        private readonly OperationMetadataFactoryInterface $mcpOperationMetadataFactory,
+        private readonly RouterInterface $router,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function supports(McpRequest $request): bool
+    {
+        return $request instanceof CallToolRequest;
+    }
+
+    public function handle(McpRequest $request, SessionInterface $session): McpResponse|Error
+    {
+        \assert($request instanceof CallToolRequest);
+
+        $toolName = $request->name;
+        $arguments = $request->arguments ?? [];
+
+        $this->logger->debug('Executing tool', ['name' => $toolName, 'arguments' => $arguments]);
+
+        try {
+            $result = $this->executeTool($toolName, $arguments);
+
+            $rawResult = new CallToolResult([new TextContent($result)]);
+
+            return new McpResponse($request->getId(), $result ? new StructuredContentResult(json_decode($result, true), $rawResult) : $rawResult);
+        } catch (OperationNotFoundException $e) {
+            $this->logger->error('Tool not found', ['name' => $toolName, 'exception' => $e->getMessage()]);
+
+            return new Error($request->getId(), Error::METHOD_NOT_FOUND, $e->getMessage());
+        } catch (\Throwable $e) {
+            $this->logger->error('Unhandled error during tool execution', [
+                'name' => $toolName,
+                'exception' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return Error::forInternalError('Error while executing tool', $request->getId());
+        }
+    }
+
+    private function executeTool(string $mcpName, array $arguments): ?string
+    {
+        $operation = $this->mcpOperationMetadataFactory->create($mcpName);
+        if (!$operation || !$operation instanceof HttpOperation) {
+            throw new OperationNotFoundException(\sprintf('Operation with MCP name "%s" not found.', $mcpName));
+        }
+
+        $uriVariables = [];
+        $bodyParams = [];
+
+        foreach ($arguments as $key => $value) {
+            if (\array_key_exists($key, $operation->getUriVariables() ?? [])) {
+                $uriVariables[$key] = $value;
+            } else {
+                $bodyParams[$key] = $value;
+            }
+        }
+
+        $url = $this->router->generate($operation->getRouteName() ?? $operation->getName(), $uriVariables);
+        $method = $operation->getMethod();
+        $content = $bodyParams ? json_encode($bodyParams, \JSON_THROW_ON_ERROR) : null;
+        $headers = ['Content-Type' => 'application/json', 'Accept' => 'application/ld+json'];
+
+        $subRequest = HttpRequest::create($url, $method, [], [], [], ['HTTP_ACCEPT' => $headers['Accept']], $content);
+        if ($content) {
+            $subRequest->headers->set('Content-Type', $headers['Content-Type']);
+        }
+
+        $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        if (HttpResponse::HTTP_NO_CONTENT === $response->getStatusCode()) {
+            return null;
+        }
+
+        return $response->getContent();
+    }
+}

--- a/src/Mcp/Server/Handler/Request/ReadResourceHandler.php
+++ b/src/Mcp/Server/Handler/Request/ReadResourceHandler.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Server\Handler\Request;
+
+use ApiPlatform\Mcp\Schema\Result\StructuredContentResult;
+use ApiPlatform\Metadata\Exception\OperationNotFoundException;
+use ApiPlatform\Metadata\Exception\RuntimeException;
+use Mcp\Schema\Content\TextResourceContents;
+use Mcp\Schema\JsonRpc\Error;
+use Mcp\Schema\JsonRpc\Request;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Request\ReadResourceRequest;
+use Mcp\Schema\Result\ReadResourceResult;
+use Mcp\Server\Handler\Request\RequestHandlerInterface;
+use Mcp\Server\Session\SessionInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class ReadResourceHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private readonly HttpKernelInterface $kernel,
+        private readonly ?LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    public function supports(Request $request): bool
+    {
+        return $request instanceof ReadResourceRequest;
+    }
+
+    public function handle(Request $request, SessionInterface $session): Response|Error
+    {
+        \assert($request instanceof ReadResourceRequest);
+
+        $uri = $request->uri;
+
+        $this->logger->debug('Reading resource', ['uri' => $uri]);
+
+        try {
+            $httpRequest = HttpRequest::create($uri, 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+            $response = $this->kernel->handle($httpRequest, HttpKernelInterface::SUB_REQUEST);
+            if (!$content = $response->getContent()) {
+                throw new RuntimeException('No content');
+            }
+
+            $array = json_decode($content, true);
+
+            return new Response($request->getId(), new StructuredContentResult($array, new ReadResourceResult([new TextResourceContents($array['@id'], 'application/ld+json', $content)])));
+        } catch (OperationNotFoundException $e) {
+            $this->logger->error('Resource not found', ['uri' => $uri]);
+
+            return new Error($request->getId(), Error::RESOURCE_NOT_FOUND, $e->getMessage());
+        } catch (\Throwable $e) {
+            $this->logger->error(\sprintf('Error while reading resource "%s": "%s".', $uri, $e->getMessage()));
+
+            return Error::forInternalError('Error while reading resource', $request->getId());
+        }
+    }
+}

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -50,6 +50,7 @@ use ApiPlatform\Validator\Exception\ValidationException;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Ramsey\Uuid\Uuid;
+use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\DirectoryResource;
@@ -175,6 +176,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerArgumentResolverConfiguration($loader);
         $this->registerLinkSecurityConfiguration($loader, $config);
         $this->registerJsonStreamerConfiguration($container, $loader, $formats, $config);
+        $this->registerMcpConfiguration($loader);
 
         if (class_exists(ObjectMapper::class)) {
             $loader->load('state/object_mapper.php');
@@ -1011,5 +1013,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
                 $loader->load('json_streamer/json.php');
             }
         }
+    }
+
+    private function registerMcpConfiguration(PhpFileLoader $loader): void
+    {
+        if (!class_exists(McpBundle::class)) {
+            throw new RuntimeException('symfony/mcp-bundle is not installed.');
+        }
+
+        $loader->load('mcp.php');
     }
 }

--- a/src/Symfony/Bundle/Resources/config/mcp.php
+++ b/src/Symfony/Bundle/Resources/config/mcp.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use ApiPlatform\Mcp\Factory\McpDocumentationFactory;
+use ApiPlatform\Mcp\Factory\McpOperationFactory;
+use ApiPlatform\Mcp\Metadata\Factory\Operation\McpOperationMetadataFactory;
+use ApiPlatform\Mcp\Metadata\Factory\Resource\McpNameResourceMetadataCollectionFactory;
+use ApiPlatform\Mcp\Server\Builder;
+use ApiPlatform\Mcp\Server\Handler\Request\CallToolHandler;
+use ApiPlatform\Mcp\Server\Handler\Request\ReadResourceHandler;
+
+return static function (ContainerConfigurator $container): void {
+    $container->services()
+        // Generator for MCP capabilities based on API Platform operations
+        ->set('api_platform.mcp.operation_factory', McpOperationFactory::class)
+            ->args([
+                service('api_platform.metadata.resource.name_collection_factory'),
+                service('api_platform.metadata.resource.metadata_collection_factory'),
+                service('router.request_context'),
+                service('api_platform.json_schema.schema_factory'),
+            ])
+            ->tag('api_platform.mcp_capability_factory')
+
+        // Generator for MCP capabilities based on API Platform documentation endpoints
+        ->set('api_platform.mcp.documentation_factory', McpDocumentationFactory::class)
+            ->args([
+                service('router.request_context'),
+            ])
+            ->tag('api_platform.mcp_capability_factory')
+
+        // Creates an Mpc specific name and adds it to an operation's `extraProperties`
+        ->set('api_platform.mcp.metadata_resource_factory.mcp_name', McpNameResourceMetadataCollectionFactory::class)
+            ->decorate('api_platform.metadata.resource.metadata_collection_factory', priority: -10)
+            ->args([
+                service('.inner'),
+            ])
+
+        ->set('api_platform.mcp.operation_metadata_factory', McpOperationMetadataFactory::class)
+            ->args([
+                service('api_platform.metadata.resource.name_collection_factory'),
+                service('api_platform.metadata.resource.metadata_collection_factory'),
+            ])
+
+        ->set('api_platform.mcp.request_handler.call_tool', CallToolHandler::class)
+            ->args([
+                service('http_kernel'),
+                service('api_platform.mcp.operation_metadata_factory'),
+                service('router'),
+            ])
+            ->tag('api_platform.mcp.request_handler')
+
+        ->set('api_platform.mcp.request_handler.read_resource', ReadResourceHandler::class)
+            ->args([
+                service('http_kernel'),
+            ])
+            ->tag('api_platform.mcp.request_handler')
+
+        ->set('api_platform.mcp.server.builder', Builder::class)
+            ->decorate('mcp.server.builder')
+            ->args([
+                service('.inner'),
+                tagged_iterator('api_platform.mcp_capability_factory'),
+                tagged_iterator('api_platform.mcp.request_handler'),
+            ]);
+};

--- a/tests/Fixtures/TestBundle/Entity/Recipe.php
+++ b/tests/Fixtures/TestBundle/Entity/Recipe.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(types: ['https://schema.org/Recipe'], normalizationContext: ['hydra_prefix' => false])]
+#[ORM\Entity]
+class Recipe
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column]
+    public string $name;
+
+    #[ORM\Column(type: 'text')]
+    public string $description;
+
+    #[ORM\Column(nullable: true)]
+    public ?string $cookTime = null;
+
+    #[ORM\Column(nullable: true)]
+    public ?string $prepTime = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -27,10 +27,12 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\MongoDBBundle\Command\TailCursorDoctrineODMCommand;
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle;
+use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MercureBundle\MercureBundle;
+use Symfony\Bundle\MonologBundle\MonologBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
@@ -81,6 +83,11 @@ class AppKernel extends Kernel
 
         if (extension_loaded('mongodb') && class_exists(DoctrineMongoDBBundle::class)) {
             $bundles[] = new DoctrineMongoDBBundle();
+        }
+
+        if (class_exists(McpBundle::class)) {
+            $bundles[] = new MonologBundle();
+            $bundles[] = new McpBundle();
         }
 
         $bundles[] = new TestBundle();

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -91,6 +91,17 @@ api_platform:
     mercure:
         include_type: true
 
+mcp:
+    client_transports:
+        http: true
+        stdio: false
+    http:
+        path: /mcp
+        session:
+            store: 'file'
+            directory: '%kernel.project_dir%/var/mcp_sessions'
+            ttl: 3600
+
 services:
     test.client:
         class: ApiPlatform\Tests\Fixtures\TestBundle\BrowserKit\Client

--- a/tests/Fixtures/app/config/routing.yml
+++ b/tests/Fixtures/app/config/routing.yml
@@ -1,3 +1,6 @@
 api:
     resource: '.'
     type: 'api_platform'
+mcp:
+    resource: '.'
+    type: 'mcp'

--- a/tests/Functional/McpTest.php
+++ b/tests/Functional/McpTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Recipe;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+class McpTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    private int $jsonRpcId = 1;
+    private array $mcpHeaders;
+
+    public static function getResources(): array
+    {
+        return [Recipe::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mcpHeaders = [
+            'Accept' => 'application/json, text/event-stream',
+            'Content-Type' => 'application/json',
+        ];
+
+        $this->recreateSchema([Recipe::class]);
+
+        $manager = $this->getManager();
+        $recipe = new Recipe();
+        $recipe->name = 'French Onion Soup';
+        $recipe->description = 'A classic French soup.';
+        $recipe->cookTime = 'PT1H';
+        $recipe->prepTime = 'PT20M';
+        $manager->persist($recipe);
+        $manager->flush();
+    }
+
+    public function testMcpEndpoint(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('MongoDB not tested.');
+        }
+
+        $client = self::createClient();
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('initialize', [
+                'protocolVersion' => '2024-11-05',
+                'clientInfo' => [
+                    'name' => 'ApiPlatform Test Suite',
+                    'version' => '1.0',
+                ],
+                'capabilities' => new \stdClass(),
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHasHeader('mcp-session-id');
+        $this->mcpHeaders['mcp-session-id'] = $response->getHeaders()['mcp-session-id'][0];
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('tools/list'),
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $baseSchema = [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'description' => ['type' => 'string'],
+                'cookTime' => ['type' => ['string', 'null']],
+                'prepTime' => ['type' => ['string', 'null']],
+            ],
+        ];
+
+        $this->assertJsonContains([
+            'result' => [
+                'tools' => [
+                    ['name' => 'recipe_create', 'inputSchema' => $baseSchema],
+                    ['name' => 'recipe_upsert_by_id', 'inputSchema' => $baseSchema + ['properties' => ['id' => ['type' => 'integer']] + $baseSchema['properties']]],
+                    ['name' => 'recipe_update_by_id', 'inputSchema' => $baseSchema + ['properties' => ['id' => ['type' => 'integer']] + $baseSchema['properties']]],
+                    ['name' => 'recipe_delete_by_id', 'inputSchema' => ['type' => 'object', 'properties' => ['id' => ['type' => 'string']], 'required' => ['id']]],
+                ],
+            ],
+        ]);
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('resources/list'),
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'result' => [
+                'resources' => [
+                    ['uri' => 'http://localhost/recipes', 'name' => 'recipe_retrieve_list', 'mimeType' => 'application/ld+json'],
+                    ['uri' => 'http://localhost/docs.jsonopenapi', 'name' => 'openapi_spec', 'description' => 'The OpenAPI specification for this API.', 'mimeType' => 'application/vnd.openapi+json'],
+                    ['uri' => 'http://localhost/docs.jsonld', 'name' => 'hydra_docs', 'description' => 'The Hydra documentation for this API.', 'mimeType' => 'application/ld+json'],
+                    ['uri' => 'http://localhost/entrypoint', 'name' => 'api_entrypoint', 'description' => 'The main entrypoint for the API.', 'mimeType' => 'application/ld+json'],
+                ],
+            ],
+        ]);
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('resources/templates/list'),
+        ]);
+
+        $this->assertJsonContains([
+            'result' => [
+                'resourceTemplates' => [
+                    [
+                        'uriTemplate' => 'http://localhost/recipes/{id}',
+                        'name' => 'recipe_retrieve_by_id',
+                        'mimeType' => 'application/ld+json',
+                    ],
+                    [
+                        'uriTemplate' => 'http://localhost/errors/{status}',
+                        'name' => 'error_retrieve_by_status',
+                        'description' => 'A representation of common errors.',
+                        'mimeType' => 'application/ld+json',
+                    ],
+                    [
+                        'uriTemplate' => 'http://localhost/validation_errors/{id}',
+                        'name' => 'constraintviolation_retrieve_by_id',
+                        'description' => 'Unprocessable entity',
+                        'mimeType' => 'application/ld+json',
+                    ],
+                    [
+                        'uriTemplate' => 'http://localhost/contexts/{shortName}',
+                        'name' => 'jsonld_context',
+                        'description' => 'The JSON-LD context for a given resource short name.',
+                        'mimeType' => 'application/ld+json',
+                    ],
+                ],
+            ],
+        ]);
+
+        $arguments = [
+            'name' => 'Ratatouille',
+            'description' => 'A traditional French Provençal stewed vegetable dish.',
+        ];
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('tools/call', [
+                'name' => 'recipe_create',
+                'arguments' => $arguments,
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $createdRecipe = $response->toArray()['result'];
+        $this->assertStringContainsString('Ratatouille', $createdRecipe['content'][0]['text']);
+        $this->assertArraySubset($arguments, $createdRecipe['structuredContent']);
+        $createdRecipeId = $createdRecipe['structuredContent']['id'];
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('resources/read', [
+                'uri' => \sprintf('http://localhost/recipes/%d', $createdRecipeId),
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $readRecipe = $response->toArray()['result'];
+        $this->assertStringContainsString('Ratatouille', $readRecipe['contents'][0]['text']);
+        $this->assertArraySubset($arguments, $readRecipe['structuredContent']);
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('resources/read', [
+                'uri' => 'http://localhost/recipes',
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $list = $response->toArray()['result'];
+        $this->assertSame(2, $list['structuredContent']['totalItems']);
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('tools/call', [
+                'name' => 'recipe_upsert_by_id',
+                'arguments' => [
+                    'id' => $createdRecipeId,
+                    'name' => 'Ratatouille Updated',
+                    'description' => 'An updated description.',
+                ],
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringContainsString('Ratatouille Updated', $response->getContent());
+
+        $response = $client->request('POST', '/mcp', [
+            'headers' => $this->mcpHeaders,
+            'json' => $this->createJsonRpcRequest('tools/call', [
+                'name' => 'recipe_delete_by_id',
+                'arguments' => ['id' => $createdRecipeId],
+            ]),
+        ]);
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('', $response->toArray()['result']['content'][0]['text']);
+    }
+
+    private function createJsonRpcRequest(string $method, array $params = []): array
+    {
+        return [
+            'jsonrpc' => '2.0',
+            'id' => $this->jsonRpcId++,
+            'method' => $method,
+            'params' => $params,
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| License       | MIT

Bringing MCP capabilities to API Platform ! 

This is huge as for every supported operation you will be able to activate MCP support by only setting `mcp: true` on your resource/operation. 

TODO:

- [ ] review this draft
- [ ] add a `mcp` flag to operation/resource to be able to select which operations to expose (default will be none)
- [ ] missing completion (probably do this in another PR)
- [ ] annotations support
- [ ] decide for formats and check if json-ld is not available how things work
- [ ] test a tool when there's an URI variable
- [ ] https://github.com/modelcontextprotocol/php-sdk/issues/108 actually we had to create new RequestHandler and could not use the ones from the SDK because of this issue, I'm wondering if we could make something better 

Because of the last issue, we're not using the default `handler` mechanics and we don't need the following compiler pass: 

```php
final class McpPass implements CompilerPassInterface
{
    public function process(ContainerBuilder $container): void
    {
        if (!$container->hasDefinition('api_platform.mcp.server.builder')) {
            return;
        }

        $handlerServices = [
            'http_kernel' => new Reference('http_kernel'),
            'router' => new Reference('router'),
            'api_platform.mcp.operation_metadata_factory' => new Reference('api_platform.mcp.operation_metadata_factory'),
        ];

        $serviceLocatorRef = ServiceLocatorTagPass::register($container, $handlerServices);
        $container->getDefinition('api_platform.mcp.server.builder')
            ->addMethodCall('setContainer', [$serviceLocatorRef]);
    }
}
```

I'll keep that here in case we rollback to this implementation.

Note the mcp-bundle is still not released and the php-sdk development is heavily active therefore we should expect things to break, use this at your own risk. 

