### PR TITLE
fix(openapi): respect schema type for non-collection parameter documentation

### DIFF
--- a/src/Doctrine/Common/Filter/OpenApiFilterTrait.php
+++ b/src/Doctrine/Common/Filter/OpenApiFilterTrait.php
@@ -23,6 +23,19 @@ trait OpenApiFilterTrait
 {
     public function getOpenApiParameters(Parameter $parameter): OpenApiParameter|array|null
     {
+        $schema = $parameter->getSchema();
+        $isArraySchema = 'array' === ($schema['type'] ?? null);
+        $castToArray = $parameter->getCastToArray();
+
+        // Use non-array notation if:
+        // 1. Schema type is explicitly set to a non-array type (string, number, etc.)
+        // 2. OR castToArray is explicitly false
+        $hasNonArraySchema = null !== $schema && !$isArraySchema;
+
+        if ($hasNonArraySchema || false === $castToArray) {
+            return new OpenApiParameter(name: $parameter->getKey(), in: 'query');
+        }
+
         return new OpenApiParameter(name: $parameter->getKey().'[]', in: 'query', style: 'deepObject', explode: true);
     }
 }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -726,13 +726,14 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $arrayValueType = method_exists(PropertyInfoExtractor::class, 'getType') ? TypeIdentifier::ARRAY->value : LegacyType::BUILTIN_TYPE_ARRAY;
             $objectValueType = method_exists(PropertyInfoExtractor::class, 'getType') ? TypeIdentifier::OBJECT->value : LegacyType::BUILTIN_TYPE_OBJECT;
 
-            $style = 'array' === ($schema['type'] ?? null) && \in_array(
+            $isArraySchema = 'array' === ($schema['type'] ?? null);
+            $style = $isArraySchema && \in_array(
                 $description['type'],
                 [$arrayValueType, $objectValueType],
                 true
             ) ? 'deepObject' : 'form';
 
-            $parameter = isset($description['openapi']) && $description['openapi'] instanceof Parameter ? $description['openapi'] : new Parameter(in: 'query', name: $name, style: $style, explode: $description['is_collection'] ?? false);
+            $parameter = isset($description['openapi']) && $description['openapi'] instanceof Parameter ? $description['openapi'] : new Parameter(in: 'query', name: $name, style: $style, explode: $isArraySchema ? ($description['is_collection'] ?? false) : false);
 
             if ('' === $parameter->getDescription() && ($str = $description['description'] ?? '')) {
                 $parameter = $parameter->withDescription($str);
@@ -771,6 +772,8 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         $arrayValueType = method_exists(PropertyInfoExtractor::class, 'getType') ? TypeIdentifier::ARRAY->value : LegacyType::BUILTIN_TYPE_ARRAY;
         $objectValueType = method_exists(PropertyInfoExtractor::class, 'getType') ? TypeIdentifier::OBJECT->value : LegacyType::BUILTIN_TYPE_OBJECT;
 
+        $isArraySchema = 'array' === $schema['type'];
+
         return new Parameter(
             $name,
             'query',
@@ -779,12 +782,12 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $description['openapi']['deprecated'] ?? false,
             $description['openapi']['allowEmptyValue'] ?? null,
             $schema,
-            'array' === $schema['type'] && \in_array(
+            $isArraySchema && \in_array(
                 $description['type'],
                 [$arrayValueType, $objectValueType],
                 true
             ) ? 'deepObject' : 'form',
-            $description['openapi']['explode'] ?? ('array' === $schema['type']),
+            $description['openapi']['explode'] ?? $isArraySchema,
             $description['openapi']['allowReserved'] ?? null,
             $description['openapi']['example'] ?? null,
             isset(

--- a/tests/Fixtures/TestBundle/Entity/ProductWithQueryParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/ProductWithQueryParameter.php
@@ -42,6 +42,16 @@ use Doctrine\ORM\Mapping as ORM;
                     filter: new OrderFilter(),
                     properties: ['rating']
                 ),
+                'exactBrand' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'brand',
+                    schema: ['type' => 'string']
+                ),
+                'exactCategory' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'category',
+                    castToArray: false
+                ),
             ]
         ),
     ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #7548
| License       | MIT
| Doc PR        | na

When a filter parameter has an explicit schema type set to a non-array type (e.g., 'string'), the OpenAPI documentation now correctly generates a non-collection parameter instead of using array notation with '[]' suffix, deepObject style, and explode: true.

Fixes #7548