### PR TITLE
fix(laravel): belongs-to-many relations dont have a get-foreign-key-name method

### DIFF
--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -76,7 +76,7 @@ final class ModelMetadata
         $columns = $schema->getColumns($table);
         $indexes = $schema->getIndexes($table);
         $relations = $this->getRelations($model);
-        
+
         $foreignKeys = array_flip(array_filter(array_column($relations, 'foreign_key')));
         $attributes = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7587 https://github.com/api-platform/core/issues/7587
| License       | MIT

API Platform library tries to extract the foreign_key from all relations, but BelongsToMany relations don't have a getForeignKeyName() method, so it returns null. When API Platform tries to flip an array containing null values, PHP throws the error: array_flip(): Can only flip string and integer values, entry skipped.