### PR TITLE
fix: consistent :property placeholder behavior

### DIFF
--- a/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
+++ b/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Common\Filter;
 
 /**
+ * TODO: 5.x uncomment method.
+ *
  * @author Antoine Bluchet <soyuka@gmail.com>
+ *
+ * @method ?array getProperties()
  *
  * @experimental
  */
@@ -24,4 +28,9 @@ interface PropertyAwareFilterInterface
      * @param string[] $properties
      */
     public function setProperties(array $properties): void;
+
+    // /**
+    //  * @return string[]
+    //  */
+    // public function getProperties(): ?array;
 }

--- a/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
+++ b/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
@@ -23,16 +23,6 @@ trait PropertyPlaceholderOpenApiParameterTrait
      */
     public function getOpenApiParameters(Parameter $parameter): ?array
     {
-        if (str_contains($parameter->getKey(), ':property')) {
-            $parameters = [];
-            $key = str_replace('[:property]', '', $parameter->getKey());
-            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
-                $parameters[] = new OpenApiParameter(name: \sprintf('%s[%s]', $key, $property), in: 'query');
-            }
-
-            return $parameters;
-        }
-
-        return null;
+        return [new OpenApiParameter(name: $parameter->getKey(), in: 'query')];
     }
 }

--- a/src/Doctrine/Common/ParameterExtensionTrait.php
+++ b/src/Doctrine/Common/ParameterExtensionTrait.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common;
+
+use ApiPlatform\Doctrine\Common\Filter\LoggerAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+use ApiPlatform\Metadata\Parameter;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+trait ParameterExtensionTrait
+{
+    use ParameterValueExtractorTrait;
+
+    protected ContainerInterface $filterLocator;
+    protected ?ManagerRegistry $managerRegistry = null;
+    protected ?LoggerInterface $logger = null;
+
+    /**
+     * @param object    $filter    the filter instance to configure
+     * @param Parameter $parameter the operation parameter associated with the filter
+     */
+    private function configureFilter(object $filter, Parameter $parameter): void
+    {
+        if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+            $filter->setManagerRegistry($this->managerRegistry);
+        }
+
+        if ($this->logger && $filter instanceof LoggerAwareInterface && !$filter->hasLogger()) {
+            $filter->setLogger($this->logger);
+        }
+
+        if ($filter instanceof PropertyAwareFilterInterface) {
+            $properties = [];
+            // Check if the filter has getProperties method (e.g., if it's an AbstractFilter)
+            if (method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check @see interface
+                $properties = $filter->getProperties() ?? [];
+            }
+
+            $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
+            foreach ($parameter->getProperties() ?? [$propertyKey] as $property) {
+                if (!isset($properties[$property])) {
+                    $properties[$property] = $parameter->getFilterContext();
+                }
+            }
+
+            $filter->setProperties($properties);
+        }
+    }
+}

--- a/src/Doctrine/Common/ParameterValueExtractorTrait.php
+++ b/src/Doctrine/Common/ParameterValueExtractorTrait.php
@@ -23,10 +23,7 @@ trait ParameterValueExtractorTrait
     private function extractParameterValue(Parameter $parameter, mixed $value): array
     {
         $key = $parameter->getProperty() ?? $parameter->getKey();
-        if (!str_contains($key, ':property')) {
-            return [$key => $value];
-        }
 
-        return [str_replace('[:property]', '', $key) => $value];
+        return [$key => $value];
     }
 }

--- a/src/Doctrine/Odm/composer.json
+++ b/src/Doctrine/Odm/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^4.2",
+        "api-platform/doctrine-common": "^4.2.9",
         "api-platform/metadata": "^4.2",
         "api-platform/state": "^4.2.4",
         "doctrine/mongodb-odm": "^2.10",

--- a/src/Doctrine/Orm/composer.json
+++ b/src/Doctrine/Orm/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^4.2.0-alpha.3@alpha",
+        "api-platform/doctrine-common": "^4.2.9",
         "api-platform/metadata": "^4.2",
         "api-platform/state": "^4.2.4",
         "doctrine/orm": "^2.17 || ^3.0"

