### PR TITLE
fix(symfony): inject default configuration in resources loaded from php files

### DIFF
--- a/src/Metadata/Resource/Factory/PhpFileResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/PhpFileResourceMetadataCollectionFactory.php
@@ -17,6 +17,9 @@ use ApiPlatform\Metadata\Extractor\ResourceExtractorInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use ApiPlatform\Metadata\Util\CamelCaseToSnakeCaseNameConverter;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 final class PhpFileResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {
@@ -25,7 +28,12 @@ final class PhpFileResourceMetadataCollectionFactory implements ResourceMetadata
     public function __construct(
         private readonly ResourceExtractorInterface $metadataExtractor,
         private readonly ?ResourceMetadataCollectionFactoryInterface $decorated = null,
+        ?LoggerInterface $logger = null,
+        array $defaults = [],
     ) {
+        $this->logger = $logger ?? new NullLogger();
+        $this->defaults = $defaults;
+        $this->camelCaseToSnakeCaseNameConverter = new CamelCaseToSnakeCaseNameConverter();
     }
 
     /**

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.php
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.php
@@ -43,7 +43,8 @@ return function (ContainerConfigurator $container) {
         ->args([
             service('api_platform.metadata.resource_extractor.php_file'),
             service('api_platform.metadata.resource.metadata_collection_factory.php_file.inner'),
-            service('service_container')->nullOnInvalid(),
+            service('logger')->nullOnInvalid(),
+            '%api_platform.defaults%',
         ]);
 
     $services->set('api_platform.metadata.resource.metadata_collection_factory.mutator', 'ApiPlatform\Metadata\Resource\Factory\MutatorResourceMetadataCollectionFactory')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 4.2
| License       | MIT

The `PhpFileResourceMetadataCollectionFactory` service added with version 4.2, allowing to load resources from php files, do not use the configuration defaults as the `AttributesResourceMetadataCollectionFactory` service do.

This PR allows setting the default configuration to resources loaded in the php file format.