### PR TITLE
fix(metadata): Use operation output DTO in ObjectMapperProcessor

### DIFF
--- a/src/Metadata/Resource/Factory/ObjectMapperMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ObjectMapperMetadataCollectionFactory.php
@@ -52,11 +52,14 @@ class ObjectMapperMetadataCollectionFactory implements ResourceMetadataCollectio
                     $entityClass = $options->getDocumentClass();
                 }
 
-                $class = $operation->getInput()['class'] ?? $operation->getClass();
+                $inputClass = $operation->getInput()['class'] ?? $operation->getClass();
+                $outputClass = $operation->getOutput()['class'] ?? null;
                 $entityMap = null;
 
                 // Look for Mapping metadata
-                if ($this->canBeMapped($class) || ($entityClass && ($entityMap = $this->canBeMapped($entityClass)))) {
+                if ($this->canBeMapped($inputClass)
+                    || ($outputClass && $this->canBeMapped($outputClass))
+                    || ($entityClass && ($entityMap = $this->canBeMapped($entityClass)))) {
                     $found = true;
                     if ($entityMap) {
                         foreach ($entityMap as $mapping) {

--- a/src/State/Processor/ObjectMapperProcessor.php
+++ b/src/State/Processor/ObjectMapperProcessor.php
@@ -34,35 +34,64 @@ final class ObjectMapperProcessor implements ProcessorInterface
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
-        $class = $operation->getInput()['class'] ?? $operation->getClass();
-
         if (
             $data instanceof Response
             || !$this->objectMapper
             || !$operation->canWrite()
             || null === $data
-            || !is_a($data, $class, true)
             || !$operation->canMap()
         ) {
             return $this->decorated->process($data, $operation, $uriVariables, $context);
         }
 
         $request = $context['request'] ?? null;
-        $persisted = $this->decorated->process(
-            // maps the Resource to an Entity
-            $this->objectMapper->map($data, $request?->attributes->get('mapped_data')),
-            $operation,
-            $uriVariables,
-            $context,
-        );
+        $resourceClass = $operation->getClass();
+        $inputClass = $operation->getInput()['class'] ?? null;
+        $outputClass = $operation->getOutput()['class'] ?? null;
 
+        // Get entity class from state options if available
+        $stateOptions = $operation->getStateOptions();
+        $entityClass = null;
+        if ($stateOptions) {
+            if (method_exists($stateOptions, 'getEntityClass')) {
+                $entityClass = $stateOptions->getEntityClass();
+            } elseif (method_exists($stateOptions, 'getDocumentClass')) {
+                $entityClass = $stateOptions->getDocumentClass();
+            }
+        }
+
+        $hasCustomInput = null !== $inputClass && $inputClass !== $resourceClass;
+        $hasCustomOutput = null !== $outputClass && $outputClass !== $resourceClass;
+        $hasEntityMapping = null !== $entityClass && $entityClass !== $resourceClass;
+
+        // Skip mapping if no custom input/output and no entity mapping needed
+        if (!$hasCustomInput && !$hasCustomOutput && !$hasEntityMapping) {
+            return $this->decorated->process($data, $operation, $uriVariables, $context);
+        }
+
+        // Map input to entity if we have custom input or entity mapping
+        if ($hasCustomInput || $hasEntityMapping) {
+            $expectedInputClass = $hasCustomInput ? $inputClass : $resourceClass;
+            if (!is_a($data, $expectedInputClass, true)) {
+                return $this->decorated->process($data, $operation, $uriVariables, $context);
+            }
+
+            $data = $this->objectMapper->map($data, $request?->attributes->get('mapped_data'));
+        }
+
+        $persisted = $this->decorated->process($data, $operation, $uriVariables, $context);
         $request?->attributes->set('persisted_data', $persisted);
 
-        // return the Resource representation of the persisted entity
-        return $this->objectMapper->map(
-            // persist the entity
-            $persisted,
-            $operation->getClass()
-        );
+        // Map output back to resource or custom output class
+        if ($hasCustomOutput) {
+            return $this->objectMapper->map($persisted, $outputClass);
+        }
+
+        // If we have entity mapping but no custom output, map back to resource class
+        if ($hasEntityMapping) {
+            return $this->objectMapper->map($persisted, $resourceClass);
+        }
+
+        return $persisted;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | none
| License       | MIT
| Doc PR        | not needed


This PR follows up on #7601 and applies the same fix to the `ObjectMapperProcessor`.

While #7601 addressed the provider side by properly using the operation output class when defined, the processor was still relying on `$operation->getClass()`. This change updates the processor to use the operation’s output DTO (`$operation->getOutput()['class'] ?? $operation->getClass()`), ensuring consistent behavior between providers and processors.

ping @yceruto
