### PR TITLE
test(symfony): ensure `pagination_maximum_items_per_page` defaults correctly when config defaults key is absent

### DIFF
--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -381,4 +381,14 @@ class ApiPlatformExtensionTest extends TestCase
 
         $this->assertSame(0, $this->container->getParameter('api_platform.collection.pagination.maximum_items_per_page'));
     }
+
+    public function testPaginationMaximumItemsPerPageWhenDefaultsKeyIsMissing(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        unset($config['api_platform']['defaults']);
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertTrue($this->container->hasParameter('api_platform.collection.pagination.maximum_items_per_page'));
+        $this->assertSame(30, $this->container->getParameter('api_platform.collection.pagination.maximum_items_per_page'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

This PR adds a unit test to the `ApiPlatformExtensionTest` to ensure that the `pagination_maximum_items_per_page` parameter is correctly set to its default value when the `defaults` configuration key is absent from the configuration.

Commit 2aa0eb195a437a5fe0dcfd42a1166089c9c5f0a1 introduced an array access safeguard (`$config['defaults'] ?? []`) in `ApiPlatformExtension.php` to prevent the `Warning: Undefined array key "defaults"` error reported in PR #7567 when attempting to read the configuration option `pagination_maximum_items_per_page`.

The error was fixed, but no test was added to verify the non-regression (if someone removes the array safeguard (`?? []`), the tests still pass).

This test unsets the `defaults` key from the configuration array before loading the extension, ensuring that the fallback mechanism works as expected and that the default value for `pagination_maximum_items_per_page` (`30`) is correctly applied.


