### PR TITLE
fix(graphql): use stateOptionsTrait to get real entity name in FieldsBuilder

### DIFF
--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -29,6 +29,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\Util\Inflector;
 use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\Util\StateOptionsTrait;
 use GraphQL\Type\Definition\InputObjectType;
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\NonNull;
@@ -48,6 +49,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  */
 final class FieldsBuilder implements FieldsBuilderEnumInterface
 {
+    use StateOptionsTrait;
+
     private readonly ContextAwareTypeBuilderInterface $typeBuilder;
 
     public function __construct(private readonly PropertyNameCollectionFactoryInterface $propertyNameCollectionFactory, private readonly PropertyMetadataFactoryInterface $propertyMetadataFactory, private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory, private readonly ResourceClassResolverInterface $resourceClassResolver, private readonly TypesContainerInterface $typesContainer, ContextAwareTypeBuilderInterface $typeBuilder, private readonly TypeConverterInterface $typeConverter, private readonly ResolverFactoryInterface $resolverFactory, private readonly ContainerInterface $filterLocator, private readonly Pagination $pagination, private readonly ?NameConverterInterface $nameConverter, private readonly string $nestingSeparator, private readonly ?InflectorInterface $inflector = new Inflector())
@@ -561,7 +564,8 @@ final class FieldsBuilder implements FieldsBuilderEnumInterface
                 continue;
             }
 
-            foreach ($this->filterLocator->get($filterId)->getDescription($resourceClass) as $key => $description) {
+            $entityClass = $this->getStateOptionsClass($resourceOperation, $resourceOperation->getClass());
+            foreach ($this->filterLocator->get($filterId)->getDescription($entityClass) as $key => $description) {
                 $nullable = isset($description['required']) ? !$description['required'] : true;
                 $filterType = \in_array($description['type'], Type::$builtinTypes, true) ? new Type($description['type'], $nullable) : new Type('object', $nullable, $description['type']);
                 $graphqlFilterType = $this->convertType($filterType, false, $resourceOperation, $rootOperation, $resourceClass, $rootResource, $property, $depth);


### PR DESCRIPTION
The resource filters were lost when using a DTO as Resource and using stateOptions with 'entityClass' to specify which is the real doctrine class.

| Q             | A
| ------------- | ---
|Branch?       |  >=4.1.8
| License       | MIT


When using a DTO as a resource and the stateOptions attribute to make the filters work with the real entity.

```
    stateOptions: new Options(entityClass: Property::class),
```

After this change https://github.com/api-platform/core/pull/7109 , all the filters stopped being recognized. It seems that the code was refactored to use a trait, but the usage of this trait in the FieldsBuilder was missing.