### PR TITLE
fix(symfony): add missing symfony/asset dependency

### DIFF
--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -39,6 +39,7 @@
         "api-platform/state": "^4.2@beta",
         "api-platform/validator": "^4.1.11",
         "api-platform/openapi": "^4.1.11",
+        "symfony/asset": "^6.4 || ^7.0",
         "symfony/finder": "^6.4 || ^7.0",
         "symfony/property-info": "^6.4 || ^7.1",
         "symfony/property-access": "^6.4 || ^7.0",


### PR DESCRIPTION
The SwaggerUi and Graphiql twig templates depend on the asset() function being present.

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
