### PR TITLE
fix: if the relationship is null the jsonapi output must present null

### DIFF
--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -321,7 +321,12 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                 }
                 $relatedDefinitions[$propertyName] = array_flip($refs);
                 if ($isOne) {
-                    $relationships[$propertyName]['properties']['data'] = self::RELATION_PROPS;
+                    $relationships[$propertyName]['properties']['data'] = [
+                        'oneOf' => [
+                            ['type' => 'null'],
+                            self::RELATION_PROPS,
+                        ],
+                    ];
                     continue;
                 }
                 $relationships[$propertyName]['properties']['data'] = [

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -460,26 +460,31 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 $relationshipName = $this->nameConverter->normalize($relationshipName, $context['resource_class'], self::FORMAT, $context);
             }
 
-            $data[$relationshipName] = [
-                'data' => null,
-            ];
-
-            if (!$attributeValue) {
-                continue;
-            }
-
             // Many to one relationship
             if ('one' === $relationshipDataArray['cardinality']) {
+                $data[$relationshipName] = [
+                    'data' => null,
+                ];
+
+                if (!$attributeValue) {
+                    continue;
+                }
+
                 unset($attributeValue['data']['attributes']);
                 $data[$relationshipName] = $attributeValue;
 
                 continue;
             }
 
+            // Many to many relationship
             $data[$relationshipName] = [
                 'data' => [],
             ];
-            // Many to many relationship
+
+            if (!$attributeValue) {
+                continue;
+            }
+
             foreach ($attributeValue as $attributeValueElement) {
                 if (!isset($attributeValueElement['data'])) {
                     throw new UnexpectedValueException(\sprintf('The JSON API attribute \'%s\' must contain a "data" key.', $relationshipName));


### PR DESCRIPTION
The JSONAPI spec expects a null value if a toOne relation is empty https://jsonapi.org/format/#fetching-relationships

The current implementation always returns 

```
"relationships": { "relation": { "data": [] } }
```

even though it should return

```
"relationships": { "relation": { "data": null } }
```

This breaks JSONAPI copliant client code.