### PR TITLE
fix(swagger): use current route for footer links

### DIFF
--- a/src/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
+++ b/src/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig
@@ -82,8 +82,8 @@
             <br>
             Other API docs:
             {% set active_ui = app.request.query.get('ui', 'swagger_ui') %}
-            {% if swaggerUiEnabled and active_ui != 'swagger_ui' %}<a href="{{ path('api_doc') }}">Swagger UI</a>{% endif %}
-            {% if reDocEnabled and active_ui != 're_doc' %}<a href="{{ path('api_doc', {'ui': 're_doc'}) }}">ReDoc</a>{% endif %}
+            {% if swaggerUiEnabled and active_ui != 'swagger_ui' %}<a href="{{ path(originalRoute, originalRouteParams) }}">Swagger UI</a>{% endif %}
+            {% if reDocEnabled and active_ui != 're_doc' %}<a href="{{ path(originalRoute, originalRouteParams|merge({'ui': 're_doc'})) }}">ReDoc</a>{% endif %}
             {% if not graphQlEnabled or graphiQlEnabled %}<a {% if graphiQlEnabled %}href="{{ path('api_graphql_graphiql') }}"{% endif %} class="graphiql-link">GraphiQL</a>{% endif %}
         </div>
     </div>


### PR DESCRIPTION
> This PR replaces #7556, targeting the `4.2` branch as requested. @soyuka 

| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Fixes #2654
| License       | MIT
| Doc PR        | N/A

## Description

When using a custom route name for Swagger UI documentation, the footer links (Swagger UI/ReDoc) were pointing to the hardcoded `api_doc` route instead of using the actual current route.

## Changes

- Updated `src/Symfony/Bundle/Resources/views/SwaggerUi/index.html.twig` to use `originalRoute` and `originalRouteParams` instead of hardcoded `api_doc` route
- This ensures footer links work correctly with custom route names