--- a/src/GraphQl/foo.diff
+++ b/src/GraphQl/foo.diff
@@ -1,0 +1,289 @@
+diff --git a/src/Doctrine/Common/Filter/ParameterAwareFilterInterface.php b/src/Doctrine/Common/Filter/ParameterAwareFilterInterface.php
+new file mode 100644
+index 00000000000..d1974a32c55
+--- /dev/null
++++ b/src/Doctrine/Common/Filter/ParameterAwareFilterInterface.php
+@@ -0,0 +1,31 @@
++<?php
++
++/*
++ * This file is part of the API Platform project.
++ *
++ * (c) Kévin Dunglas <dunglas@gmail.com>
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++declare(strict_types=1);
++
++namespace ApiPlatform\Doctrine\Common\Filter;
++
++use ApiPlatform\Metadata\Operation;
++
++/**
++ * Interface for filters that can be applied by a ParameterExtension.
++ *
++ * @author Antoine Bluchet <soyuka@gmail.com>
++ */
++interface ParameterAwareFilterInterface
++{
++    /**
++     * Applies the filter to the query.
++     *
++     * @param array<string, mixed> $context
++     */
++    public function apply(object $queryBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void;
++}
+diff --git a/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php b/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
+index aa0857cef20..1b041f480fb 100644
+--- a/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
++++ b/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
+@@ -16,6 +16,8 @@
+ /**
+  * @author Antoine Bluchet <soyuka@gmail.com>
+  *
++ * @method ?array getProperties()
++ *
+  * @experimental
+  */
+ interface PropertyAwareFilterInterface
+@@ -24,4 +26,9 @@ interface PropertyAwareFilterInterface
+      * @param string[] $properties
+      */
+     public function setProperties(array $properties): void;
++
++    // /**
++    //  * @return string[]
++    //  */
++    // public function getProperties(): ?array;
+ }
+diff --git a/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php b/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
+index f2f09e5758c..3acab18a05f 100644
+--- a/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
++++ b/src/Doctrine/Common/Filter/PropertyPlaceholderOpenApiParameterTrait.php
+@@ -23,16 +23,6 @@ trait PropertyPlaceholderOpenApiParameterTrait
+      */
+     public function getOpenApiParameters(Parameter $parameter): ?array
+     {
+-        if (str_contains($parameter->getKey(), ':property')) {
+-            $parameters = [];
+-            $key = str_replace('[:property]', '', $parameter->getKey());
+-            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
+-                $parameters[] = new OpenApiParameter(name: \sprintf('%s[%s]', $key, $property), in: 'query');
+-            }
+-
+-            return $parameters;
+-        }
+-
+-        return null;
++        return [new OpenApiParameter(name: $parameter->getKey(), in: 'query')];
+     }
+ }
+diff --git a/src/Doctrine/Common/ParameterExtensionTrait.php b/src/Doctrine/Common/ParameterExtensionTrait.php
+new file mode 100644
+index 00000000000..4d865a8730f
+--- /dev/null
++++ b/src/Doctrine/Common/ParameterExtensionTrait.php
+@@ -0,0 +1,63 @@
++<?php
++
++/*
++ * This file is part of the API Platform project.
++ *
++ * (c) Kévin Dunglas <dunglas@gmail.com>
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++declare(strict_types=1);
++
++namespace ApiPlatform\Doctrine\Common;
++
++use ApiPlatform\Doctrine\Common\Filter\LoggerAwareInterface;
++use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
++use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
++use ApiPlatform\Metadata\Parameter;
++use Doctrine\Persistence\ManagerRegistry;
++use Psr\Container\ContainerInterface;
++use Psr\Log\LoggerInterface;
++
++trait ParameterExtensionTrait
++{
++    use ParameterValueExtractorTrait;
++
++    protected ContainerInterface $filterLocator;
++    protected ?ManagerRegistry $managerRegistry = null;
++    protected ?LoggerInterface $logger = null;
++
++    /**
++     * @param object    $filter    the filter instance to configure
++     * @param Parameter $parameter the operation parameter associated with the filter
++     */
++    private function configureFilter(object $filter, Parameter $parameter): void
++    {
++        if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
++            $filter->setManagerRegistry($this->managerRegistry);
++        }
++
++        if ($this->logger && $filter instanceof LoggerAwareInterface && !$filter->hasLogger()) {
++            $filter->setLogger($this->logger);
++        }
++
++        if ($filter instanceof PropertyAwareFilterInterface) {
++            $properties = [];
++            // Check if the filter has getProperties method (e.g., if it's an AbstractFilter)
++            if (method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check @see interface
++                $properties = $filter->getProperties() ?? [];
++            }
++
++            $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
++            foreach ($parameter->getProperties() ?? [$propertyKey] as $property) {
++                if (!isset($properties[$property])) {
++                    $properties[$property] = $parameter->getFilterContext();
++                }
++            }
++
++            $filter->setProperties($properties);
++        }
++    }
++}
+diff --git a/src/Doctrine/Common/ParameterValueExtractorTrait.php b/src/Doctrine/Common/ParameterValueExtractorTrait.php
+index b50dede8f76..62c18f6483c 100644
+--- a/src/Doctrine/Common/ParameterValueExtractorTrait.php
++++ b/src/Doctrine/Common/ParameterValueExtractorTrait.php
+@@ -23,10 +23,7 @@ trait ParameterValueExtractorTrait
+     private function extractParameterValue(Parameter $parameter, mixed $value): array
+     {
+         $key = $parameter->getProperty() ?? $parameter->getKey();
+-        if (!str_contains($key, ':property')) {
+-            return [$key => $value];
+-        }
+ 
+-        return [str_replace('[:property]', '', $key) => $value];
++        return [$key => $value];
+     }
+ }
+diff --git a/src/Doctrine/Odm/Extension/ParameterExtension.php b/src/Doctrine/Odm/Extension/ParameterExtension.php
+index d68e6e9ed3b..d841fb9240e 100644
+--- a/src/Doctrine/Odm/Extension/ParameterExtension.php
++++ b/src/Doctrine/Odm/Extension/ParameterExtension.php
+@@ -13,11 +13,9 @@
+ 
+ namespace ApiPlatform\Doctrine\Odm\Extension;
+ 
+-use ApiPlatform\Doctrine\Common\Filter\LoggerAwareInterface;
+-use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+-use ApiPlatform\Doctrine\Common\ParameterValueExtractorTrait;
+-use ApiPlatform\Doctrine\Odm\Filter\AbstractFilter;
+-use ApiPlatform\Doctrine\Odm\Filter\FilterInterface;
++use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
++use ApiPlatform\Doctrine\Common\ParameterExtensionTrait;
++use ApiPlatform\Doctrine\Odm\Filter\FilterInterface; // Explicitly import PropertyAwareFilterInterface
+ use ApiPlatform\Metadata\Operation;
+ use ApiPlatform\State\ParameterNotFound;
+ use Doctrine\Bundle\MongoDBBundle\ManagerRegistry;
+@@ -32,13 +30,16 @@
+  */
+ final class ParameterExtension implements AggregationCollectionExtensionInterface, AggregationItemExtensionInterface
+ {
+-    use ParameterValueExtractorTrait;
++    use ParameterExtensionTrait;
+ 
+     public function __construct(
+-        private readonly ContainerInterface $filterLocator,
+-        private readonly ?ManagerRegistry $managerRegistry = null,
+-        private readonly ?LoggerInterface $logger = null,
++        ContainerInterface $filterLocator,
++        ?ManagerRegistry $managerRegistry = null,
++        ?LoggerInterface $logger = null,
+     ) {
++        $this->filterLocator = $filterLocator;
++        $this->managerRegistry = $managerRegistry;
++        $this->logger = $logger;
+     }
+ 
+     /**
+@@ -66,28 +67,7 @@ private function applyFilter(Builder $aggregationBuilder, ?string $resourceClass
+                 continue;
+             }
+ 
+-            if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+-                $filter->setManagerRegistry($this->managerRegistry);
+-            }
+-
+-            if ($this->logger && $filter instanceof LoggerAwareInterface && !$filter->hasLogger()) {
+-                $filter->setLogger($this->logger);
+-            }
+-
+-            if ($filter instanceof AbstractFilter && !$filter->getProperties()) {
+-                $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
+-
+-                if (str_contains($propertyKey, ':property')) {
+-                    $extraProperties = $parameter->getExtraProperties()['_properties'] ?? [];
+-                    foreach (array_keys($extraProperties) as $property) {
+-                        $properties[$property] = $parameter->getFilterContext();
+-                    }
+-                } else {
+-                    $properties = [$propertyKey => $parameter->getFilterContext()];
+-                }
+-
+-                $filter->setProperties($properties ?? []);
+-            }
++            $this->configureFilter($filter, $parameter);
+ 
+             $context['filters'] = $values;
+             $context['parameter'] = $parameter;
+diff --git a/src/Doctrine/Orm/Extension/ParameterExtension.php b/src/Doctrine/Orm/Extension/ParameterExtension.php
+index b7c8d8938b9..0264567a602 100644
+--- a/src/Doctrine/Orm/Extension/ParameterExtension.php
++++ b/src/Doctrine/Orm/Extension/ParameterExtension.php
+@@ -13,11 +13,8 @@
+ 
+ namespace ApiPlatform\Doctrine\Orm\Extension;
+ 
+-use ApiPlatform\Doctrine\Common\Filter\LoggerAwareInterface;
+-use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+ use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+-use ApiPlatform\Doctrine\Common\ParameterValueExtractorTrait;
+-use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
++use ApiPlatform\Doctrine\Common\ParameterExtensionTrait; // Explicitly import PropertyAwareFilterInterface
+ use ApiPlatform\Doctrine\Orm\Filter\FilterInterface;
+ use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+ use ApiPlatform\Metadata\Operation;
+@@ -34,13 +31,16 @@
+  */
+ final class ParameterExtension implements QueryCollectionExtensionInterface, QueryItemExtensionInterface
+ {
+-    use ParameterValueExtractorTrait;
++    use ParameterExtensionTrait;
+ 
+     public function __construct(
+-        private readonly ContainerInterface $filterLocator,
+-        private readonly ?ManagerRegistry $managerRegistry = null,
+-        private readonly ?LoggerInterface $logger = null,
++        ContainerInterface $filterLocator,
++        ?ManagerRegistry $managerRegistry = null,
++        ?LoggerInterface $logger = null,
+     ) {
++        $this->filterLocator = $filterLocator;
++        $this->managerRegistry = $managerRegistry;
++        $this->logger = $logger;
+     }
+ 
+     /**
+@@ -68,30 +68,7 @@ private function applyFilter(QueryBuilder $queryBuilder, QueryNameGeneratorInter
+                 continue;
+             }
+ 
+-            if ($this->managerRegistry && $filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+-                $filter->setManagerRegistry($this->managerRegistry);
+-            }
+-
+-            if ($this->logger && $filter instanceof LoggerAwareInterface && !$filter->hasLogger()) {
+-                $filter->setLogger($this->logger);
+-            }
+-
+-            if ($filter instanceof PropertyAwareFilterInterface) {
+-                $properties = [];

--- a/src/JsonApi/Filter/SparseFieldsetParameterProvider.php
+++ b/src/JsonApi/Filter/SparseFieldsetParameterProvider.php
@@ -26,7 +26,7 @@ final readonly class SparseFieldsetParameterProvider implements ParameterProvide
             return null;
         }
 
-        $allowedProperties = $parameter->getExtraProperties()['_properties'] ?? [];
+        $allowedProperties = $parameter->getProperties() ?? [];
         $value = $parameter->getValue();
         $normalizationContext = $operation->getNormalizationContext();
 
@@ -45,7 +45,7 @@ final readonly class SparseFieldsetParameterProvider implements ParameterProvide
             }
 
             foreach (explode(',', $fields) as $f) {
-                if (\array_key_exists($f, $allowedProperties)) {
+                if (\in_array($f, $allowedProperties, true)) {
                     $p[] = $f;
                 }
             }

--- a/src/Laravel/Eloquent/Extension/FilterQueryExtension.php
+++ b/src/Laravel/Eloquent/Extension/FilterQueryExtension.php
@@ -60,7 +60,7 @@ final readonly class FilterQueryExtension implements QueryExtensionInterface
 
             $filter = $filterId instanceof FilterInterface ? $filterId : ($this->filterLocator->has($filterId) ? $this->filterLocator->get($filterId) : null);
             if ($filter instanceof FilterInterface) {
-                $builder = $filter->apply($builder, $values, $parameter->withKey($parameter->getExtraProperties()['_query_property'] ?? $parameter->getKey()), $context + ($parameter->getFilterContext() ?? []));
+                $builder = $filter->apply($builder, $values, $parameter, $context + ($parameter->getFilterContext() ?? []));
             }
         }
 

--- a/src/Laravel/Eloquent/Filter/JsonApi/SortFilterParameterProvider.php
+++ b/src/Laravel/Eloquent/Filter/JsonApi/SortFilterParameterProvider.php
@@ -26,7 +26,7 @@ final readonly class SortFilterParameterProvider implements ParameterProviderInt
         }
 
         $parameters = $operation->getParameters();
-        $properties = $parameter->getExtraProperties()['_properties'] ?? [];
+        $properties = $parameter->getProperties() ?? [];
         $value = $parameter->getValue();
 
         // most eloquent filters work with only a single value
@@ -47,14 +47,12 @@ final readonly class SortFilterParameterProvider implements ParameterProviderInt
                 $v = substr($v, 1);
             }
 
-            if (\array_key_exists($v, $properties)) {
-                $orderBy[$properties[$v]] = $dir;
+            if (\in_array($v, $properties, true)) {
+                $orderBy[$v] = $dir;
             }
         }
 
-        $parameters->add($parameter->getKey(), $parameter->withExtraProperties(
-            ['_api_values' => $orderBy] + $parameter->getExtraProperties()
-        ));
+        $parameters->add($parameter->getKey(), $parameter->setValue($orderBy));
 
         return $operation->withParameters($parameters);
     }

--- a/src/Laravel/Eloquent/Filter/OrderFilter.php
+++ b/src/Laravel/Eloquent/Filter/OrderFilter.php
@@ -31,7 +31,7 @@ final class OrderFilter implements FilterInterface, JsonSchemaFilterInterface, O
     public function apply(Builder $builder, mixed $values, Parameter $parameter, array $context = []): Builder
     {
         if (!\is_string($values)) {
-            $properties = $parameter->getExtraProperties()['_properties'] ?? [];
+            $properties = $parameter->getProperties() ?? [];
 
             foreach ($values as $key => $value) {
                 if (!isset($properties[$key])) {
@@ -55,20 +55,10 @@ final class OrderFilter implements FilterInterface, JsonSchemaFilterInterface, O
     }
 
     /**
-     * @return OpenApiParameter[]|null
+     * @return OpenApiParameter[]
      */
-    public function getOpenApiParameters(Parameter $parameter): ?array
+    public function getOpenApiParameters(Parameter $parameter): array
     {
-        if (str_contains($parameter->getKey(), ':property')) {
-            $parameters = [];
-            $key = str_replace('[:property]', '', $parameter->getKey());
-            foreach (array_keys($parameter->getExtraProperties()['_properties'] ?? []) as $property) {
-                $parameters[] = new OpenApiParameter(name: \sprintf('%s[%s]', $key, $property), in: 'query');
-            }
-
-            return $parameters;
-        }
-
-        return null;
+        return [new OpenApiParameter(name: $parameter->getKey(), in: 'query')];
     }
 }

--- a/src/Laravel/Tests/Eloquent/Filter/OrderFilterTest.php
+++ b/src/Laravel/Tests/Eloquent/Filter/OrderFilterTest.php
@@ -34,10 +34,10 @@ class OrderFilterTest extends TestCase
         DB::enableQueryLog();
         $response = $this->get('/api/active_books?sort[isActive]=asc', ['Accept' => ['application/ld+json']]);
         $response->assertStatus(200);
-        $this->assertEquals(\DB::getQueryLog()[1]['query'], 'select * from "active_books" order by "isActive" asc limit 30 offset 0');
+        $this->assertEquals(\DB::getQueryLog()[1]['query'], 'select * from "active_books" order by "is_active" asc limit 30 offset 0');
         DB::flushQueryLog();
         $response = $this->get('/api/active_books?sort[isActive]=desc', ['Accept' => ['application/ld+json']]);
         $response->assertStatus(200);
-        $this->assertEquals(DB::getQueryLog()[1]['query'], 'select * from "active_books" order by "isActive" desc limit 30 offset 0');
+        $this->assertEquals(DB::getQueryLog()[1]['query'], 'select * from "active_books" order by "is_active" desc limit 30 offset 0');
     }
 }

