### PR TITLE
Render BCMath\Number (PHP 8.4+) as string instead of object

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -319,6 +319,10 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             return ['type' => 'string', 'format' => 'binary'];
         }
 
+        if (is_a($className, \BcMath\Number::class, true)) {
+            return ['type' => 'string', 'format' => 'string'];
+        }
+
         $isResourceClass = $this->isResourceClass($className);
         if (!$isResourceClass && is_a($className, \BackedEnum::class, true)) {
             $enumCases = array_map(static fn (\BackedEnum $enum): string|int => $enum->value, $className::cases());
@@ -506,6 +510,13 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             return [
                 'type' => 'string',
                 'format' => 'binary',
+            ];
+        }
+
+        if (is_a($className, \BcMath\Number::class, true)) {
+            return [
+                'type' => 'string',
+                'format' => 'string',
             ];
         }
 

--- a/tests/Fixtures/TestBundle/ApiResource/MathNumber.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MathNumber.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+
+if (class_exists(\BcMath\Number::class)) {
+    #[Get(
+        provider: [self::class, 'provide'],
+    )]
+    #[Post]
+    class MathNumber
+    {
+        #[ApiProperty(identifier: true)]
+        public int $id;
+
+        #[ApiProperty(property: 'value')]
+        public ?\BcMath\Number $value;
+
+        public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+        {
+            $mathNumber = new self();
+            $mathNumber->id = $uriVariables['id'];
+            $mathNumber->value = new \BcMath\Number('300.55');
+
+            return $mathNumber;
+        }
+    }
+}

--- a/tests/Functional/MathNumberTest.php
+++ b/tests/Functional/MathNumberTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MathNumber;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Symfony\Component\Serializer\Normalizer\NumberNormalizer;
+
+#[RequiresPhp('^8.4')]
+#[RequiresPhpExtension('bcmath')]
+final class MathNumberTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [MathNumber::class];
+    }
+
+    protected function setUp(): void
+    {
+        if (!class_exists(NumberNormalizer::class)) {
+            $this->markTestSkipped('Requires BcMath/Number and symfony/serialiser >=7.3');
+        }
+
+        parent::setUp();
+    }
+
+    public function testGetMathNumber(): void
+    {
+        self::createClient()->request('GET', '/math_numbers/1', ['headers' => ['Accept' => 'application/ld+json']]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/contexts/MathNumber',
+            '@id' => '/math_numbers/1',
+            '@type' => 'MathNumber',
+            'id' => 1,
+            'value' => '300.55',
+        ]);
+    }
+
+    public function testPostMathNumber(): void
+    {
+        self::createClient()->request('POST', '/math_numbers', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => [
+                'id' => 2,
+                'value' => '120.23',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonEquals([
+            '@context' => '/contexts/MathNumber',
+            '@id' => '/math_numbers/2',
+            '@type' => 'MathNumber',
+            'id' => 2,
+            'value' => '120.23',
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #6934
| License       | MIT

Render BCMath\Number (PHP 8.4+) as string instead of object

**Before**

```
{
    "@context": "/contexts/MathNumber",
    "@id": "/math_numbers/1",
    "@type": "MathNumber",
    "id": 1,
    "value": {
        "@id": "/.well-known/genid/d884d3a7bec8d1a52024",
        "@type": "Number",
        "scale": 2,
        "value": "300.55"
    }
}
```

**After** 

```
{
    "@context": "/contexts/MathNumber",
    "@id": "/math_numbers/1",
    "@type": "MathNumber",
    "id": 1,
    "value": "300.55"
}
```

The `symfony/serializer:7.3` added the `NumberNormalizer`, the `symfony/framework-bundle:7.3` registered it.

In CI and the job [PHPUnit (PHP 8.4)](https://github.com/api-platform/core/actions/runs/19438754788/job/55616484116#logs),  `api-platform` install  `symfony/framework-bundle:7.2`
```
  - Locking symfony/framework-bundle (7.2.x-dev 42ac8bb)
  - Locking symfony/http-client (v7.3.6)
  - Locking symfony/http-client-contracts (v3.6.0)
```

if I try locally
```
composer require --dev "symfony/framework-bundle:7.3" -W --dry-run 
```

```
....
- symfony/object-mapper is locked to version 7.4.x-dev and an update of this package was not requested.
- symfony/framework-bundle v7.3.0 conflicts with symfony/object-mapper >=7.4.
```
