### PR TITLE
fix(jsonschema): call to an undefined method `Symfony\Component\TypeInfo\Type::getClassName()`

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -360,9 +360,11 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
 
                 if ($valueType instanceof ObjectType) {
                     $className = $valueType->getClassName();
-                } else {
+                } elseif (($wrappedType = $valueType->getWrappedType()) instanceof ObjectType) {
                     // GenericType
-                    $className = $valueType->getWrappedType()->getClassName();
+                    $className = $wrappedType->getClassName();
+                } else {
+                    continue;
                 }
 
                 $subSchemaInstance = new Schema($version);


### PR DESCRIPTION
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Fix the followig error: 
```
Error: Call to an undefined method Symfony\Component\TypeInfo\Type::getClassName().
 ------ -------------------------------------------------- 
  Line   src/JsonSchema/SchemaFactory.php                  
 ------ -------------------------------------------------- 
  365    Call to an undefined method                       
         Symfony\Component\TypeInfo\Type::getClassName().  
         🪪  method.notFound                               
 ------ -------------------------------------------------- 
```
