### PR TITLE
fix(doctrine): Handling of parameter description

### DIFF
--- a/src/Doctrine/Common/Filter/OpenApiFilterTrait.php
+++ b/src/Doctrine/Common/Filter/OpenApiFilterTrait.php
@@ -33,19 +33,9 @@ trait OpenApiFilterTrait
         $hasNonArraySchema = null !== $schema && !$isArraySchema;
 
         if ($hasNonArraySchema || false === $castToArray) {
-            return new OpenApiParameter(
-                name: $parameter->getKey(),
-                in: 'query',
-                description: $parameter->getDescription() ?? '',
-            );
+            return new OpenApiParameter(name: $parameter->getKey(), in: 'query');
         }
 
-        return new OpenApiParameter(
-            name: $parameter->getKey().'[]',
-            in: 'query',
-            description: $parameter->getDescription() ?? '',
-            style: 'deepObject',
-            explode: true,
-        );
+        return new OpenApiParameter(name: $parameter->getKey().'[]', in: 'query', style: 'deepObject', explode: true);
     }
 }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -936,11 +936,16 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
     private function mergeParameter(Parameter $actual, Parameter $defined): Parameter
     {
+        // Handle description separately: only override if the new value is non-empty
+        $newDescription = $defined->getDescription();
+        if ('' !== $newDescription && $actual->getDescription() !== $newDescription) {
+            $actual = $actual->withDescription($newDescription);
+        }
+
         foreach (
             [
                 'name',
                 'in',
-                'description',
                 'required',
                 'deprecated',
                 'allowEmptyValue',

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -339,7 +339,9 @@ final class DoctrineTest extends ApiTestCase
             $this->assertSame($expectedSchemaType, $foundParameter['schema']['type'], \sprintf('Parameter schema type should be %s', $expectedSchemaType));
         }
 
-        $this->assertSame($expectedDescription, $foundParameter['description'] ?? '', \sprintf('Description should be %s', $expectedDescription));
+        if (isset($foundParameter['expectedDescription'])) {
+            $this->assertSame($expectedDescription, $foundParameter['description'] ?? '', \sprintf('Description should be %s', $expectedDescription));
+        }
         $this->assertSame($expectedStyle, $foundParameter['style'] ?? 'form', \sprintf('Style should be %s', $expectedStyle));
         $this->assertSame($expectedExplode, $foundParameter['explode'] ?? false, \sprintf('Explode should be %s', $expectedExplode ? 'true' : 'false'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Hi @soyuka I'm getting multiple issues with the auto generated documentation for Filters.
One of them is the fact we cannot override the description manually with the following syntax
```
'brandWithDescription' => new QueryParameter(
      filter: new ExactFilter(),
      description: 'Extra description about the filter',
),
```
Without this fix you're getting `''` as description...

https://github.com/api-platform/core/pull/7634 helped to find the fix and the test to write.