### PR TITLE
 fix(jsonld): read identifier with itemUriTemplate

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/ItemUriTemplateWithCollection/Recipe.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ItemUriTemplateWithCollection/Recipe.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ItemUriTemplateWithCollection;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Recipe as EntityRecipe;
+
+#[Get(
+    uriTemplate: '/item_uri_template_recipes/{id}{._format}',
+    shortName: 'ItemRecipe',
+    uriVariables: ['id'],
+    provider: [self::class, 'provide'],
+    openapi: false
+)]
+#[Get(
+    uriTemplate: '/item_uri_template_recipes_state_option/{id}{._format}',
+    shortName: 'ItemRecipe',
+    uriVariables: ['id'],
+    openapi: false,
+    stateOptions: new Options(entityClass: EntityRecipe::class)
+)]
+class Recipe
+{
+    public ?string $id;
+    public ?string $name = null;
+
+    public ?string $description = null;
+
+    public ?string $author = null;
+
+    public ?array $recipeIngredient = [];
+
+    public ?string $recipeInstructions = null;
+
+    public ?string $prepTime = null;
+
+    public ?string $cookTime = null;
+
+    public ?string $totalTime = null;
+
+    public ?string $recipeCuisine = null;
+
+    public ?string $suitableForDiet = null;
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $recipe = new self();
+        $recipe->id = '1';
+        $recipe->name = 'Dummy Recipe';
+        $recipe->description = 'A simple recipe for testing purposes.';
+        $recipe->prepTime = 'PT15M';
+        $recipe->cookTime = 'PT30M';
+        $recipe->totalTime = 'PT45M';
+        $recipe->recipeIngredient = ['Ingredient 1', 'Ingredient 2'];
+        $recipe->recipeInstructions = 'Do these things.';
+
+        return $recipe;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/ItemUriTemplateWithCollection/RecipeCollection.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ItemUriTemplateWithCollection/RecipeCollection.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ItemUriTemplateWithCollection;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Recipe as EntityRecipe;
+
+#[GetCollection(
+    uriTemplate: '/item_uri_template_recipes{._format}',
+    provider: [self::class, 'provide'],
+    openapi: false,
+    shortName: 'CollectionRecipe',
+    itemUriTemplate: '/item_uri_template_recipes/{id}{._format}',
+    normalizationContext: ['hydra_prefix' => false],
+)]
+#[GetCollection(
+    uriTemplate: '/item_uri_template_recipes_state_option{._format}',
+    openapi: false,
+    shortName: 'CollectionRecipe',
+    itemUriTemplate: '/item_uri_template_recipes_state_option/{id}{._format}',
+    stateOptions: new Options(entityClass: EntityRecipe::class),
+    normalizationContext: ['hydra_prefix' => false],
+)]
+class RecipeCollection
+{
+    public ?string $id;
+    public ?string $name = null;
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        $recipe = new self();
+        $recipe->id = '1';
+        $recipe->name = 'Dummy Recipe';
+
+        $recipe2 = new self();
+        $recipe2->id = '2';
+        $recipe2->name = 'Dummy Recipe 2';
+
+        return [$recipe, $recipe2];
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Recipe.php
+++ b/tests/Fixtures/TestBundle/Entity/Recipe.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Recipe
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $name = null;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    public ?string $description = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $author = null;
+
+    #[ORM\Column(type: 'json', nullable: true)]
+    public ?array $recipeIngredient = [];
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    public ?string $recipeInstructions = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $prepTime = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $cookTime = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $totalTime = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $recipeCategory = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $recipeCuisine = null;
+
+    #[ORM\Column(type: 'string', nullable: true)]
+    public ?string $suitableForDiet = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| License       | MIT

When splitting resources into two separate classes (one for Get, one for GetCollection) there was an issue when reading the identifiers. 