### PR TITLE
fix(symfony): disable Swagger UI and keep openapi.json

### DIFF
--- a/src/Symfony/Bundle/Resources/config/symfony/events.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.php
@@ -179,6 +179,7 @@ return function (ContainerConfigurator $container) {
             service('api_platform.state_processor.documentation'),
             service('api_platform.negotiator')->nullOnInvalid(),
             '%api_platform.docs_formats%',
+            '%api_platform.enable_swagger_ui%',
         ]);
 
     $services->set('api_platform.action.placeholder', 'ApiPlatform\Symfony\Action\PlaceholderAction')

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -108,6 +108,8 @@ class ApiPlatformExtensionTest extends TestCase
         'asset_package' => null,
         'enable_entrypoint' => true,
         'enable_docs' => true,
+        'enable_swagger' => true,
+        'enable_swagger_ui' => true,
         'use_symfony_listeners' => false,
     ]];
 

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -36,6 +36,8 @@ api_platform:
     description: |
         This is a test API.
         Made with love
+    enable_swagger: true
+    enable_swagger_ui: true
     formats:
         jsonld:                        ['application/ld+json']
         jsonhal:                       ['application/hal+json']

--- a/tests/Fixtures/app/config/config_swagger_ui_disabled.yml
+++ b/tests/Fixtures/app/config/config_swagger_ui_disabled.yml
@@ -1,6 +1,0 @@
-imports:
-    - { resource: config_test.yml }
-
-api_platform:
-    enable_swagger: true
-    enable_swagger_ui: false

--- a/tests/Fixtures/app/config/config_swagger_ui_enabled.yml
+++ b/tests/Fixtures/app/config/config_swagger_ui_enabled.yml
@@ -1,6 +1,0 @@
-imports:
-    - { resource: config_test.yml }
-
-api_platform:
-    enable_swagger: true
-    enable_swagger_ui: true

--- a/tests/Fixtures/app/config/routing_swagger_ui_disabled.yml
+++ b/tests/Fixtures/app/config/routing_swagger_ui_disabled.yml
@@ -1,2 +1,0 @@
-_main:
-    resource: routing_test.yml

--- a/tests/Fixtures/app/config/routing_swagger_ui_enabled.yml
+++ b/tests/Fixtures/app/config/routing_swagger_ui_enabled.yml
@@ -1,2 +1,0 @@
-_main:
-    resource: routing_test.yml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7544 
| License       | MIT
| Doc PR        | na <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

## Descripton

This PR fixes an issue where `enable_swagger_ui: false` did not actually disable the Swagger UI HTML interface.

Currently, when configuring `enable_swagger: true` and `enable_swagger_ui: false`, accessing the documentation route (`/api/docs`), still displays the Swagger UI HTML interface, ignoring the configuration (`enable_swagger_ui: false`) to disable it.

The goal is to fully disable the Swagger UI HTML interface while keeping the JSON documentation (`/api/docs.jsonopenapi`) accessible.

## Changes

- Modified `ApiPlatformExtension` to load Swagger UI services (definitions, listeners, providers) only if `enable_swagger_ui` is `true`.
- Updated `src/Symfony/Action/DocumentationAction.php` to throw a `NotFoundHttpException` when Swagger UI is disabled.

`src/Laravel/Controller/DocumentationController::getOpenApiDocumentation()` : 
```php
if ('html' === $format && $this->swaggerUiEnabled) {
    $operation = $operation->withProcessor('api_platform.swagger_ui.processor')->withWrite(true);
}
```

`src/Symfony/Action/DocumentationAction::getOpenApiDocumentation()` : 

```php
if ('html' === $format) {
    $operation = $operation->withProcessor('api_platform.swagger_ui.processor')->withWrite(true);
}
```
- Updated `src/Symfony/Action/DocumentationAction.php` to check `enable_swagger_ui`, aligning the logic with `src/Laravel/Controller/DocumentationController.php` : 
```diff
- if ('html' === $format) {
+ if ('html' === $format && $this->swaggerUiEnabled) {
    $operation = $operation->withProcessor('api_platform.swagger_ui.processor')->withWrite(true);
}
```

- Added unit & functional tests (using a custom Kernel to handle dynamic configuration) to cover these scenarios.

## Before

```yml
api_platform:
    enable_swagger: true
    enable_swagger_ui: false
```

- `/api/docs` → still HTML Swagger UI accessible (not expected)
- `/api/docs.jsonopenapi` → accessible (expected)

## After

```yml
api_platform:
    enable_swagger: true
    enable_swagger_ui: false
```

- `/api/docs` → returns 404
- `/api/docs.jsonopenapi` → still accessible (expected)

| Route                 | Format | Before     | After          |
|-----------------------|--------|------------|----------------|
| /api/docs             | HTML   | 200 OK (UI Visible) | 404 Not Found  |
| /api/docs.jsonopenapi | JSON   | 200 OK     | 200 OK         |