--- a/src/Laravel/workbench/app/Models/Slot.php
+++ b/src/Laravel/workbench/app/Models/Slot.php
@@ -36,6 +36,7 @@ use Workbench\App\Http\Requests\StoreSlotRequest;
         new Patch(),
         new Delete(),
     ],
+    graphQlOperations: []
 )]
 class Slot extends Model
 {

--- a/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
@@ -35,7 +35,10 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
         $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'hydra', 'everywhere']));
         $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
-        $propertyMetadata->method('create')->willReturnOnConsecutiveCalls(new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true));
+        $propertyMetadata->method('create')->willReturnOnConsecutiveCalls(
+            new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true),
+            new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true)
+        );
         $filterLocator = $this->createStub(ContainerInterface::class);
         $filterLocator->method('has')->willReturn(true);
         $filterLocator->method('get')->willReturn(new class implements FilterInterface {
@@ -79,7 +82,10 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
         $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'hydra', 'everywhere']));
         $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
-        $propertyMetadata->method('create')->willReturnOnConsecutiveCalls(new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true));
+        $propertyMetadata->method('create')->willReturnOnConsecutiveCalls(
+            new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true),
+            new ApiProperty(identifier: true), new ApiProperty(readable: true), new ApiProperty(readable: true)
+        );
         $filterLocator = $this->createStub(ContainerInterface::class);
         $filterLocator->method('has')->willReturn(false);
         $parameter = new ParameterResourceMetadataCollectionFactory(

--- a/src/State/Util/ParameterParserTrait.php
+++ b/src/State/Util/ParameterParserTrait.php
@@ -66,8 +66,25 @@ trait ParameterParserTrait
 
         $value = $values[$key] ?? new ParameterNotFound();
         foreach ($accessors ?? [] as $accessor) {
+            if ($value instanceof ParameterNotFound) {
+                break;
+            }
+
             if (\is_array($value) && isset($value[$accessor])) {
                 $value = $value[$accessor];
+            } elseif (\is_array($value) && array_is_list($value)) {
+                $l = [];
+                foreach ($value as $i) {
+                    if (\is_array($i) && isset($i[$accessor])) {
+                        $l[] = $i[$accessor];
+                    }
+                }
+
+                if (!$l) {
+                    $value = new ParameterNotFound();
+                } else {
+                    $value = $l;
+                }
             } else {
                 $value = new ParameterNotFound();
             }

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -104,21 +104,13 @@ final class ParameterValidatorProvider implements ProviderInterface
     // There's a `property` inside Parameter but it's used for hydra:search only as here we want the parameter name instead
     private function getProperty(Parameter $parameter, ConstraintViolationInterface $violation): string
     {
-        $key = $parameter->getKey();
-
-        if (str_contains($key, '[:property]')) {
-            return str_replace('[:property]', $violation->getPropertyPath(), $key);
-        }
-
-        if (str_contains($key, ':property')) {
-            return str_replace(':property', $violation->getPropertyPath(), $key);
-        }
-
         $openApi = $parameter->getOpenApi();
+
         if (false === $openApi) {
             $openApi = null;
         }
 
+        $key = $parameter->getKey();
         if (\is_array($openApi)) {
             foreach ($openApi as $oa) {
                 if ('deepObject' === $oa->getStyle() && ($oa->getName() === $key || str_starts_with($oa->getName(), $key.'['))) {

--- a/src/Validator/Util/ParameterValidationConstraints.php
+++ b/src/Validator/Util/ParameterValidationConstraints.php
@@ -21,7 +21,6 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\Choice;
-use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Constraints\GreaterThan;
@@ -99,15 +98,6 @@ trait ParameterValidationConstraints
 
         if (isset($schema['enum'])) {
             $assertions[] = new Choice(choices: $schema['enum']);
-        }
-
-        if ($properties = $parameter->getExtraProperties()['_properties'] ?? []) {
-            $fields = [];
-            foreach ($properties as $propertyName) {
-                $fields[$propertyName] = $assertions;
-            }
-
-            return [new Collection(fields: $fields, allowMissingFields: true)];
         }
 
         $isCollectionType = fn ($t) => $t instanceof CollectionType;

--- a/tests/Fixtures/TestBundle/ApiResource/ValidateParameterBeforeProvider.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ValidateParameterBeforeProvider.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\OpenApi\Model\Parameter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
@@ -25,7 +26,13 @@ use Symfony\Component\Validator\Constraints\NotBlank;
     uriTemplate: 'query_parameter_validate_before_read',
     parameters: [
         'search' => new QueryParameter(constraints: [new NotBlank()]),
-        'sort[:property]' => new QueryParameter(constraints: [new NotBlank(), new Collection(['id' => new Choice(choices: ['asc', 'desc'])], allowMissingFields: true)]),
+        'sort' => new QueryParameter(
+            openApi: new Parameter(name: 'sort', in: 'query', style: 'deepObject'),
+            constraints: [
+                new NotBlank(),
+                new Collection(['id' => new Choice(choices: ['asc', 'desc'])], allowMissingFields: true),
+            ]
+        ),
     ],
     provider: [self::class, 'provide']
 )]

--- a/tests/Fixtures/TestBundle/Document/SearchFilterParameter.php
+++ b/tests/Fixtures/TestBundle/Document/SearchFilterParameter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\Doctrine\Odm\Filter\PartialSearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
@@ -33,6 +34,10 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
         'searchExact[:property]' => new QueryParameter(filter: 'app_odm_search_filter_with_exact'),
         'searchOnTextAndDate[:property]' => new QueryParameter(filter: 'app_odm_filter_date_and_search'),
         'q' => new QueryParameter(property: 'hydra:freetextQuery'),
+        'search[:property]' => new QueryParameter(
+            filter: new PartialSearchFilter(),
+            properties: ['foo', 'createdAt']
+        ),
     ]
 )]
 #[QueryCollection(
@@ -46,8 +51,8 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
         'q' => new QueryParameter(property: 'hydra:freetextQuery'),
     ]
 )]
