### PR TITLE
Disable Swagger UI and ReDoc when Swagger is off

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -587,6 +587,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         if (!$config['enable_swagger']) {
+            $container->setParameter('api_platform.enable_swagger_ui', false);
+            $container->setParameter('api_platform.enable_re_doc', false);
+
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Fix https://github.com/api-platform/core/pull/7549#pullrequestreview-3540924125
| License       | MIT
| Doc PR        | 


When swagger is disabled, the parameters is not initialized, and the DIC fails to build the `api_platform.action.documentation` service.

This PR adds default values for the missing parameters