### PR TITLE
fix: Add support for the Deprecation header

### DIFF
--- a/src/State/Processor/AddLinkHeaderProcessor.php
+++ b/src/State/Processor/AddLinkHeaderProcessor.php
@@ -52,8 +52,7 @@ final class AddLinkHeaderProcessor implements ProcessorInterface, StopwatchAware
         // We add our header here as Symfony does it only for the main Request and we want it to be done on errors (sub-request) as well
         $linksProvider = $request->attributes->get('_api_platform_links');
         if ($this->serializer && ($links = $linksProvider?->getLinks())) {
-            $linkHeader = implode(',', array_filter([$this->serializer->serialize($links), $response->headers->get('Link')]));
-            $response->headers->set('Link', '' === $linkHeader ? null : $linkHeader);
+            $response->headers->set('Link', $this->serializer->serialize($links));
         }
         $this->stopwatch?->stop('api_platform.processor.add_link_header');
 

--- a/tests/Fixtures/TestBundle/ApiResource/DeprecationHeader.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DeprecationHeader.php
@@ -16,15 +16,20 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
+use Symfony\Component\WebLink\Link;
 
 #[ApiResource(
-    operations: [new GetCollection(provider: [self::class, 'provide'])],
-    deprecationReason: 'This API is deprecated ',
-    headers: [
-        'deprecation' => '@1688169599',
-        'sunset' => 'Sun, 30 Jun 2024 23:59:59 UTC',
-        'link' => '<https://developer.example.com/deprecation>; rel="deprecation"; type="text/html"',
-    ],
+    operations: [new GetCollection(
+        headers: [
+            'deprecation' => '@1688169599',
+            'sunset' => 'Sun, 30 Jun 2024 23:59:59 UTC',
+        ],
+        links: [
+            new Link('deprecation', 'https://developer.example.com/deprecation'),
+        ],
+        deprecationReason: 'This API is deprecated',
+        provider: [self::class, 'provide'],
+    )],
 )]
 class DeprecationHeader
 {

--- a/tests/Functional/DeprecationHeaderTest.php
+++ b/tests/Functional/DeprecationHeaderTest.php
@@ -39,6 +39,6 @@ final class DeprecationHeaderTest extends ApiTestCase
 
         $this->assertContains('@1688169599', $headers['deprecation']);
         $this->assertContains('Sun, 30 Jun 2024 23:59:59 UTC', $headers['sunset']);
-        $this->assertStringContainsString('<https://developer.example.com/deprecation>; rel="deprecation"; type="text/html"', $headers['link'][0]);
+        $this->assertStringContainsString('<https://developer.example.com/deprecation>; rel="deprecation"', $headers['link'][0]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Tickets       | Closes #5889
| License       | MIT

Add support for the Deprecation header

Uses the headers property of the APIResource directly to send the headers.

It is not configured like the sunset header; the sunset header can also be overridden via the headers. 
If both the sunset property and the header are configured, the sunset property takes precedence.

```
#[ApiResource(
    operations: [new GetCollection(provider: [self::class, 'provide'])],
    headers: [
        'Deprecation' => '@1688169599',
        'Sunset' => 'Sun, 30 Jun 2024 23:59:59 UTC',
        'Link' => '<https://developer.example.com/deprecation>; rel="deprecation"; type="text/html"',
    ],
)]
```

The developer experience is less enjoyable because it's necessary to ensure the correct formatting of date.

```
curl -X 'GET' \
  'http://127.0.0.1:40185/deprecation_headers?page=1&itemsPerPage=3' \
  -H 'accept: application/ld+json'
```

```
cache-control: max-age=60,public,s-maxage=3600  
cache-tags: /deprecation_headers/1,/deprecation_headers/2,/deprecation_headers  
deprecation: @1688169599  
link: <http://127.0.0.1:40185/docs.jsonld>; rel="http://www.w3.org/ns/hydra/core#apiDocumentation",<https://developer.example.com/deprecation>; rel="deprecation"; type="text/html" 
...
```

This can be seen as a bug fix because the header link could not be defined; it was being overridden by src/State/Processor/AddLinkHeaderProcessor.php
