### PR TITLE
Fix validation errors when defining multiple query parameters on an operation using the `:property` template valid + property restriction.

### DIFF
--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -120,6 +120,10 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         $propertyNames = $properties = [];
         $parameters = $operation->getParameters() ?? new Parameters();
         foreach ($parameters as $key => $parameter) {
+            if (!$parameter->getKey()) {
+                $parameter = $parameter->withKey($key);
+            }
+
             ['propertyNames' => $propertyNames, 'properties' => $properties] = $this->getProperties($resourceClass, $parameter);
             if (null === $parameter->getProvider() && (($f = $parameter->getFilter()) && $f instanceof ParameterProviderFilterInterface)) {
                 $parameters->add($key, $parameter->withProvider($f->getParameterProvider()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | #7460
| License       | MIT
| Doc PR        | N/A

Potential fix for #7460. This fixes the issue for me, but not sure if it's the best way, or if there will be any side effects.