### PR TITLE
Fix IRI generation with link parameter resources

### DIFF
--- a/src/Metadata/UriVariableTransformer/ApiResourceUriVariableTransformer.php
+++ b/src/Metadata/UriVariableTransformer/ApiResourceUriVariableTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\UriVariableTransformer;
+
+use ApiPlatform\Metadata\IdentifiersExtractorInterface;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
+use ApiPlatform\Metadata\UriVariableTransformerInterface;
+
+final class ApiResourceUriVariableTransformer implements UriVariableTransformerInterface
+{
+    public function __construct(private readonly IdentifiersExtractorInterface $identifiersExtractor, private readonly ResourceClassResolverInterface $resourceClassResolver)
+    {
+    }
+
+    public function transform(mixed $value, array $types, array $context = []): mixed
+    {
+        return current($this->identifiersExtractor->getIdentifiersFromItem($value));
+    }
+
+    public function supportsTransformation(mixed $value, array $types, array $context = []): bool
+    {
+        return \is_object($value) && $this->resourceClassResolver->isResourceClass($value::class);
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/api.php
+++ b/src/Symfony/Bundle/Resources/config/api.php
@@ -169,6 +169,13 @@ return function (ContainerConfigurator $container) {
     $services->set('api_platform.uri_variables.transformer.date_time', 'ApiPlatform\Metadata\UriVariableTransformer\DateTimeUriVariableTransformer')
         ->tag('api_platform.uri_variables.transformer', ['priority' => -100]);
 
+    $services->set('api_platform.uri_variables.transformer.api_resource', 'ApiPlatform\Metadata\UriVariableTransformer\ApiResourceUriVariableTransformer')
+        ->args([
+            service('api_platform.api.identifiers_extractor'),
+            service('api_platform.resource_class_resolver'),
+        ])
+        ->tag('api_platform.uri_variables.transformer', ['priority' => -100]);
+
     $services->alias('api_platform.iri_converter', 'api_platform.symfony.iri_converter');
 
     $services->set('api_platform.symfony.iri_converter', 'ApiPlatform\Symfony\Routing\IriConverter')

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7469TestResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7469TestResource.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ParameterProvider\ReadLinkParameterProvider;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7469Dummy;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/issue_7469_test_resources/{id}',
+            uriVariables: [
+                'id' => new Link(
+                    provider: ReadLinkParameterProvider::class,
+                    fromClass: Issue7469Dummy::class
+                ),
+            ],
+            provider: [self::class, 'provide']
+        ),
+    ]
+)]
+final class Issue7469TestResource
+{
+    public int $id;
+    public string $dummyName;
+
+    /**
+     * @param HttpOperation $operation
+     */
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = [])
+    {
+        /** @var Issue7469Dummy $dummy */
+        $dummy = $operation->getUriVariables()['id']->getValue();
+
+        $resource = new self();
+        $resource->id = $dummy->id;
+        $resource->dummyName = $dummy->name;
+
+        return $resource;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/Issue7469Dummy.php
+++ b/tests/Fixtures/TestBundle/Document/Issue7469Dummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+#[ApiResource(
+    uriTemplate: '/issue_7469_dummies/{id}',
+)]
+class Issue7469Dummy
+{
+    #[ODM\Id]
+    #[ApiProperty(identifier: true)]
+    public ?string $id = null;
+
+    #[ODM\Field(type: 'string')]
+    public string $name;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7469Dummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7469Dummy.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ApiResource(
+    uriTemplate: '/issue_7469_dummies/{id}',
+)]
+class Issue7469Dummy
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ApiProperty(identifier: true)]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7469
| License       | MIT

Fixes a bug where link resources using the new ReadLinkParameterProvider fail to generate an IRI when using Hydra.
