### PR TITLE
fix(swagger) use app.request.query.get() directly

### DIFF
--- a/src/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -81,7 +81,7 @@
             {% endfor %}
             <br>
             Other API docs:
-            {% set active_ui = app.request.get('ui', 'swagger_ui') %}
+            {% set active_ui = app.request.query.get('ui', 'swagger_ui') %}
             {% if swaggerUiEnabled and active_ui != 'swagger_ui' %}<a href="{{ path('api_doc') }}">Swagger UI</a>{% endif %}
             {% if reDocEnabled and active_ui != 're_doc' %}<a href="{{ path('api_doc', {'ui': 're_doc'}) }}">ReDoc</a>{% endif %}
             {% if not graphQlEnabled or graphiQlEnabled %}<a {% if graphiQlEnabled %}href="{{ path('api_graphql_graphiql') }}"{% endif %} class="graphiql-link">GraphiQL</a>{% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7577 
| License       | MIT
| Doc PR        | N/A

With Symfony 8.0 request object does not have method get() anymore.
Now it should be replaced with direct access: request.query.get() or request.request.get().