-#[ApiFilter(ODMSearchFilterValueTransformer::class, alias: 'app_odm_search_filter_partial', properties: ['foo' => 'partial'], arguments: ['key' => 'searchPartial'])]
-#[ApiFilter(ODMSearchFilterValueTransformer::class, alias: 'app_odm_search_filter_with_exact', properties: ['foo' => 'exact'], arguments: ['key' => 'searchExact'])]
+#[ApiFilter(ODMSearchFilterValueTransformer::class, alias: 'app_odm_search_filter_partial', properties: ['foo' => 'partial'])]
+#[ApiFilter(ODMSearchFilterValueTransformer::class, alias: 'app_odm_search_filter_with_exact', properties: ['foo' => 'exact'])]
 #[ApiFilter(ODMSearchTextAndDateFilter::class, alias: 'app_odm_filter_date_and_search', properties: ['foo', 'createdAt'], arguments: ['dateFilterProperties' => ['createdAt' => 'exclude_null'], 'searchFilterProperties' => ['foo' => 'exact']])]
 #[QueryParameter(key: ':property', filter: QueryParameterOdmFilter::class)]
 #[ODM\Document]

--- a/tests/Fixtures/TestBundle/Entity/SearchFilterParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/SearchFilterParameter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Doctrine\Orm\Filter\PartialSearchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
@@ -35,6 +36,10 @@ use Doctrine\ORM\Mapping as ORM;
         'searchExact[:property]' => new QueryParameter(filter: 'app_search_filter_with_exact'),
         'searchOnTextAndDate[:property]' => new QueryParameter(filter: 'app_filter_date_and_search'),
         'q' => new QueryParameter(property: 'hydra:freetextQuery'),
