### PR TITLE
IriFilter: Add test for filtering with non-existing resource

### DIFF
--- a/tests/Functional/Parameters/IriFilterTest.php
+++ b/tests/Functional/Parameters/IriFilterTest.php
@@ -40,9 +40,15 @@ final class IriFilterTest extends ApiTestCase
     public function testIriFilter(): void
     {
         $client = $this->createClient();
+
         $res = $client->request('GET', '/chickens?chickenCoop=/chicken_coops/2')->toArray();
+
         $this->assertCount(1, $res['member']);
         $this->assertEquals('/chicken_coops/2', $res['member'][0]['chickenCoop']);
+
+        $res = $client->request('GET', '/chickens?chickenCoop=/chicken_coops/595')->toArray();
+
+        $this->assertCount(0, $res['member']);
     }
 
     public function testIriFilterMultiple(): void


### PR DESCRIPTION
This PR extends the existing testIriFilter to also cover the case where the filtered IRI does not exist.