### PR TITLE
fix(openapi): phpdoc operation response as array<int|string, OpenApi\Response> 

### DIFF
--- a/src/OpenApi/Model/Operation.php
+++ b/src/OpenApi/Model/Operation.php
@@ -17,15 +17,16 @@ final class Operation
 {
     use ExtensionTrait;
 
+    /**
+     * @param ?string[]   $tags
+     * @param ?Response[] $responses
+     */
     public function __construct(private ?string $operationId = null, private ?array $tags = null, private ?array $responses = null, private ?string $summary = null, private ?string $description = null, private ?ExternalDocumentation $externalDocs = null, private ?array $parameters = null, private ?RequestBody $requestBody = null, private ?\ArrayObject $callbacks = null, private ?bool $deprecated = null, private ?array $security = null, private ?array $servers = null, array $extensionProperties = [])
     {
         $this->extensionProperties = $extensionProperties;
     }
 
-    /**
-     * @param string $status
-     */
-    public function addResponse(Response $response, $status = 'default'): self
+    public function addResponse(Response $response, int|string $status = 'default'): self
     {
         $this->responses[$status] = $response;
 
@@ -62,6 +63,9 @@ final class Operation
         return $this->externalDocs;
     }
 
+    /**
+     * @return ?Parameter[]
+     */
     public function getParameters(): ?array
     {
         return $this->parameters;
@@ -151,6 +155,9 @@ final class Operation
         return $clone;
     }
 
+    /**
+     * @param Parameter[] $parameters
+     */
     public function withParameters(array $parameters): self
     {
         $clone = clone $this;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes. Let me know if you consider this a feature or a bugfix please.
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

1. Commit 4aeb82e ; When bumping from `v4.1.23` to `v4.2.11` I noticed the following wasn't allowed anymore in `v4.2.11`; resulting in a `cannot call getDescription() on array`.

```php
use Symfony\Component\HttpFoundation\Response;
...
new Delete(responses: [Response::HTTP_NO_CONTENT => ['description' => 'Some description']]);
```

and must be replaced with:

```php
use Symfony\Component\HttpFoundation\Response;
use ApiPlatform\OpenApi\Model\Response as OpenApiResponse;
...
new Delete(responses: [Response::HTTP_NO_CONTENT => new OpenApiResponse(description: 'Some description')]);
```

I found this (intentional?) BC break at runtime. If the correct annotation were in place, static analysis (phpstan in my case) would have found it earlier.

2. Commit 5660e4d ; Flyby fix. Key of `responses` can also be an int (like `200`, etc).