+        'search[:property]' => new QueryParameter(
+            filter: new PartialSearchFilter(),
+            properties: ['foo', 'createdAt']
+        ),
     ]
 )]
 #[QueryCollection(
@@ -48,8 +53,8 @@ use Doctrine\ORM\Mapping as ORM;
         'q' => new QueryParameter(property: 'hydra:freetextQuery'),
     ]
 )]
-#[ApiFilter(SearchFilterValueTransformer::class, alias: 'app_search_filter_partial', properties: ['foo' => 'partial'], arguments: ['key' => 'searchPartial'])]
-#[ApiFilter(SearchFilterValueTransformer::class, alias: 'app_search_filter_with_exact', properties: ['foo' => 'exact'], arguments: ['key' => 'searchExact'])]
+#[ApiFilter(SearchFilterValueTransformer::class, alias: 'app_search_filter_partial', properties: ['foo' => 'partial'])]
+#[ApiFilter(SearchFilterValueTransformer::class, alias: 'app_search_filter_with_exact', properties: ['foo' => 'exact'])]
 #[ApiFilter(SearchTextAndDateFilter::class, alias: 'app_filter_date_and_search', properties: ['foo', 'createdAt'], arguments: ['dateFilterProperties' => ['createdAt' => 'exclude_null'], 'searchFilterProperties' => ['foo' => 'exact']])]
 #[QueryParameter(key: ':property', filter: QueryParameterFilter::class)]
 #[ORM\Entity]

