### PR TITLE
feat(symfony): allow symfony makers namespace configuration

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -964,6 +964,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             return;
         }
 
+        $namespaceprefix = $config['maker']['namespace_prefix'] ?? '';
+        if ('' !== $namespaceprefix) {
+            $namespaceprefix = trim($namespaceprefix, '\\').'\\';
+        }
+        $container->setParameter('api_platform.maker.namespace_prefix', $namespaceprefix);
+
         $loader->load('maker.php');
     }
 

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -657,6 +657,9 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('maker')
                     ->{class_exists(MakerBundle::class) ? 'canBeDisabled' : 'canBeEnabled'}()
+                    ->children()
+                        ->scalarNode('namespace_prefix')->defaultValue('')->info('Add a prefix to all maker generated classes. e.g set it to "Api" to set the maker namespace to "App\\Api\\" (if the maker.root_namespace config is App). e.g. App\\Api\\State\\MyStateProcessor')->end()
+                    ->end()
                 ->end()
             ->end();
     }

--- a/src/Symfony/Bundle/Resources/config/maker.php
+++ b/src/Symfony/Bundle/Resources/config/maker.php
@@ -17,14 +17,14 @@ return function (ContainerConfigurator $container) {
     $services = $container->services();
 
     $services->set('api_platform.maker.command.state_processor', 'ApiPlatform\Symfony\Maker\MakeStateProcessor')
-        ->args([service('api_platform.metadata.resource.name_collection_factory')])
+        ->args([param('api_platform.maker.namespace_prefix')])
         ->tag('maker.command');
 
     $services->set('api_platform.maker.command.state_provider', 'ApiPlatform\Symfony\Maker\MakeStateProvider')
-        ->args([service('api_platform.metadata.resource.name_collection_factory')])
+        ->args([param('api_platform.maker.namespace_prefix')])
         ->tag('maker.command');
 
     $services->set('api_platform.maker.command.filter', 'ApiPlatform\Symfony\Maker\MakeFilter')
-        ->args([service('api_platform.metadata.resource.name_collection_factory')])
+        ->args([param('api_platform.maker.namespace_prefix')])
         ->tag('maker.command');
 };

