### PR TITLE
fix:(symfony) clarify deprecation messages for BC

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -50,7 +50,7 @@ abstract class ApiTestCase extends KernelTestCase
             trigger_deprecation(
                 'api-platform/symfony',
                 '4.1.0',
-                'In API Platform 5.0, the kernel will not always be booted when a new client is created (see https://github.com/api-platform/core/issues/6971).',
+                'Currently, the kernel will always be booted when a new client is created, but in API Platform 5.0, it will not be booted unless you set `static::$alwaysBootKernel` to `true` (the default will be `false`). See https://github.com/api-platform/core/issues/6971 for more information.',
             );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Related to #7007
| License       | MIT
| Doc PR        | N/A

Current deprecation message was unclear as to whether the default value of `$alwaysBootKernel` was planned to be `true` or `false`, so I edited the message a little.