--- a/tests/Fixtures/TestBundle/Filter/ODMSearchFilterValueTransformer.php
+++ b/tests/Fixtures/TestBundle/Filter/ODMSearchFilterValueTransformer.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class ODMSearchFilterValueTransformer implements FilterInterface
 {
-    public function __construct(#[Autowire('@api_platform.doctrine_mongodb.odm.search_filter.instance')] private readonly FilterInterface $searchFilter, private ?array $properties = null, private readonly ?string $key = null)
+    public function __construct(#[Autowire('@api_platform.doctrine_mongodb.odm.search_filter.instance')] private readonly FilterInterface $searchFilter, private ?array $properties = null)
     {
     }
 
@@ -41,7 +41,6 @@ final class ODMSearchFilterValueTransformer implements FilterInterface
             $this->searchFilter->setProperties($this->properties);
         }
 
-        $filterContext = ['filters' => $context['filters'][$this->key]] + $context;
-        $this->searchFilter->apply($aggregationBuilder, $resourceClass, $operation, $filterContext);
+        $this->searchFilter->apply($aggregationBuilder, $resourceClass, $operation, $context);
     }
 }

--- a/tests/Fixtures/TestBundle/Filter/ODMSearchTextAndDateFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/ODMSearchTextAndDateFilter.php
@@ -39,8 +39,7 @@ final class ODMSearchTextAndDateFilter implements FilterInterface
 
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
-        $filterContext = ['filters' => $context['filters']['searchOnTextAndDate']] + $context;
-        $this->searchFilter->apply($aggregationBuilder, $resourceClass, $operation, $filterContext);
-        $this->dateFilter->apply($aggregationBuilder, $resourceClass, $operation, $filterContext);
+        $this->searchFilter->apply($aggregationBuilder, $resourceClass, $operation, $context);
+        $this->dateFilter->apply($aggregationBuilder, $resourceClass, $operation, $context);
     }
 }

