### PR TITLE
fix(metadata): fix mutator collection class names

### DIFF
--- a/src/Metadata/Mutator/OperationMutatorCollection.php
+++ b/src/Metadata/Mutator/OperationMutatorCollection.php
@@ -13,18 +13,21 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Mutator;
 
-use ApiPlatform\Metadata\ResourceMutatorInterface;
+use ApiPlatform\Metadata\OperationMutatorInterface;
 
 /**
  * @internal
  */
-final class ResourceResourceMutatorCollection implements ResourceMutatorCollectionInterface
+final class OperationMutatorCollection implements OperationMutatorCollectionInterface
 {
-    private array $mutators;
+    private array $mutators = [];
 
-    public function add(string $resourceClass, ResourceMutatorInterface $mutator): void
+    /**
+     * Adds a mutator to the container for a given operation name.
+     */
+    public function add(string $operationName, OperationMutatorInterface $mutator): void
     {
-        $this->mutators[$resourceClass][] = $mutator;
+        $this->mutators[$operationName][] = $mutator;
     }
 
     public function get(string $id): array

--- a/src/Metadata/Mutator/ResourceMutatorCollection.php
+++ b/src/Metadata/Mutator/ResourceMutatorCollection.php
@@ -13,21 +13,18 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Mutator;
 
-use ApiPlatform\Metadata\OperationMutatorInterface;
+use ApiPlatform\Metadata\ResourceMutatorInterface;
 
 /**
  * @internal
  */
-final class OperationResourceMutatorCollection implements OperationMutatorCollectionInterface
+final class ResourceMutatorCollection implements ResourceMutatorCollectionInterface
 {
     private array $mutators = [];
 
-    /**
-     * Adds a mutator to the container for a given operation name.
-     */
-    public function add(string $operationName, OperationMutatorInterface $mutator): void
+    public function add(string $resourceClass, ResourceMutatorInterface $mutator): void
     {
-        $this->mutators[$operationName][] = $mutator;
+        $this->mutators[$resourceClass][] = $mutator;
     }
 
     public function get(string $id): array

--- a/src/Metadata/Tests/Resource/Factory/MutatorResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/MutatorResourceMetadataCollectionFactoryTest.php
@@ -15,8 +15,8 @@ namespace ApiPlatform\Metadata\Tests\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\HttpOperation;
-use ApiPlatform\Metadata\Mutator\OperationResourceMutatorCollection;
-use ApiPlatform\Metadata\Mutator\ResourceResourceMutatorCollection;
+use ApiPlatform\Metadata\Mutator\OperationMutatorCollection;
+use ApiPlatform\Metadata\Mutator\ResourceMutatorCollection;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\OperationMutatorInterface;
 use ApiPlatform\Metadata\Operations;
@@ -35,10 +35,10 @@ final class MutatorResourceMetadataCollectionFactoryTest extends TestCase
         $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
         $resourceMetadataCollection[] = (new ApiResource())->withClass($resourceClass);
 
-        $resourceMutatorCollection = new ResourceResourceMutatorCollection();
+        $resourceMutatorCollection = new ResourceMutatorCollection();
         $resourceMutatorCollection->add($resourceClass, new DummyResourceMutator());
 
-        $customResourceMetadataCollectionFactory = new MutatorResourceMetadataCollectionFactory($resourceMutatorCollection, new OperationResourceMutatorCollection(), $decorated);
+        $customResourceMetadataCollectionFactory = new MutatorResourceMetadataCollectionFactory($resourceMutatorCollection, new OperationMutatorCollection(), $decorated);
 
         $decorated->expects($this->once())->method('create')->with($resourceClass)->willReturn(
             $resourceMetadataCollection,
@@ -62,10 +62,10 @@ final class MutatorResourceMetadataCollectionFactoryTest extends TestCase
         $resourceMetadataCollection = new ResourceMetadataCollection($resourceClass);
         $resourceMetadataCollection[] = (new ApiResource())->withClass($resourceClass)->withOperations($operations);
 
-        $operationMutatorCollection = new OperationResourceMutatorCollection();
+        $operationMutatorCollection = new OperationMutatorCollection();
         $operationMutatorCollection->add('_api_Dummy_get', new DummyOperationMutator());
 
-        $customResourceMetadataCollectionFactory = new MutatorResourceMetadataCollectionFactory(new ResourceResourceMutatorCollection(), $operationMutatorCollection, $decorated);
+        $customResourceMetadataCollectionFactory = new MutatorResourceMetadataCollectionFactory(new ResourceMutatorCollection(), $operationMutatorCollection, $decorated);
 
         $decorated->expects($this->once())->method('create')->with($resourceClass)->willReturn(
             $resourceMetadataCollection,

--- a/src/Symfony/Bundle/Resources/config/metadata/mutator.php
+++ b/src/Symfony/Bundle/Resources/config/metadata/mutator.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 return function (ContainerConfigurator $container) {
     $services = $container->services();
 
-    $services->set('api_platform.metadata.mutator_collection.resource', 'ApiPlatform\Metadata\Mutator\ResourceResourceMutatorCollection');
+    $services->set('api_platform.metadata.mutator_collection.resource', 'ApiPlatform\Metadata\Mutator\ResourceMutatorCollection');
 
-    $services->set('api_platform.metadata.mutator_collection.operation', 'ApiPlatform\Metadata\Mutator\OperationResourceMutatorCollection');
+    $services->set('api_platform.metadata.mutator_collection.operation', 'ApiPlatform\Metadata\Mutator\OperationMutatorCollection');
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main or 4.2?
| Tickets       |
| License       | MIT
| Doc PR        | 

It's marked as internal, so I'm not sure if we can rename these collections in a bug fix release, or in a minor one.