### PR TITLE
fix(openapi): invalid openapi on ConstraintViolation properties payload

### DIFF
--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -203,7 +203,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
                     'message' => ['type' => 'string', 'description' => 'The message associated with the violation'],
                     'code' => ['type' => 'string', 'description' => 'The code of the violation'],
                     'hint' => ['type' => 'string', 'description' => 'An extra hint to understand the violation'],
-                    'payload' => ['type' => 'array', 'description' => 'The serialized payload of the violation'],
+                    'payload' => ['type' => 'object', 'description' => 'The serialized payload of the violation'],
                 ],
                 'required' => ['propertyPath', 'message'],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| License       | MIT

Fixed schema validation errors by changing `payload` from `array` to `object`.
`array` types require an `items` definition, which was not applicable here.


To reproduce the error with spectral.
```
bin/console api:openapi:export --yaml --output=openapi.yaml
echo "extends: ["spectral:oas"]" > .spectral.yaml
docker run --rm -it -v $(pwd):/tmp stoplight/spectral:6 lint /tmp/openapi.yaml --ruleset /tmp/.spectral.yaml
```

```
 *:23    error  array-items           Schemas with "type: array", require a sibling "items" field                                    components.schemas.ConstraintViolation.properties.violations.items.properties.payload
 *:27    error  array-items           Schemas with "type: array", require a sibling "items" field                                    components.schemas.ConstraintViolation.jsonld.allOf[1].properties.violations.items.properties.payload
```

