### PR TITLE
ci - fix testMapPutAllowCreate

### DIFF
--- a/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
@@ -22,7 +22,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 class MappedResourceWithRelationEntity
 {
     #[ORM\Id, ORM\Column]
-    #[Map(transform: 'to_string')]
+    #[Map(transform: 'strval')]
     private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: MappedResourceWithRelationRelatedEntity::class)]


### PR DESCRIPTION
fix testMapPutAllowCreate with symfony/object-mapper (8.1.x-dev 6b6b529)

the method `to_string` does not exists, I imagine the object mapper was failing silently.

@see https://github.com/api-platform/core/actions/runs/20967516845/job/60261869428?pr=7668