### PR TITLE
fix(doctrine): useless generateParameterName call

### DIFF
--- a/src/Doctrine/Orm/Filter/PartialSearchFilter.php
+++ b/src/Doctrine/Orm/Filter/PartialSearchFilter.php
@@ -34,10 +34,10 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
         $property = $parameter->getProperty();
         $alias = $queryBuilder->getRootAliases()[0];
         $field = $alias.'.'.$property;
-        $parameterName = $queryNameGenerator->generateParameterName($property);
         $values = $parameter->getValue();
 
         if (!is_iterable($values)) {
+            $parameterName = $queryNameGenerator->generateParameterName($property);
             $queryBuilder->setParameter($parameterName, $this->formatLikeValue(strtolower($values)));
 
             $likeExpression = 'LOWER('.$field.') LIKE :'.$parameterName.' ESCAPE \'\\\'';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

When values is an iterable, `generateParameterName` is called one time for nothing.