### PR TITLE
fix(hydra): json streamer iri template does not need metadata

### DIFF
--- a/src/JsonLd/JsonStreamer/WritePropertyMetadataLoader.php
+++ b/src/JsonLd/JsonStreamer/WritePropertyMetadataLoader.php
@@ -38,12 +38,6 @@ final class WritePropertyMetadataLoader implements PropertyMetadataLoaderInterfa
         $properties = $this->loader->load($className, $options, $context);
 
         if (IriTemplate::class === $className) {
-            $properties['template'] = new PropertyMetadata(
-                'template',
-                Type::string(),
-                ['api_platform.hydra.json_streamer.write.value_transformer.template'],
-            );
-
             return $properties;
         }
 

--- a/tests/Fixtures/TestBundle/Entity/JsonStreamResource.php
+++ b/tests/Fixtures/TestBundle/Entity/JsonStreamResource.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity()]
@@ -21,7 +22,10 @@ use Doctrine\ORM\Mapping as ORM;
 #[ApiResource(
     jsonStream: true,
     paginationEnabled: false,
-    normalizationContext: ['hydra_prefix' => false]
+    normalizationContext: ['hydra_prefix' => false],
+    parameters: [
+        'q' => new QueryParameter(property: 'FreeTextQuery'),
+    ]
 )]
 class JsonStreamResource
 {

--- a/tests/Functional/JsonStreamerTest.php
+++ b/tests/Functional/JsonStreamerTest.php
@@ -160,6 +160,7 @@ class JsonStreamerTest extends ApiTestCase
         $this->assertEquals('JsonStreamResource', $res['member'][0]['@type']);
         $this->assertArrayHasKey('totalItems', $res);
         $this->assertIsInt($res['totalItems']);
+        $this->assertArrayHasKey('search', $res);
     }
 
     public function testJsonStreamerJson(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4,2
| Tickets       | na
| License       | MIT
| Doc PR        | na

We were missing a test on this code path.
