### PR TITLE
feat(symfony): allow disabling PHPStan PhpDocParser

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -337,7 +337,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->getDefinition('api_platform.metadata.resource_extractor.xml')->replaceArgument(0, $xmlResources);
         $container->getDefinition('api_platform.metadata.property_extractor.xml')->replaceArgument(0, $xmlResources);
 
-        if (class_exists(PhpDocParser::class)) {
+        if ($config['enable_phpdoc_parser'] && class_exists(PhpDocParser::class)) {
             $loader->load('metadata/php_doc.xml');
         }
 

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -111,6 +111,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
                 ->booleanNode('enable_profiler')->defaultTrue()->info('Enable the data collector and the WebProfilerBundle integration.')->end()
+                ->booleanNode('enable_phpdoc_parser')->defaultTrue()->info('Enable resource metadata collector using PHPStan PhpDocParser.')->end()
                 ->booleanNode('enable_link_security')->defaultFalse()->info('Enable security for Links (sub resources)')->end()
                 ->arrayNode('collection')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 4.2.3
| Tickets       |
| License       | MIT
| Doc PR        | (will updated as needed, waiting for feedback first)


PHP docblocks may be used for internal documentation only, so exposing
the details may leak internal information.

Another issue is that PHPStan may be available only on debug
environment, thus creating different behaviour when deploying an
application in production.

By default is enabled to avoid breaking changes.

Note: this is a bug from out point of view (since we found "leaking" internal information), but may be seen as a new feature since it's a new option. I'll wait for your feedback for changing description, docs & co