### PR TITLE
fix: Change payload type from array to free-form object in schema

### DIFF
--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -203,7 +203,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
                     'message' => ['type' => 'string', 'description' => 'The message associated with the violation'],
                     'code' => ['type' => 'string', 'description' => 'The code of the violation'],
                     'hint' => ['type' => 'string', 'description' => 'An extra hint to understand the violation'],
-                    'payload' => ['type' => 'array', 'description' => 'The serialized payload of the violation'],
+                    'payload' => ['type' => 'object', 'additionalProperties' => true, 'description' => 'The serialized payload of the violation'],
                 ],
                 'required' => ['propertyPath', 'message'],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Fixes https://github.com/api-platform/core/issues/7659
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

https://github.com/api-platform/core/pull/7673 added the `payload` field to the schema, the current schema is invalid because:
1. The `items` field is missing https://swagger.io/docs/specification/v3_0/data-models/data-types/#arrays
> the items keyword is required in arrays
2. The payload field is a dictionary which can contain any value (`mixed`) https://swagger.io/docs/specification/v3_0/data-models/data-types/#objects
