### PR TITLE
fix(symfony): skip argument resolver when context is not api platform

### DIFF
--- a/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
+++ b/src/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolver.php
@@ -71,7 +71,11 @@ final class PayloadArgumentResolver implements CompatibleValueResolverInterface
     private function getExpectedInputClass(Request $request): ?string
     {
         $operation = $this->initializeOperation($request);
-        if (Request::METHOD_DELETE === $request->getMethod() || $request->isMethodSafe() || !($operation?->canDeserialize() ?? true)) {
+        if (!$operation) {
+            return null;
+        }
+
+        if (Request::METHOD_DELETE === $request->getMethod() || $request->isMethodSafe() || !($operation->canDeserialize() ?? true)) {
             return null;
         }
 

--- a/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
+++ b/tests/Symfony/Bundle/ArgumentResolver/PayloadArgumentResolverTest.php
@@ -166,6 +166,10 @@ class PayloadArgumentResolverTest extends KernelTestCase
 
         yield 'request without attributes' => [self::createRequest('PUT', [])];
 
+        yield 'request without API Platform operation attributes' => [self::createRequest('POST', [
+            'data' => new ResourceImplementation(),
+        ])];
+
         yield 'request on operation with deserialization disabled' => [self::createRequest('PUT', [
             '_api_resource_class' => ResourceImplementation::class,
             '_api_operation_name' => 'update_no_deserialize',


### PR DESCRIPTION
fixes #7574
