### PR TITLE
fix(doctrine): escape values with `%` or `_` in search filter

### DIFF
--- a/src/Doctrine/Orm/Filter/PartialSearchFilter.php
+++ b/src/Doctrine/Orm/Filter/PartialSearchFilter.php
@@ -40,10 +40,8 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
         if (!is_iterable($values)) {
             $queryBuilder->setParameter($parameterName, $this->formatLikeValue(strtolower($values)));
 
-            $queryBuilder->{$context['whereClause'] ?? 'andWhere'}($queryBuilder->expr()->like(
-                'LOWER('.$field.')',
-                ':'.$parameterName
-            ));
+            $likeExpression = 'LOWER('.$field.') LIKE :'.$parameterName.' ESCAPE \'\\\'';
+            $queryBuilder->{$context['whereClause'] ?? 'andWhere'}($likeExpression);
 
             return;
         }
@@ -51,10 +49,7 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
         $likeExpressions = [];
         foreach ($values as $val) {
             $parameterName = $queryNameGenerator->generateParameterName($property);
-            $likeExpressions[] = $queryBuilder->expr()->like(
-                'LOWER('.$field.')',
-                ':'.$parameterName
-            );
+            $likeExpressions[] = 'LOWER('.$field.') LIKE :'.$parameterName.' ESCAPE \'\\\'';
             $queryBuilder->setParameter($parameterName, $this->formatLikeValue(strtolower($val)));
         }
 
@@ -65,6 +60,6 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
 
     private function formatLikeValue(string $value): string
     {
-        return '%'.addcslashes($value, '%_').'%';
+        return '%'.addcslashes($value, '\\%_').'%';
     }
 }

--- a/tests/Functional/Parameters/PartialSearchFilterTest.php
+++ b/tests/Functional/Parameters/PartialSearchFilterTest.php
@@ -119,19 +119,25 @@ final class PartialSearchFilterTest extends ApiTestCase
         yield 'filter by partial name "%"' => [
             '/chickens?namePartial=%25',
             1,
-            ['xx_%_\_%_xx'],
+            ['xx_%_\\_%_xx'],
         ];
 
         yield 'filter by partial name "_"' => [
-            '/chickens?namePartial=_',
+            '/chickens?namePartial=%5F',
             1,
-            ['xx_%_\_%_xx'],
+            ['xx_%_\\_%_xx'],
         ];
 
         yield 'filter by partial name "\"' => [
             '/chickens?namePartial=%5C',
             1,
-            ['xx_%_\_%_xx'],
+            ['xx_%_\\_%_xx'],
+        ];
+
+        yield 'filter by partial name "\_"' => [
+            '/chickens?namePartial=%5C%5F',
+            1,
+            ['xx_%_\\_%_xx'],
         ];
     }
 
@@ -158,7 +164,7 @@ final class PartialSearchFilterTest extends ApiTestCase
         $chicken2->setChickenCoop($chickenCoop2);
 
         $chicken3 = new $chickenClass();
-        $chicken3->setName('xx_%_\_%_xx');
+        $chicken3->setName('xx_%_\\_%_xx');
         $chicken3->setChickenCoop($chickenCoop1);
 
         $chickenCoop1->addChicken($chicken1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

`%` and `_` are reserved characters which need to be escaped when used in a LIKE query.

Before this PR `'/chickens?namePartial=%',` returns 2 results ; now it correctly returns 0.