### PR TITLE
fix: add missing php version to property-info

### DIFF
--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -41,7 +41,7 @@
         "api-platform/openapi": "^4.2.3",
         "symfony/asset": "^6.4 || ^7.0 || ^8.0",
         "symfony/finder": "^6.4 || ^7.0 || ^8.0",
-        "symfony/property-info": "^6.4 || ^7.1",
+        "symfony/property-info": "^6.4 || ^7.0 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
         "symfony/security-core": "^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

A PHP version (8.x) was missing for the “property-info” package.

```  Problem 1
    - Root composer.json requires api-platform/symfony ^4.2.7 -> satisfiable by api-platform/symfony[v4.2.7].
    - api-platform/symfony v4.2.7 requires symfony/property-info ^6.4 || ^7.1 -> found symfony/property-info[v6.4.0, ..., v6.4.24, v7.1.0, ..., v7.4.0] but it conflicts with your root composer.json require (8.0.*).```