### PR TITLE
fix(symfony): enable to set default values for stale-while-revalidate and stale-if-error cache headers via config file

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -333,6 +333,8 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.http_cache.shared_max_age', $config['defaults']['cache_headers']['shared_max_age'] ?? null);
         $container->setParameter('api_platform.http_cache.vary', $config['defaults']['cache_headers']['vary'] ?? ['Accept']);
         $container->setParameter('api_platform.http_cache.public', $config['defaults']['cache_headers']['public'] ?? $config['http_cache']['public']);
+        $container->setParameter('api_platform.http_cache.stale_while_revalidate', $config['defaults']['cache_headers']['stale_while_revalidate'] ?? null);
+        $container->setParameter('api_platform.http_cache.stale_if_error', $config['defaults']['cache_headers']['stale_if_error'] ?? null);
         $container->setParameter('api_platform.http_cache.invalidation.max_header_length', $config['defaults']['cache_headers']['invalidation']['max_header_length'] ?? $config['http_cache']['invalidation']['max_header_length']);
         $container->setParameter('api_platform.http_cache.invalidation.xkey.glue', $config['defaults']['cache_headers']['invalidation']['xkey']['glue'] ?? $config['http_cache']['invalidation']['xkey']['glue']);
 

--- a/src/Symfony/Bundle/Resources/config/http_cache.php
+++ b/src/Symfony/Bundle/Resources/config/http_cache.php
@@ -25,5 +25,7 @@ return function (ContainerConfigurator $container) {
             '%api_platform.http_cache.shared_max_age%',
             '%api_platform.http_cache.vary%',
             '%api_platform.http_cache.public%',
+            '%api_platform.http_cache.stale_while_revalidate%',
+            '%api_platform.http_cache.stale_if_error%',
         ]);
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Related to #3439
| License       | MIT
| Doc PR        | N/A

After #3439, the `stale-while-revalidate` and `stale-if-error` cache headers are supported, but it was not possible to set default values ​​in `api_platform.yaml` in Symfony variant.

This PR makes it possible to set default values.