### PR TITLE
fix(symfony): pass missing arguments to `ConcernsResourceMetadataCollectionFactory`

### DIFF
--- a/src/Symfony/Bundle/Resources/config/metadata/resource.php
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.php
@@ -57,7 +57,12 @@ return function (ContainerConfigurator $container) {
 
     $services->set('api_platform.metadata.resource.metadata_collection_factory.concerns', 'ApiPlatform\Metadata\Resource\Factory\ConcernsResourceMetadataCollectionFactory')
         ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 800)
-        ->args([service('api_platform.metadata.resource.metadata_collection_factory.concerns.inner')]);
+        ->args([
+            service('api_platform.metadata.resource.metadata_collection_factory.concerns.inner'),
+            service('logger')->nullOnInvalid(),
+            '%api_platform.defaults%',
+            '%api_platform.graphql.enabled%',
+        ]);
 
     $services->set('api_platform.metadata.resource.metadata_collection_factory.not_exposed_operation', 'ApiPlatform\Metadata\Resource\Factory\NotExposedOperationResourceMetadataCollectionFactory')
         ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 700)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

## Summary

When using the `apiResource()` method to define API resources in Symfony, default GraphQL operations (Query, QueryCollection, etc.) are not automatically generated, causing errors like:

> Operation "item_query" not found for resource "Foo".

## Root Cause

In [`src/Symfony/Bundle/Resources/config/metadata/resource.php`](https://github.com/api-platform/core/blob/v4.2.12/src/Symfony/Bundle/Resources/config/metadata/resource.php#L58-L60), `ConcernsResourceMetadataCollectionFactory` is registered with only the `decorated` argument:

https://github.com/api-platform/core/blob/61d272af61cf7025972ee58793c1c8d546d46e37/src/Symfony/Bundle/Resources/config/metadata/resource.php#L58-L60

This causes `graphQlEnabled` to default to false, skipping default GraphQL operation generation in `MetadataCollectionFactoryTrait`.

## Fix

Pass all required arguments (`logger`, `defaults`, `graphQlEnabled`) matching [`AttributesResourceMetadataCollectionFactory`](https://github.com/api-platform/core/blob/v4.2.12/src/Symfony/Bundle/Resources/config/metadata/resource.php#L23-L29).

## Note

The Laravel integration already passes these arguments correctly in `ApiPlatformDeferredProvider.php`:

https://github.com/api-platform/core/blob/61d272af61cf7025972ee58793c1c8d546d46e37/src/Laravel/ApiPlatformDeferredProvider.php#L221-L231