### PR TITLE
ci: fix php8.5 warnings

### DIFF
--- a/src/Serializer/composer.json
+++ b/src/Serializer/composer.json
@@ -39,6 +39,7 @@
         "doctrine/collections": "^2.1",
         "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^12.2",
+        "sebastian/exporter": "^6.3.2 || ^7.0.2",
         "symfony/mercure-bundle": "*",
         "symfony/var-dumper": "^6.4 || ^7.0 || ^8.0",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch      | main for features
| License       | MIT

Fix php8.5 warnings `The float xxxx is not representable as an int, cast occurred`