### PR TITLE
chore: upgrade justinrainbow/json-schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,7 @@
         "illuminate/routing": "^11.0 || ^12.0",
         "illuminate/support": "^11.0 || ^12.0",
         "jangregor/phpstan-prophecy": "^2.1.11",
-        "justinrainbow/json-schema": "5.3.0",
+        "justinrainbow/json-schema": "^6.5.2",
         "laravel/framework": "^11.0 || ^12.0",
         "orchestra/testbench": "^9.1",
         "phpspec/prophecy-phpunit": "^2.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| License       | MIT

Fix comment https://github.com/api-platform/core/pull/7607#discussion_r2619328330

The version 6.5.2 has the PHP8.5 depreciation fix. The continuous integration should pass thanks to https://github.com/jsonrainbow/json-schema/pull/843


