### PR TITLE
Fix #7599 Allow overide of CsvEncoder::AS_COLLECTION_KEY in context

### DIFF
--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -107,7 +107,7 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
             }
 
             if ('csv' === (method_exists(Request::class, 'getContentTypeFormat') ? $request->getContentTypeFormat() : $request->getContentType())) {
-                $context[CsvEncoder::AS_COLLECTION_KEY] = false;
+                $context[CsvEncoder::AS_COLLECTION_KEY] = $context[CsvEncoder::AS_COLLECTION_KEY] ?? false;
             }
         }
         if ($operation->getCollectDenormalizationErrors() ?? false) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7599
| License       | MIT
| Doc PR        | -

denormalizationContext CsvEncoder::AS_COLLECTION_KEY is erased with false by API platforme when defined on a route operation.
This commit allow overriding this context key.