--- a/tests/Fixtures/TestBundle/Filter/SearchFilterValueTransformer.php
+++ b/tests/Fixtures/TestBundle/Filter/SearchFilterValueTransformer.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class SearchFilterValueTransformer implements FilterInterface
 {
-    public function __construct(#[Autowire('@api_platform.doctrine.orm.search_filter.instance')] private readonly FilterInterface $searchFilter, private ?array $properties = null, private readonly ?string $key = null)
+    public function __construct(#[Autowire('@api_platform.doctrine.orm.search_filter.instance')] private readonly FilterInterface $searchFilter, private ?array $properties = null)
     {
     }
 
@@ -42,6 +42,6 @@ final class SearchFilterValueTransformer implements FilterInterface
             $this->searchFilter->setProperties($this->properties);
         }
 
-        $this->searchFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $context['filters'][$this->key]] + $context);
+        $this->searchFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
     }
 }

--- a/tests/Fixtures/TestBundle/Filter/SearchTextAndDateFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/SearchTextAndDateFilter.php
@@ -48,7 +48,7 @@ final class SearchTextAndDateFilter implements FilterInterface
             $this->dateFilter->setProperties($this->dateFilterProperties);
         }
 
-        $this->searchFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $context['filters']['searchOnTextAndDate']] + $context);
-        $this->dateFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, ['filters' => $context['filters']['searchOnTextAndDate']] + $context);
+        $this->searchFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+        $this->dateFilter->apply($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
     }
 }

