### PR TITLE
fix(Elasticsearch): use output config when provided

### DIFF
--- a/src/Elasticsearch/State/CollectionProvider.php
+++ b/src/Elasticsearch/State/CollectionProvider.php
@@ -87,9 +87,7 @@ final class CollectionProvider implements ProviderInterface
             $documents = $documents->asArray();
         }
 
-        if (\is_string($operation->getOutput()) && class_exists($operation->getOutput())) {
-            $resourceClass = $operation->getOutput();
-        }
+        $resourceClass = $operation->getOutput()['class'] ?? $resourceClass;
 
         return new Paginator(
             $this->denormalizer,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | 
| License       | MIT


Not sure if it's new feature or bug fix, but provider not handling `output` looks like a bug to me