### PR TITLE
fix(state): use existing symfony object-mapper

### DIFF
--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -23,6 +23,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MutatorPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ObjectMapperPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
@@ -59,5 +60,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new AuthenticatorManagerPass());
         $container->addCompilerPass(new SerializerMappingLoaderPass());
         $container->addCompilerPass(new MutatorPass());
+        $container->addCompilerPass(new ObjectMapperPass());
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/ObjectMapperPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/ObjectMapperPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ObjectMapper\ObjectMapper;
+
+/**
+ * Creates the Object Mapper.
+ *
+ * @author Florent Blaison <florent.blaison@gmail.com>
+ */
+final class ObjectMapperPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!class_exists(ObjectMapper::class)) {
+            return;
+        }
+
+        if ($container->has('object_mapper.metadata_factory')) {
+            $container->setAlias('api_platform.object_mapper.metadata_factory', 'object_mapper.metadata_factory');
+        } else {
+            $container->setDefinition('api_platform.object_mapper.metadata_factory', new Definition('Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory'));
+        }
+
+        if ($container->has('object_mapper')) {
+            $container->setAlias('api_platform.object_mapper', 'object_mapper');
+        } else {
+            $container->setDefinition('api_platform.object_mapper', new Definition('Symfony\Component\ObjectMapper\ObjectMapper', [
+                new Reference('api_platform.object_mapper.metadata_factory'),
+                new Reference('property_accessor', ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                new ServiceLocatorArgument(new TaggedIteratorArgument('object_mapper.transform_callable', null, null, true)),
+                new ServiceLocatorArgument(new TaggedIteratorArgument('object_mapper.condition_callable', null, null, true)),
+            ]));
+        }
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/state/object_mapper.php
+++ b/src/Symfony/Bundle/Resources/config/state/object_mapper.php
@@ -16,16 +16,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 return function (ContainerConfigurator $container) {
     $services = $container->services();
 
-    $services->set('api_platform.object_mapper.metadata_factory', 'Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory');
-
-    $services->set('api_platform.object_mapper', 'Symfony\Component\ObjectMapper\ObjectMapper')
-        ->args([
-            service('api_platform.object_mapper.metadata_factory'),
-            service('property_accessor')->nullOnInvalid(),
-            tagged_locator('object_mapper.transform_callable'),
-            tagged_locator('object_mapper.condition_callable'),
-        ]);
-
     $services->set('api_platform.object_mapper.relation', 'ApiPlatform\State\ObjectMapper\ObjectMapper')
         ->decorate('api_platform.object_mapper', null, -255)
         ->args([service('api_platform.object_mapper.relation.inner')]);

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -24,6 +24,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlResolverPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MutatorPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\ObjectMapperPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
@@ -57,6 +58,7 @@ class ApiPlatformBundleTest extends TestCase
         $containerProphecy->addCompilerPass(Argument::type(AuthenticatorManagerPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(SerializerMappingLoaderPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
         $containerProphecy->addCompilerPass(Argument::type(MutatorPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
+        $containerProphecy->addCompilerPass(Argument::type(ObjectMapperPass::class))->willReturn($containerProphecy->reveal())->shouldBeCalled();
 
         $bundle = new ApiPlatformBundle();
         $bundle->build($containerProphecy->reveal());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Use Symfony `object_mapper.metadata_factory` and `object_mapper` if exist, if not create new one

@soyuka as we already discussed