--- a/src/Symfony/Maker/MakeFilter.php
+++ b/src/Symfony/Maker/MakeFilter.php
@@ -23,9 +23,14 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 final class MakeFilter extends AbstractMaker
 {
+    public function __construct(private readonly string $namespacePrefix = '')
+    {
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -50,6 +55,7 @@ final class MakeFilter extends AbstractMaker
         $command
             ->addArgument('type', InputArgument::REQUIRED, \sprintf('Choose a type for your filter (<fg=yellow>%s</>)', self::getFilterTypesAsString()))
             ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your filter (e.g. <fg=yellow>AwesomeFilter</>)')
+            ->addOption('namespace-prefix', 'p', InputOption::VALUE_REQUIRED, 'Specify the namespace prefix to use for the filter class', $this->namespacePrefix.'Filter')
             ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeFilter.txt'));
     }
 
@@ -75,7 +81,7 @@ final class MakeFilter extends AbstractMaker
 
         $filterNameDetails = $generator->createClassNameDetails(
             name: $input->getArgument('name'),
-            namespacePrefix: 'Filter\\'
+            namespacePrefix: trim($input->getOption('namespace-prefix'), '\\').'\\'
         );
         $filterName = \sprintf('%sFilter', ucfirst($type->value));
 

--- a/src/Symfony/Maker/MakeStateProcessor.php
+++ b/src/Symfony/Maker/MakeStateProcessor.php
@@ -21,9 +21,14 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 final class MakeStateProcessor extends AbstractMaker
 {
+    public function __construct(private readonly string $namespacePrefix = '')
+    {
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -47,6 +52,7 @@ final class MakeStateProcessor extends AbstractMaker
     {
         $command
             ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your state processor (e.g. <fg=yellow>AwesomeStateProcessor</>)')
+            ->addOption('namespace-prefix', 'p', InputOption::VALUE_REQUIRED, 'Specify the namespace prefix to use for the state processor class', $this->namespacePrefix.'State')
             ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeStateProcessor.txt'));
     }
 
@@ -64,7 +70,7 @@ final class MakeStateProcessor extends AbstractMaker
     {
         $stateProcessorClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'State\\'
+            trim($input->getOption('namespace-prefix'), '\\').'\\'
         );
 
         $generator->generateClass(

--- a/src/Symfony/Maker/MakeStateProvider.php
+++ b/src/Symfony/Maker/MakeStateProvider.php
@@ -21,9 +21,14 @@ use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 
 final class MakeStateProvider extends AbstractMaker
 {
+    public function __construct(private readonly string $namespacePrefix = '')
+    {
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -47,6 +52,7 @@ final class MakeStateProvider extends AbstractMaker
     {
         $command
             ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your state provider (e.g. <fg=yellow>AwesomeStateProvider</>)')
+            ->addOption('namespace-prefix', 'p', InputOption::VALUE_REQUIRED, 'Specify the namespace prefix to use for the state provider class', $this->namespacePrefix.'State')
             ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeStateProvider.txt'));
     }
 
@@ -64,7 +70,7 @@ final class MakeStateProvider extends AbstractMaker
     {
         $stateProviderClassNameDetails = $generator->createClassNameDetails(
             $input->getArgument('name'),
-            'State\\'
+            trim($input->getOption('namespace-prefix'), '\\').'\\'
         );
 
         $generator->generateClass(

--- a/tests/Fixtures/Symfony/Maker/NamespacedCustomOrmFilter.fixture
+++ b/tests/Fixtures/Symfony/Maker/NamespacedCustomOrmFilter.fixture
@@ -1,0 +1,29 @@
+namespace App\Api\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+
+class CustomOrmFilter implements FilterInterface
+{
+    use BackwardCompatibleFilterDescriptionTrait; // Here for backward compatibility, keep it until 5.0.
+
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        // Retrieve the parameter and it's value
+        // $parameter = $context['parameter'];
+        // $value = $parameter->getValue();
+
+        // Retrieve the property
+        // $property = $parameter->getProperty();
+
+        // Retrieve alias and parameter name
+        // $alias = $queryBuilder->getRootAliases()[0];
+        // $parameterName = $queryNameGenerator->generateParameterName($property);
+
+        // TODO: make your awesome query using the $queryBuilder
+        // $queryBuilder->
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/NamespacedCustomStateProcessor.fixture
+++ b/tests/Fixtures/Symfony/Maker/NamespacedCustomStateProcessor.fixture
@@ -1,0 +1,12 @@
+namespace App\Api\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+class CustomStateProcessor implements ProcessorInterface
+{
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): void
+    {
+        // Handle the state
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/NamespacedCustomStateProvider.fixture
+++ b/tests/Fixtures/Symfony/Maker/NamespacedCustomStateProvider.fixture
@@ -1,0 +1,12 @@
+namespace App\Api\State;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class CustomStateProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        // Retrieve the state from somewhere
+    }
+}

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -229,6 +229,7 @@ class ConfigurationTest extends TestCase
             ],
             'maker' => [
                 'enabled' => true,
+                'namespace_prefix' => '',
             ],
             'use_symfony_listeners' => false,
             'handle_symfony_errors' => false,

--- a/tests/Symfony/Maker/MakeFilterTest.php
+++ b/tests/Symfony/Maker/MakeFilterTest.php
@@ -61,6 +61,25 @@ class MakeFilterTest extends KernelTestCase
         $this->assertStringContainsString(' Next: Open your filter class and start customizing it.', $display);
     }
 
+    public function testMakeFilterWithCustomNamespace(): void
+    {
+        $inputs = ['name' => 'CustomOrmFilter', 'type' => 'orm', '--namespace-prefix' => 'Api\\Filter\\'];
+        $newFilterFile = self::tempFile('src/Api/Filter/CustomOrmFilter.php');
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:filter'));
+        $tester->execute($inputs);
+
+        $this->assertFileExists($newFilterFile);
+
+        // Unify line endings
+        $expected = preg_replace('~\R~u', "\r\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/NamespacedCustomOrmFilter.fixture'));
+        $result = preg_replace('~\R~u', "\r\n", file_get_contents($newFilterFile));
+        $this->assertStringContainsString($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
     public static function filterProvider(): \Generator
     {
         yield 'Generate ORM filter' => ['orm', 'CustomOrmFilter', true];

--- a/tests/Symfony/Maker/MakeStateProcessorTest.php
+++ b/tests/Symfony/Maker/MakeStateProcessorTest.php
@@ -56,6 +56,25 @@ class MakeStateProcessorTest extends KernelTestCase
         $this->assertStringContainsString('Next: Open your new state processor class and start customizing it.', $display);
     }
 
+    public function testMakeStateProcessorWithCustomNamespace(): void
+    {
+        $inputs = ['name' => 'CustomStateProcessor', '--namespace-prefix' => 'Api\\State\\'];
+        $newProviderFile = self::tempFile('src/Api/State/CustomStateProcessor.php');
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:state-processor'));
+        $tester->execute($inputs);
+
+        $this->assertFileExists($newProviderFile);
+
+        // Unify line endings
+        $expected = preg_replace('~\R~u', "\r\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/NamespacedCustomStateProcessor.fixture'));
+        $result = preg_replace('~\R~u', "\r\n", file_get_contents($newProviderFile));
+        $this->assertStringContainsString($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
     public static function stateProcessorProvider(): \Generator
     {
         yield 'Generate state processor' => [

--- a/tests/Symfony/Maker/MakeStateProviderTest.php
+++ b/tests/Symfony/Maker/MakeStateProviderTest.php
@@ -56,6 +56,25 @@ class MakeStateProviderTest extends KernelTestCase
         $this->assertStringContainsString('Next: Open your new state provider class and start customizing it.', $display);
     }
 
+    public function testMakeStateProviderWithCustomNamespace(): void
+    {
+        $inputs = ['name' => 'CustomStateProvider', '--namespace-prefix' => 'Api\\State\\'];
+        $newProviderFile = self::tempFile('src/Api/State/CustomStateProvider.php');
+
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:state-provider'));
+        $tester->execute($inputs);
+
+        $this->assertFileExists($newProviderFile);
+
+        // Unify line endings
+        $expected = preg_replace('~\R~u', "\r\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/NamespacedCustomStateProvider.fixture'));
+        $result = preg_replace('~\R~u', "\r\n", file_get_contents($newProviderFile));
+        $this->assertStringContainsString($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
     public static function stateProviderDataProvider(): \Generator
     {
         yield 'Generate state provider' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/2224

You can now configure the base namespace prefix for all makers but also add a command line option in case you want to customize the namespace even further

This allows developers to organize all api code into a single namespace/directory

Example
```yaml
api_platform:
    maker:
        namespace_prefix: Api
```
will cause all generated classes to be created in `src/Api`

Cli Example
```bash
bin/console make:state-provider --namespace-prefix Api\\StateProvider
```
will cause the generated provider to be created in `src/Api/StateProvider`
the same applies to the processor and filter maker
