### PR TITLE
feat(laravel): Enable to skip autoconfiguration with new `SkipAutoconfigure` attribute

### DIFF
--- a/src/Laravel/ApiPlatformDeferredProvider.php
+++ b/src/Laravel/ApiPlatformDeferredProvider.php
@@ -51,6 +51,7 @@ use ApiPlatform\Laravel\State\SwaggerUiProcessor;
 use ApiPlatform\Laravel\State\ValidateProvider;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
 use ApiPlatform\Metadata\InflectorInterface;
+use ApiPlatform\Metadata\Laravel\SkipAutoconfigure;
 use ApiPlatform\Metadata\Operation\PathSegmentNameGeneratorInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -101,6 +102,15 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
     {
         $directory = app_path();
         $classes = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([$directory], '(?!.*Test\.php$)');
+
+        foreach ($classes as $className => $refl) {
+            foreach ($refl->getAttributes() as $attribute) {
+                if (SkipAutoconfigure::class === $attribute->getName()) {
+                    unset($classes[$className]);
+                    break;
+                }
+            }
+        }
 
         $this->autoconfigure($classes, QueryExtensionInterface::class, [FilterQueryExtension::class]);
         $this->app->singleton(ItemProvider::class, function (Application $app) {

--- a/src/Metadata/Laravel/SkipAutoconfigure.php
+++ b/src/Metadata/Laravel/SkipAutoconfigure.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Laravel;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class SkipAutoconfigure
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

We discovered an issue where a circular dependency could occur when decorating a system processor such as `WriteProcessor`.

For example, create a decorator for `WriteProcessor` called `AppWriteProcessor` as follows:

```php
$this->app->extend(WriteProcessor::class, function (WriteProcessor $inner) {
    return new AppWriteProcessor($inner);
});
```

```php
final class AppWriteProcessor implements ProcessorInterface
{
    public function __construct(
        private readonly WriteProcessor $decorated,
    ) {
    }

    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
    {
        return $this->decorated->process($data, $operation, $uriVariables, $context);
    }
}
```

In this case, because `AppWriteProcessor` implements `ProcessorInterface`, it is tagged with `ProcessorInterface` and is therefore [included as a dependency of `CallableProcessor`](https://github.com/api-platform/laravel/blob/v4.2.2/ApiPlatformDeferredProvider.php#L173).

Furthermore, because [`CallableProcessor` is included in the dependencies of `WriteProcessor`](https://github.com/api-platform/laravel/blob/v4.2.2/ApiPlatformProvider.php#L432), a circular dependency occurs: `CallableProcessor` -> `AppWriteProcessor` -> `WriteProcessor` -> `CallableProcessor`.

The only two ways to prevent this are to change the constructor argument type of `AppWriteProcessor` to `mixed` instead of `WriteProcessor`, or to remove the tagging of `AppWriteProcessor` with `ProcessorInterface`.

This PR introduces a new `SkipAutoconfigure` attribute, which allows us to exclude some application code from `autoconfigure`.

I've created a minimal environment to reproduce this issue in the following GitHub repository, and the commit logs explain the process to resolve it.

https://github.com/ttskch/api-platform-laravel-system-provider-decoration-example/commits/main/