--- a/tests/Fixtures/TestBundle/Filter/SortComputedFieldFilter.php
+++ b/tests/Fixtures/TestBundle/Filter/SortComputedFieldFilter.php
@@ -34,7 +34,7 @@ class SortComputedFieldFilter implements FilterInterface, JsonSchemaFilterInterf
             return;
         }
 
-        $queryBuilder->addOrderBy('totalQuantity', $context['parameter']->getValue()['totalQuantity'] ?? 'ASC');
+        $queryBuilder->addOrderBy('totalQuantity', $context['parameter']->getValue() ?? 'ASC');
     }
 
     /**

--- a/tests/Functional/Doctrine/ComputedFieldTest.php
+++ b/tests/Functional/Doctrine/ComputedFieldTest.php
@@ -45,7 +45,7 @@ final class ComputedFieldTest extends ApiTestCase
         $this->recreateSchema($this->getResources());
         $this->loadFixtures();
 
-        $res = $this->createClient()->request('GET', '/carts?sort[totalQuantity]=wrong');
+        $this->createClient()->request('GET', '/carts?sort[totalQuantity]=wrong');
         $this->assertResponseStatusCodeSame(422);
     }
 
@@ -60,7 +60,7 @@ final class ComputedFieldTest extends ApiTestCase
 
         $ascReq = $this->createClient()->request('GET', '/carts?sort[totalQuantity]=asc');
 
-        $asc = $ascReq->toArray();
+        $asc = $ascReq->toArray(false);
 
         $this->assertArrayHasKey('view', $asc);
         $this->assertArrayHasKey('first', $asc['view']);


### PR DESCRIPTION
Completes 

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7478
| License       | MIT
| Doc PR        | tbd

This patch introduces a significant internal refactoring to how parameters are processed and applied to filters across API Platform's core, Doctrine, GraphQL, and Laravel integrations. The primary goal is to centralize and solidify parameter handling, particularly for filters that can operate on multiple properties using the `:property` placeholder.

Filters will now receive a more precise context. During the `apply` method, `$context['filters']` will contain only the values directly relevant to the specific filter being processed. This simplifies filter implementation, and developers are encouraged to use `$parameter->getValue()` for direct access to their parameter's associated value.
The `:property` placeholder in parameter keys is now  integrates with the `getProperties()` method of `PropertyAwareFilterInterface` implementations. This resolves previous inconsistencies and solidifies the behavior where `:property` placeholders are dynamically expanded and filled with the content of `getProperties`, ensuring a more predictable and consistent approach for filters that target multiple properties.

This is a **risky change** as it fundamentally alters how certain parameters, especially those using dynamic properties, are processed and how filters receive their values. The previous parameter handling, particularly concerning the interaction between `getProperties` on parameters and dynamic property expansion, was inconsistent and did not work properly in all scenarios. This patch solidifies that behavior.
