### PR TITLE
Allow operation element to be optional in XML

### DIFF
--- a/src/Metadata/Extractor/schema/resources.xsd
+++ b/src/Metadata/Extractor/schema/resources.xsd
@@ -27,7 +27,7 @@
 
     <xsd:complexType name="operations">
         <xsd:sequence maxOccurs="unbounded">
-            <xsd:element name="operation" maxOccurs="unbounded" type="operation"/>
+            <xsd:element name="operation" minOccurs="0" maxOccurs="unbounded" type="operation"/>
         </xsd:sequence>
     </xsd:complexType>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | -
| License       | MIT
| Doc PR        | -

It's already possible for GraphQL operations in XML format, and already supported for other formats.