### PR TITLE
fix(test): change string to int for status in JsonApiTest::testError

### DIFF
--- a/tests/Functional/JsonApiTest.php
+++ b/tests/Functional/JsonApiTest.php
@@ -43,7 +43,8 @@ class JsonApiTest extends ApiTestCase
         $this->assertJsonContains([
             'errors' => [
                 [
-                    'status' => '400',
+                    // TODO: change this to '400' in 5.x
+                    'status' => 400,
                     'detail' => 'Resource "nonexistent" not found.',
                 ],
             ],


### PR DESCRIPTION
The `ErrorNormalizer` temporarily returns the `status` code as an integer, causing `JsonApiTest::testError()` to fail as it expected a string,

This is due to #7569, causing 8 test failures for each new PR.
