### PR TITLE
feat: support relations on filters

### DIFF
--- a/src/Doctrine/Orm/Filter/ExactFilter.php
+++ b/src/Doctrine/Orm/Filter/ExactFilter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\OpenApiFilterTrait;
+use ApiPlatform\Doctrine\Orm\NestedPropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
@@ -27,6 +28,7 @@ use Doctrine\ORM\QueryBuilder;
 final class ExactFilter implements FilterInterface, OpenApiParameterFilterInterface
 {
     use BackwardCompatibleFilterDescriptionTrait;
+    use NestedPropertyHelperTrait;
     use OpenApiFilterTrait;
 
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
@@ -41,6 +43,8 @@ final class ExactFilter implements FilterInterface, OpenApiParameterFilterInterf
         $property = $parameter->getProperty();
         $alias = $queryBuilder->getRootAliases()[0];
         $parameterName = $queryNameGenerator->generateParameterName($property);
+
+        [$alias, $property] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $parameter);
 
         if (\is_array($value)) {
             $queryBuilder

--- a/src/Doctrine/Orm/Filter/PartialSearchFilter.php
+++ b/src/Doctrine/Orm/Filter/PartialSearchFilter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\OpenApiFilterTrait;
+use ApiPlatform\Doctrine\Orm\NestedPropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
@@ -27,6 +28,7 @@ use Doctrine\ORM\QueryBuilder;
 final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilterInterface
 {
     use BackwardCompatibleFilterDescriptionTrait;
+    use NestedPropertyHelperTrait;
     use OpenApiFilterTrait;
 
     public function __construct(private readonly bool $caseSensitive = false)
@@ -43,6 +45,7 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
 
         $property = $parameter->getProperty();
         $alias = $queryBuilder->getRootAliases()[0];
+        [$alias, $property] = $this->addJoinsForNestedProperty($property, $alias, $queryBuilder, $queryNameGenerator, $parameter);
         $field = $alias.'.'.$property;
         $values = $parameter->getValue();
 

--- a/src/Doctrine/Orm/NestedPropertyHelperTrait.php
+++ b/src/Doctrine/Orm/NestedPropertyHelperTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Orm;
+
+use ApiPlatform\Doctrine\Orm\Util\QueryBuilderHelper;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Parameter;
+use Doctrine\ORM\QueryBuilder;
+
+/**
+ * Helper trait for handling nested properties.
+ *
+ * @author Kévin Dunglas <dunglas@gmail.com>
+ */
+trait NestedPropertyHelperTrait
+{
+    /**
+     * Adds the necessary join for a nested property.
+     *
+     * @return array An array where the first element is the join $alias of the leaf entity,
+     *               the second element is the leaf property
+     */
+    protected function addJoinsForNestedProperty(
+        string $property,
+        string $alias,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        Parameter $parameter,
+    ): array {
+        $extraProperties = $parameter->getExtraProperties();
+        $nestedInfo = $extraProperties['nested_property_info'] ?? null;
+
+        if (!$nestedInfo) {
+            return [$alias, $property];
+        }
+
+        foreach ($nestedInfo['converted_relation_segments'] as $association) {
+            $alias = QueryBuilderHelper::addJoinOnce(
+                $queryBuilder,
+                $queryNameGenerator,
+                $alias,
+                $association
+            );
+        }
+
+        return [$alias, $nestedInfo['leaf_property']];
+    }
+}

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -379,6 +379,11 @@ class ApiPlatformProvider extends ServiceProvider
             });
         }
 
+        // Parameter metadata factory with Laravel Eloquent support
+        $this->app->extend(ResourceMetadataCollectionFactoryInterface::class, static function (ResourceMetadataCollectionFactoryInterface $inner, Application $app) {
+            return new Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory($inner, $app->make(ModelMetadata::class), new \Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter());
+        });
+
         $this->app->singleton(OperationMetadataFactory::class, static function (Application $app) {
             return new OperationMetadataFactory($app->make(ResourceNameCollectionFactoryInterface::class), $app->make(ResourceMetadataCollectionFactoryInterface::class));
         });

--- a/src/Laravel/Eloquent/Filter/EqualsFilter.php
+++ b/src/Laravel/Eloquent/Filter/EqualsFilter.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 
 final class EqualsFilter implements FilterInterface
 {
+    use NestedPropertyTrait;
     use QueryPropertyTrait;
 
     /**
@@ -27,6 +28,11 @@ final class EqualsFilter implements FilterInterface
      */
     public function apply(Builder $builder, mixed $values, Parameter $parameter, array $context = []): Builder
     {
-        return $builder->{$context['whereClause'] ?? 'where'}($this->getQueryProperty($parameter), $values);
+        return $this->applyWithNestedProperty(
+            $builder,
+            $parameter,
+            static fn (Builder $query, string $property, string $whereClause) => $query->{$whereClause}($property, $values),
+            $context['whereClause'] ?? 'where'
+        );
     }
 }

--- a/src/Laravel/Eloquent/Filter/NestedPropertyTrait.php
+++ b/src/Laravel/Eloquent/Filter/NestedPropertyTrait.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Eloquent\Filter;
+
+use ApiPlatform\Metadata\Parameter;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @internal
+ */
+trait NestedPropertyTrait
+{
+    /**
+     * Applies a filter condition supporting nested properties via relationships.
+     *
+     * @param Builder<\Illuminate\Database\Eloquent\Model> $builder
+     * @param callable                                     $condition Callback receiving ($query, $property) to apply the actual filter condition
+     *
+     * @return Builder<\Illuminate\Database\Eloquent\Model>
+     */
+    private function applyWithNestedProperty(
+        Builder $builder,
+        Parameter $parameter,
+        callable $condition,
+        string $whereClause = 'where',
+    ): Builder {
+        $nestedInfo = $parameter->getExtraProperties()['nested_property_info'] ?? null;
+
+        if (!$nestedInfo) {
+            // No nested property, use simple where clause
+            $property = $this->getQueryProperty($parameter);
+
+            return $condition($builder, $property, $whereClause);
+        }
+
+        // Handle nested property using whereHas
+        // For Laravel Eloquent, use the original relation names (camelCase method names)
+        // not the converted names (snake_case database columns)
+        $relationSegments = $nestedInfo['relation_segments'];
+        $leafProperty = $nestedInfo['leaf_property'];
+
+        if (0 === \count($relationSegments)) {
+            // Edge case: no relations, just a property
+            return $condition($builder, $leafProperty, $whereClause);
+        }
+
+        // Build nested whereHas callbacks from innermost to outermost
+        // For product.name: whereHas('product', fn($q) => $q->where('name', ...))
+        // For product.variations.code: whereHas('product', fn($q) => $q->whereHas('variations', fn($q2) => $q2->where('code', ...)))
+
+        $callback = static function ($query) use ($leafProperty, $condition, $whereClause) {
+            return $condition($query, $leafProperty, $whereClause);
+        };
+
+        // Build the chain from the end to the beginning
+        for ($i = \count($relationSegments) - 1; $i > 0; --$i) {
+            $relation = $relationSegments[$i];
+            $previousCallback = $callback;
+            $callback = static function ($query) use ($relation, $previousCallback) {
+                return $query->whereHas($relation, $previousCallback);
+            };
+        }
+
+        // Apply the outermost whereHas
+        return $builder->whereHas($relationSegments[0], $callback);
+    }
+}

--- a/src/Laravel/Eloquent/Filter/PartialSearchFilter.php
+++ b/src/Laravel/Eloquent/Filter/PartialSearchFilter.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Model;
 
 final class PartialSearchFilter implements FilterInterface
 {
+    use NestedPropertyTrait;
     use QueryPropertyTrait;
 
     /**
@@ -27,6 +28,11 @@ final class PartialSearchFilter implements FilterInterface
      */
     public function apply(Builder $builder, mixed $values, Parameter $parameter, array $context = []): Builder
     {
-        return $builder->{$context['whereClause'] ?? 'where'}($this->getQueryProperty($parameter), 'like', '%'.$values.'%');
+        return $this->applyWithNestedProperty(
+            $builder,
+            $parameter,
+            static fn (Builder $query, string $property, string $whereClause) => $query->{$whereClause}($property, 'like', '%'.$values.'%'),
+            $context['whereClause'] ?? 'where'
+        );
     }
 }

--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -316,6 +316,31 @@ final class ModelMetadata
     }
 
     /**
+     * Gets the related model class for a given relationship property.
+     *
+     * @param class-string<Model> $modelClass The current model class
+     * @param string              $property   The property/relationship name
+     *
+     * @return class-string<Model>|null The related model class, or null if not a relationship
+     */
+    public function getRelatedModelClass(string $modelClass, string $property): ?string
+    {
+        if (!class_exists($modelClass)) {
+            return null;
+        }
+
+        $relations = $this->getRelations(new $modelClass());
+
+        foreach ($relations as $relation) {
+            if ($relation['method_name'] === $property || $relation['name'] === $property) {
+                return $relation['related'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Determines if the given attribute is unique.
      *
      * @param array<int, array{columns: string[], unique: bool}> $indexes

--- a/src/Laravel/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Laravel/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -1,0 +1,189 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Metadata\Resource\Factory;
+
+use ApiPlatform\Laravel\Eloquent\Metadata\ModelMetadata;
+use ApiPlatform\Laravel\Eloquent\State\Options;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * Decorates the resource metadata factory to enhance nested property parameters
+ * with Laravel Eloquent relationship information.
+ */
+final class ParameterResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+        private readonly ModelMetadata $modelMetadata,
+        private readonly NameConverterInterface $nameConverter,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $i => $resource) {
+            $stateOptions = $resource->getStateOptions();
+            $modelClass = $stateOptions instanceof Options ? $stateOptions->getModelClass() : null;
+
+            $operations = $resource->getOperations();
+
+            foreach ($operations as $operationName => $operation) {
+                $parameters = $operation->getParameters();
+                if (!$parameters) {
+                    continue;
+                }
+
+                $modified = false;
+
+                foreach ($parameters as $key => $parameter) {
+                    $property = str_contains($key, '.') ? $key : $parameter->getProperty();
+                    if (!$property || !str_contains($property, '.')) {
+                        continue;
+                    }
+
+                    $extraProperties = $parameter->getExtraProperties();
+                    $nestedInfo = $extraProperties['nested_property_info'] ?? null;
+
+                    if (!$nestedInfo && $modelClass) {
+                        $nestedInfo = $this->buildNestedPropertyInfo($property, $modelClass);
+                        if (!$nestedInfo) {
+                            continue;
+                        }
+
+                        $extraProperties['nested_property_info'] = $nestedInfo;
+                        $parameters = $parameters->add(
+                            $key,
+                            $parameter->withProperty($property)->withExtraProperties($extraProperties)
+                        );
+                        $modified = true;
+                        continue;
+                    }
+
+                    if (!$nestedInfo) {
+                        continue;
+                    }
+
+                    $nestedInfo = $this->fillMissingRelationClasses($nestedInfo);
+                    if (!$nestedInfo) {
+                        continue;
+                    }
+
+                    $extraProperties['nested_property_info'] = $nestedInfo;
+                    $parameters = $parameters->add($key, $parameter->withExtraProperties($extraProperties));
+                    $modified = true;
+                }
+
+                if ($modified) {
+                    $operations = $operations->add($operationName, $operation->withParameters($parameters));
+                }
+            }
+
+            if ($operations !== $resource->getOperations()) {
+                $resourceMetadataCollection[$i] = $resource->withOperations($operations);
+            }
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    /**
+     * Traverses a nested property path using Laravel Eloquent relationships.
+     *
+     * @param string $property   The nested property path (e.g., "product.productVariations.variantName")
+     * @param string $modelClass The starting model class
+     *
+     * @return array<string, mixed>|null The nested_property_info array, or null if traversal fails
+     */
+    private function buildNestedPropertyInfo(string $property, string $modelClass): ?array
+    {
+        $parts = explode('.', $property);
+        $currentClass = $modelClass;
+        $relationSegments = [];
+        $relationClasses = [];
+
+        for ($i = 0, $last = \count($parts) - 1; $i < $last; ++$i) {
+            $part = $parts[$i];
+            $relationSegments[] = $part;
+            $relationClasses[] = $currentClass;
+
+            /** @var class-string<\Illuminate\Database\Eloquent\Model> $currentClass */
+            $nextClass = $this->modelMetadata->getRelatedModelClass($currentClass, $part);
+            if (!$nextClass) {
+                return null;
+            }
+
+            $currentClass = $nextClass;
+        }
+
+        $leafProperty = $this->nameConverter->normalize($parts[\count($parts) - 1]);
+
+        return [
+            'relation_segments' => $relationSegments,
+            'converted_relation_segments' => $relationSegments,
+            'relation_classes' => $relationClasses,
+            'leaf_property' => $leafProperty,
+            'leaf_class' => $currentClass,
+        ];
+    }
+
+    /**
+     * Fills in missing relation_classes entries using Eloquent relationship resolution.
+     *
+     * @param array<string, mixed> $nestedInfo
+     *
+     * @return array<string, mixed>|null Updated nested info, or null if no changes were needed
+     */
+    private function fillMissingRelationClasses(array $nestedInfo): ?array
+    {
+        $relationSegments = $nestedInfo['relation_segments'] ?? [];
+        $relationClasses = $nestedInfo['relation_classes'] ?? [];
+        $needsUpdate = false;
+
+        for ($idx = 0, $count = \count($relationSegments); $idx < $count; ++$idx) {
+            $fromClass = $relationClasses[$idx] ?? null;
+            if (!$fromClass) {
+                continue;
+            }
+
+            $nextIdx = $idx + 1;
+            if ($nextIdx < $count && !isset($relationClasses[$nextIdx])) {
+                $targetClass = $this->modelMetadata->getRelatedModelClass($fromClass, $relationSegments[$idx]);
+                if ($targetClass) {
+                    $relationClasses[$nextIdx] = $targetClass;
+                    $needsUpdate = true;
+                }
+            }
+        }
+
+        if (!$needsUpdate) {
+            return null;
+        }
+
+        $lastIdx = \count($relationSegments) - 1;
+        if ($lastIdx >= 0 && isset($relationClasses[$lastIdx])) {
+            $leafClass = $this->modelMetadata->getRelatedModelClass($relationClasses[$lastIdx], $relationSegments[$lastIdx]);
+            if ($leafClass) {
+                $nestedInfo['leaf_class'] = $leafClass;
+            }
+        }
+
+        $nestedInfo['relation_classes'] = $relationClasses;
+
+        return $nestedInfo;
+    }
+}

--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -121,7 +121,9 @@ class IriConverter implements IriConverterInterface
         }
 
         if ($operation instanceof HttpOperation && 301 === $operation->getStatus()) {
-            $operation = ($operation instanceof CollectionOperationInterface ? new GetCollection() : new Get())->withClass($operation->getClass());
+            /** @var class-string $operationClass */
+            $operationClass = $operation->getClass() ?? $resourceClass;
+            $operation = ($operation instanceof CollectionOperationInterface ? new GetCollection() : new Get())->withClass($operationClass);
             unset($context['uri_variables']);
         }
 

--- a/src/Laravel/Tests/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
+++ b/src/Laravel/Tests/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Laravel\Eloquent\Metadata\ModelMetadata;
+use ApiPlatform\Laravel\Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory as LaravelParameterResourceMetadataCollectionFactory;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
+use ApiPlatform\Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+class ParameterResourceMetadataCollectionFactoryTest extends TestCase
+{
+    public function testNestedPropertyWithEloquentRelationship(): void
+    {
+        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'name']));
+
+        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadata->method('create')->willReturnCallback(
+            static function (string $class, string $property) {
+                return new ApiProperty(readable: true);
+            }
+        );
+
+        $filterLocator = $this->createStub(ContainerInterface::class);
+        $filterLocator->method('has')->willReturn(false);
+
+        $coreFactory = new ParameterResourceMetadataCollectionFactory(
+            $nameCollection,
+            $propertyMetadata,
+            new AttributesResourceMetadataCollectionFactory(),
+            $filterLocator
+        );
+
+        $parameterFactory = new LaravelParameterResourceMetadataCollectionFactory($coreFactory, new ModelMetadata(), new CamelCaseToSnakeCaseNameConverter());
+
+        $resourceMetadataCollection = $parameterFactory->create(TestProductOrderResource::class);
+        $operation = $resourceMetadataCollection->getOperation(forceCollection: true);
+        $parameters = $operation->getParameters();
+
+        $this->assertNotNull($parameters);
+        $this->assertTrue($parameters->has('search[name]'));
+        $this->assertTrue($parameters->has('search[product.name]'));
+
+        $searchNameParam = $parameters->get('search[name]');
+        $this->assertSame('name', $searchNameParam->getProperty());
+
+        $searchProductNameParam = $parameters->get('search[product.name]');
+        $this->assertSame('product.name', $searchProductNameParam->getProperty());
+
+        $this->assertNotNull($searchProductNameParam);
+    }
+}
+
+// Test fixtures
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'search[:property]' => new QueryParameter(
+                    properties: ['name', 'product.name']
+                ),
+            ]
+        ),
+    ]
+)]
+class TestProductOrderResource
+{
+    public ?int $id = null;
+    public ?string $name = null;
+    public ?object $product = null;
+}

--- a/src/Laravel/Tests/NestedPropertyFilterTest.php
+++ b/src/Laravel/Tests/NestedPropertyFilterTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\Product;
+use Workbench\App\Models\ProductOrder;
+use Workbench\App\Models\ProductVariation;
+
+class NestedPropertyFilterTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config): void {
+            $config->set('api-platform.name_converter', null);
+            $config->set('api-platform.formats', ['jsonld' => ['application/ld+json']]);
+        });
+    }
+
+    public function testFilterByNestedPropertyWithSnakeCase(): void
+    {
+        // Create test data
+        $product1 = Product::create(['name' => 'Laptop', 'price' => 999.99]);
+        $product2 = Product::create(['name' => 'Mouse', 'price' => 29.99]);
+
+        ProductOrder::create([
+            'product_id' => $product1->id,
+            'quantity' => 2,
+            'customer_name' => 'John Doe',
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $product2->id,
+            'quantity' => 5,
+            'customer_name' => 'Jane Smith',
+        ]);
+
+        // First test: simple property filter (no nesting)
+        $response = $this->getJson('/api/product_orders?quantity=2', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'member');
+
+        // Test filtering by nested product.name (snake_case in DB)
+        $response = $this->getJson('/api/product_orders?product.name=Laptop', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'member');
+        $response->assertJsonPath('member.0.quantity', 2);
+    }
+
+    public function testFilterByDeeplyNestedPropertyWithSnakeCase(): void
+    {
+        // Create test data
+        $product1 = Product::create(['name' => 'Laptop', 'price' => 999.99]);
+        $product2 = Product::create(['name' => 'Keyboard', 'price' => 79.99]);
+
+        $variation1 = ProductVariation::create([
+            'product_id' => $product1->id,
+            'variant_name' => 'Gaming Edition',
+            'sku_code' => 'LAP-GAMING-001',
+            'price_adjustment' => 200.00,
+        ]);
+
+        $variation2 = ProductVariation::create([
+            'product_id' => $product2->id,
+            'variant_name' => 'Mechanical Blue',
+            'sku_code' => 'KEY-MECH-BLUE',
+            'price_adjustment' => 30.00,
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $product1->id,
+            'quantity' => 1,
+            'customer_name' => 'Gamer Pro',
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $product2->id,
+            'quantity' => 3,
+            'customer_name' => 'Office Supply',
+        ]);
+
+        // Test filtering by deeply nested product.productVariations.variantName
+        // This property path has snake_case columns: product_variations.variant_name
+        $response = $this->getJson('/api/product_orders?product.productVariations.variantName=Gaming%20Edition', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'member');
+        $response->assertJsonPath('member.0.quantity', 1);
+    }
+
+    public function testFilterByDeeplyNestedPropertySkuCodeWithSnakeCase(): void
+    {
+        // Create test data
+        $product = Product::create(['name' => 'Laptop', 'price' => 999.99]);
+
+        ProductVariation::create([
+            'product_id' => $product->id,
+            'variant_name' => 'Standard Edition',
+            'sku_code' => 'LAP-STD-001',
+            'price_adjustment' => 0,
+        ]);
+
+        ProductVariation::create([
+            'product_id' => $product->id,
+            'variant_name' => 'Pro Edition',
+            'sku_code' => 'LAP-PRO-001',
+            'price_adjustment' => 500.00,
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'customer_name' => 'Corporate Buyer',
+        ]);
+
+        // Test filtering by deeply nested product.productVariations.skuCode
+        // This tests: product_variations.sku_code (snake_case in DB)
+        $response = $this->getJson('/api/product_orders?product.productVariations.skuCode=LAP-PRO-001', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'member');
+        $response->assertJsonPath('member.0.quantity', 2);
+    }
+
+    public function testMultipleNestedFiltersWithSnakeCase(): void
+    {
+        // Create test data
+        $laptop = Product::create(['name' => 'Laptop', 'price' => 999.99]);
+        $mouse = Product::create(['name' => 'Mouse', 'price' => 29.99]);
+
+        ProductVariation::create([
+            'product_id' => $laptop->id,
+            'variant_name' => 'Gaming',
+            'sku_code' => 'LAP-GAME',
+            'price_adjustment' => 200.00,
+        ]);
+
+        ProductVariation::create([
+            'product_id' => $mouse->id,
+            'variant_name' => 'Gaming',
+            'sku_code' => 'MOU-GAME',
+            'price_adjustment' => 10.00,
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $laptop->id,
+            'quantity' => 1,
+            'customer_name' => 'Laptop Buyer',
+        ]);
+
+        ProductOrder::create([
+            'product_id' => $mouse->id,
+            'quantity' => 2,
+            'customer_name' => 'Mouse Buyer',
+        ]);
+
+        // Filter by both product.name AND product.productVariations.variantName
+        $response = $this->getJson('/api/product_orders?product.name=Laptop&product.productVariations.variantName=Gaming', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertJsonCount(1, 'member');
+        $response->assertJsonPath('member.0.quantity', 1);
+    }
+}

--- a/src/Laravel/workbench/app/ApiResource/ProductOrder.php
+++ b/src/Laravel/workbench/app/ApiResource/ProductOrder.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\ApiResource;
+
+use ApiPlatform\Laravel\Eloquent\Filter\EqualsFilter;
+use ApiPlatform\Laravel\Eloquent\State\Options;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Workbench\App\Models\ProductOrder as ProductOrderModel;
+
+#[ApiResource(
+    operations: [new GetCollection()],
+    stateOptions: new Options(modelClass: ProductOrderModel::class),
+)]
+#[QueryParameter(key: 'quantity', property: 'quantity', filter: EqualsFilter::class)]
+#[QueryParameter(key: 'product.name', property: 'product.name', filter: EqualsFilter::class)]
+#[QueryParameter(key: 'product.productVariations.variantName', property: 'product.productVariations.variantName', filter: EqualsFilter::class)]
+#[QueryParameter(key: 'product.productVariations.skuCode', property: 'product.productVariations.skuCode', filter: EqualsFilter::class)]
+class ProductOrder
+{
+    #[ApiProperty(readable: false, writable: false, identifier: true)]
+    public ?int $id = null;
+
+    #[ApiProperty(readable: false, writable: false)]
+    public ?Product $product = null;
+
+    public ?int $quantity = null;
+
+    public ?string $customerName = null;
+}

--- a/src/Laravel/workbench/app/ApiResource/ProductVariation.php
+++ b/src/Laravel/workbench/app/ApiResource/ProductVariation.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\ApiResource;
+
+use ApiPlatform\Laravel\Eloquent\State\Options;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Workbench\App\Models\ProductVariation as ProductVariationModel;
+
+#[ApiResource(
+    operations: [],
+    stateOptions: new Options(modelClass: ProductVariationModel::class),
+)]
+class ProductVariation
+{
+    #[ApiProperty(readable: false, writable: false, identifier: true)]
+    public ?int $id = null;
+
+    public ?int $productId = null;
+
+    public ?string $variantName = null;
+
+    public ?string $skuCode = null;
+
+    public ?float $priceAdjustment = null;
+}

--- a/src/Laravel/workbench/app/Models/Product.php
+++ b/src/Laravel/workbench/app/Models/Product.php
@@ -15,6 +15,7 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Product extends Model
 {
@@ -25,4 +26,14 @@ class Product extends Model
     protected $casts = [
         'price' => 'float',
     ];
+
+    public function productVariations(): HasMany
+    {
+        return $this->hasMany(ProductVariation::class);
+    }
+
+    public function productOrders(): HasMany
+    {
+        return $this->hasMany(ProductOrder::class);
+    }
 }

--- a/src/Laravel/workbench/app/Models/ProductOrder.php
+++ b/src/Laravel/workbench/app/Models/ProductOrder.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProductOrder extends Model
+{
+    protected $fillable = ['product_id', 'quantity', 'customer_name'];
+
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/src/Laravel/workbench/app/Models/ProductVariation.php
+++ b/src/Laravel/workbench/app/Models/ProductVariation.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProductVariation extends Model
+{
+    protected $fillable = ['product_id', 'variant_name', 'sku_code', 'price_adjustment'];
+
+    protected $casts = [
+        'price_adjustment' => 'float',
+    ];
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/src/Laravel/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Workbench\App\Providers;
 
+use ApiPlatform\Laravel\Eloquent\Filter\EqualsFilter;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Filesystem\Filesystem;
@@ -41,6 +42,7 @@ class WorkbenchServiceProvider extends ServiceProvider
         $this->app->singleton(MockPurger::class, static fn ($app) => new MockPurger());
         $this->app->singleton(DummyService::class, static fn ($app) => new DummyService($app['config']->get('api-platform.title')));
         $this->app->singleton(CustomProviderWithDependency::class, static fn ($app) => new CustomProviderWithDependency($app->make(DummyService::class)));
+        $this->app->singleton('app.exact_filter', static fn ($app) => new EqualsFilter());
     }
 
     /**

--- a/src/Laravel/workbench/database/migrations/2026_02_13_000000_create_variations_and_orders_table.php
+++ b/src/Laravel/workbench/database/migrations/2026_02_13_000000_create_variations_and_orders_table.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // Create variations table with snake_case columns
+        Schema::create('product_variations', static function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->string('variant_name'); // snake_case column
+            $table->string('sku_code'); // snake_case column
+            $table->decimal('price_adjustment', 10, 2)->default(0);
+            $table->timestamps();
+        });
+
+        // Create orders table that references products
+        Schema::create('product_orders', static function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->integer('quantity');
+            $table->string('customer_name'); // snake_case column
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_orders');
+        Schema::dropIfExists('product_variations');
+    }
+};

--- a/src/Metadata/Parameter.php
+++ b/src/Metadata/Parameter.php
@@ -21,8 +21,20 @@ use Symfony\Component\TypeInfo\Type;
 abstract class Parameter
 {
     /**
+     * @phpstan-type NestedPropertyInfo array{
+     *     relation_segments: list<string>,
+     *     converted_relation_segments: list<string>,
+     *     relation_classes: list<class-string>,
+     *     leaf_property: string,
+     *     leaf_class: class-string,
+     * }
+     *
+     * @param array{
+     *     nested_property_info?: NestedPropertyInfo,
+     *     nested_properties_info?: array<string, NestedPropertyInfo>,
+     *     ...
+     * }|array<string, mixed> $extraProperties
      * @param array<string, mixed>|null                       $schema
-     * @param array<string, mixed>                            $extraProperties
      * @param ParameterProviderInterface|callable|string|null $provider
      * @param list<string>                                    $properties       a list of properties this parameter applies to (works with the :property placeholder)
      * @param FilterInterface|string|null                     $filter

--- a/src/Metadata/Util/ResourceClassInfoTrait.php
+++ b/src/Metadata/Util/ResourceClassInfoTrait.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Util;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
+use Symfony\Component\TypeInfo\Type;
 
 /**
  * Retrieves information about a resource class.
@@ -62,5 +64,29 @@ trait ResourceClassInfoTrait
 
         // assume that it's a resource class
         return true;
+    }
+
+    private function getTypeFromProperty(ApiProperty $propertyMetadata): ?Type
+    {
+        return $propertyMetadata->getNativeType();
+    }
+
+    private function extractClassNameFromType(Type $type): ?string
+    {
+        return TypeHelper::getClassName(TypeHelper::getCollectionValueType($type) ?? $type);
+    }
+
+    /**
+     * Gets the class name from a property metadata if it's a resource class.
+     */
+    protected function getClassNameFromProperty(ApiProperty $propertyMetadata): ?string
+    {
+        if (!($type = $this->getTypeFromProperty($propertyMetadata))) {
+            return null;
+        }
+
+        $className = $this->extractClassNameFromType($type);
+
+        return $className && $this->isResourceClass($className) ? $className : null;
     }
 }

--- a/tests/Fixtures/TestBundle/Document/Chicken.php
+++ b/tests/Fixtures/TestBundle/Document/Chicken.php
@@ -18,31 +18,54 @@ use ApiPlatform\Doctrine\Odm\Filter\FreeTextQueryFilter;
 use ApiPlatform\Doctrine\Odm\Filter\IriFilter;
 use ApiPlatform\Doctrine\Odm\Filter\OrFilter;
 use ApiPlatform\Doctrine\Odm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 #[ODM\Document]
-#[GetCollection(
-    normalizationContext: ['hydra_prefix' => false],
-    parameters: [
-        'chickenCoop' => new QueryParameter(filter: new IriFilter()),
-        'chickenCoopNoProperty' => new QueryParameter(filter: new IriFilter()),
-        'chickenCoopId' => new QueryParameter(filter: new ExactFilter(), property: 'chickenCoop'),
-        'name' => new QueryParameter(filter: new ExactFilter()),
-        'nameExactNoProperty' => new QueryParameter(filter: new ExactFilter()),
-        'namePartial' => new QueryParameter(
-            filter: new PartialSearchFilter(false),
-            property: 'name',
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'chickenCoop' => new QueryParameter(filter: new IriFilter()),
+                'chickenCoopNoProperty' => new QueryParameter(filter: new IriFilter()),
+                'chickenCoopId' => new QueryParameter(filter: new ExactFilter(), property: 'chickenCoop'),
+                'name' => new QueryParameter(filter: new ExactFilter()),
+                'nameExactNoProperty' => new QueryParameter(filter: new ExactFilter()),
+                'namePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(false),
+                    property: 'name',
+                ),
+                'namePartialNoProperty' => new QueryParameter(filter: new PartialSearchFilter()),
+                'namePartialSensitive' => new QueryParameter(
+                    filter: new PartialSearchFilter(true),
+                    property: 'name',
+                ),
+                'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
+                'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
+                'ownerNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'owner.name',
+                ),
+                'searchOwnerNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['owner.name'],
+                ),
+                'ownerNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'owner.name',
+                ),
+                'searchOwnerNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['owner.name'],
+                ),
+            ],
         ),
-        'namePartialNoProperty' => new QueryParameter(filter: new PartialSearchFilter()),
-        'namePartialSensitive' => new QueryParameter(
-            filter: new PartialSearchFilter(true),
-            property: 'name',
-        ),
-        'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
-        'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
-    ],
+        new Get(),
+    ]
 )]
 class Chicken
 {
@@ -57,6 +80,9 @@ class Chicken
 
     #[ODM\ReferenceOne(targetDocument: ChickenCoop::class, inversedBy: 'chickens')]
     private ?ChickenCoop $chickenCoop = null;
+
+    #[ODM\EmbedOne(targetDocument: Owner::class)]
+    private ?Owner $owner = null;
 
     public function getId(): ?string
     {
@@ -95,6 +121,18 @@ class Chicken
     public function setChickenCoop(?ChickenCoop $chickenCoop): self
     {
         $this->chickenCoop = $chickenCoop;
+
+        return $this;
+    }
+
+    public function getOwner(): ?Owner
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?Owner $owner): self
+    {
+        $this->owner = $owner;
 
         return $this;
     }

--- a/tests/Fixtures/TestBundle/Document/ChickenCoop.php
+++ b/tests/Fixtures/TestBundle/Document/ChickenCoop.php
@@ -13,26 +13,99 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
+use ApiPlatform\Doctrine\Odm\Filter\ExactFilter;
+use ApiPlatform\Doctrine\Odm\Filter\FreeTextQueryFilter;
+use ApiPlatform\Doctrine\Odm\Filter\IriFilter;
+use ApiPlatform\Doctrine\Odm\Filter\OrFilter;
+use ApiPlatform\Doctrine\Odm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
 
 #[ODM\Document]
-#[GetCollection(
-    normalizationContext: ['hydra_prefix' => false]
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'chickenNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'chickens.name',
+                ),
+                'searchChickenNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['chickens.name'],
+                ),
+                'chickenNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'chickens.name',
+                ),
+                'searchChickenNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['chickens.name'],
+                ),
+                'chickenIri' => new QueryParameter(
+                    filter: new IriFilter(),
+                    property: 'chickenReferences',
+                ),
+                'searchChickenIri[:property]' => new QueryParameter(
+                    filter: new IriFilter(),
+                    properties: ['chickenReferences'],
+                ),
+                'q' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.name'],
+                ),
+                'chickenNameOrEan' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new OrFilter(new PartialSearchFilter())),
+                    properties: ['chickens.name', 'chickens.ean'],
+                ),
+                'qOwner' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.owner.name'],
+                ),
+                'searchQOwner[:property]' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.owner.name'],
+                ),
+                'chickenOwnerNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'chickens.owner.name',
+                ),
+                'searchChickenOwnerNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['chickens.owner.name'],
+                ),
+                'chickenOwnerNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'chickens.owner.name',
+                ),
+                'searchChickenOwnerNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['chickens.owner.name'],
+                ),
+            ],
+        ),
+    ]
 )]
 class ChickenCoop
 {
     #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
     private ?int $id = null;
 
-    #[ODM\ReferenceMany(targetDocument: Chicken::class, mappedBy: 'chickenCoop')]
+    #[ODM\EmbedMany(targetDocument: Chicken::class)]
     private Collection $chickens;
+
+    #[ODM\ReferenceMany(targetDocument: Chicken::class, cascade: 'all')]
+    private Collection $chickenReferences;
 
     public function __construct()
     {
         $this->chickens = new ArrayCollection();
+        $this->chickenReferences = new ArrayCollection();
     }
 
     public function getId(): ?int
@@ -65,6 +138,30 @@ class ChickenCoop
                 $chicken->setChickenCoop(null);
             }
         }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Chicken>
+     */
+    public function getChickenReferences(): Collection
+    {
+        return $this->chickenReferences;
+    }
+
+    public function addChickenReference(Chicken $chicken): self
+    {
+        if (!$this->chickenReferences->contains($chicken)) {
+            $this->chickenReferences[] = $chicken;
+        }
+
+        return $this;
+    }
+
+    public function removeChickenReference(Chicken $chicken): self
+    {
+        $this->chickenReferences->removeElement($chicken);
 
         return $this;
     }

--- a/tests/Fixtures/TestBundle/Document/Owner.php
+++ b/tests/Fixtures/TestBundle/Document/Owner.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * @author Maxence Castel <maxence.castel59@gmail.com>
+ */
+#[ODM\Document]
+#[ApiResource]
+class Owner
+{
+    #[ODM\Id(type: 'int', strategy: 'INCREMENT')]
+    private ?int $id = null;
+
+    #[ODM\Field(type: 'string')]
+    private string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Chicken.php
+++ b/tests/Fixtures/TestBundle/Entity/Chicken.php
@@ -18,31 +18,54 @@ use ApiPlatform\Doctrine\Orm\Filter\FreeTextQueryFilter;
 use ApiPlatform\Doctrine\Orm\Filter\IriFilter;
 use ApiPlatform\Doctrine\Orm\Filter\OrFilter;
 use ApiPlatform\Doctrine\Orm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-#[GetCollection(
-    normalizationContext: ['hydra_prefix' => false],
-    parameters: [
-        'chickenCoop' => new QueryParameter(filter: new IriFilter()),
-        'chickenCoopNoProperty' => new QueryParameter(filter: new IriFilter()),
-        'chickenCoopId' => new QueryParameter(filter: new ExactFilter(), property: 'chickenCoop'),
-        'name' => new QueryParameter(filter: new ExactFilter()),
-        'nameExactNoProperty' => new QueryParameter(filter: new ExactFilter()),
-        'namePartial' => new QueryParameter(
-            filter: new PartialSearchFilter(),
-            property: 'name',
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'chickenCoop' => new QueryParameter(filter: new IriFilter()),
+                'chickenCoopNoProperty' => new QueryParameter(filter: new IriFilter()),
+                'chickenCoopId' => new QueryParameter(filter: new ExactFilter(), property: 'chickenCoop'),
+                'name' => new QueryParameter(filter: new ExactFilter()),
+                'nameExactNoProperty' => new QueryParameter(filter: new ExactFilter()),
+                'namePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'name',
+                ),
+                'namePartialNoProperty' => new QueryParameter(filter: new PartialSearchFilter()),
+                'namePartialSensitive' => new QueryParameter(
+                    filter: new PartialSearchFilter(true),
+                    property: 'name',
+                ),
+                'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
+                'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
+                'ownerNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'owner.name',
+                ),
+                'searchOwnerNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['owner.name'],
+                ),
+                'ownerNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'owner.name',
+                ),
+                'searchOwnerNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['owner.name'],
+                ),
+            ],
         ),
-        'namePartialNoProperty' => new QueryParameter(filter: new PartialSearchFilter()),
-        'namePartialSensitive' => new QueryParameter(
-            filter: new PartialSearchFilter(true),
-            property: 'name',
-        ),
-        'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
-        'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
-    ],
+        new Get(),
+    ]
 )]
 class Chicken
 {
@@ -60,6 +83,10 @@ class Chicken
     #[ORM\ManyToOne(targetEntity: ChickenCoop::class, inversedBy: 'chickens')]
     #[ORM\JoinColumn(nullable: false)]
     private ChickenCoop $chickenCoop;
+
+    #[ORM\ManyToOne(targetEntity: Owner::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?Owner $owner = null;
 
     public function getId(): ?int
     {
@@ -98,6 +125,18 @@ class Chicken
     public function setChickenCoop(?ChickenCoop $chickenCoop): self
     {
         $this->chickenCoop = $chickenCoop;
+
+        return $this;
+    }
+
+    public function getOwner(): ?Owner
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?Owner $owner): self
+    {
+        $this->owner = $owner;
 
         return $this;
     }

--- a/tests/Fixtures/TestBundle/Entity/ChickenCoop.php
+++ b/tests/Fixtures/TestBundle/Entity/ChickenCoop.php
@@ -13,14 +13,83 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
+use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
+use ApiPlatform\Doctrine\Orm\Filter\FreeTextQueryFilter;
+use ApiPlatform\Doctrine\Orm\Filter\IriFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrFilter;
+use ApiPlatform\Doctrine\Orm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-#[GetCollection(
-    normalizationContext: ['hydra_prefix' => false],
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'chickenNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'chickens.name',
+                ),
+                'searchChickenNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['chickens.name'],
+                ),
+                'chickenNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'chickens.name',
+                ),
+                'searchChickenNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['chickens.name'],
+                ),
+                'chickenIri' => new QueryParameter(
+                    filter: new IriFilter(),
+                    property: 'chickens',
+                ),
+                'searchChickenIri[:property]' => new QueryParameter(
+                    filter: new IriFilter(),
+                    properties: ['chickens'],
+                ),
+                'q' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.name'],
+                ),
+                'chickenNameOrEan' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new OrFilter(new PartialSearchFilter())),
+                    properties: ['chickens.name', 'chickens.ean'],
+                ),
+                'qOwner' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.owner.name'],
+                ),
+                'searchQOwner[:property]' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new PartialSearchFilter()),
+                    properties: ['chickens.owner.name'],
+                ),
+                'chickenOwnerNamePartial' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    property: 'chickens.owner.name',
+                ),
+                'searchChickenOwnerNamePartial[:property]' => new QueryParameter(
+                    filter: new PartialSearchFilter(),
+                    properties: ['chickens.owner.name'],
+                ),
+                'chickenOwnerNameExact' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'chickens.owner.name',
+                ),
+                'searchChickenOwnerNameExact[:property]' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    properties: ['chickens.owner.name'],
+                ),
+            ],
+        ),
+    ]
 )]
 class ChickenCoop
 {

--- a/tests/Fixtures/TestBundle/Entity/Owner.php
+++ b/tests/Fixtures/TestBundle/Entity/Owner.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Maxence Castel <maxence.castel59@gmail.com>
+ */
+#[ORM\Entity]
+#[ApiResource]
+class Owner
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Functional/Parameters/FreeTextQueryFilterTest.php
+++ b/tests/Functional/Parameters/FreeTextQueryFilterTest.php
@@ -16,8 +16,10 @@ namespace ApiPlatform\Tests\Functional\Parameters;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Chicken as DocumentChicken;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ChickenCoop as DocumentChickenCoop;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Owner as DocumentOwner;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Chicken;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ChickenCoop;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Owner;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Doctrine\ODM\MongoDB\MongoDBException;
@@ -34,7 +36,7 @@ final class FreeTextQueryFilterTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [ChickenCoop::class, Chicken::class];
+        return [ChickenCoop::class, Chicken::class, Owner::class];
     }
 
     public function testFreeTextQueryFilter(): void
@@ -44,12 +46,90 @@ final class FreeTextQueryFilterTest extends ApiTestCase
         $this->assertJsonContains(['totalItems' => 1]);
     }
 
+    public function testFreeTextQueryFilterWithOneToManyRelation(): void
+    {
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?q=Gertrude')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertCount(1, $response['member']);
+        $this->assertArrayHasKey('chickens', $response['member'][0]);
+    }
+
+    public function testFreeTextQueryFilterWithOneToManyRelationNoMatch(): void
+    {
+        $client = $this->createClient();
+
+        $client->request('GET', '/chicken_coops?q=nonExistentChicken')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    public function testFreeTextQueryFilterWithOneToManyRelationMultipleMatches(): void
+    {
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?q=ette')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+    }
+
+    public function testFreeTextQueryFilterWithTwoLevelTraversalPartial(): void
+    {
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?qOwner=Alice')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?qOwner=Bob')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?qOwner=ob')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+    }
+
+    public function testFreeTextQueryFilterWithTwoLevelTraversalPartialWithPropertyPlaceholder(): void
+    {
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?searchQOwner[chickens.owner.name]=Alice')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?searchQOwner[chickens.owner.name]=Bob')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chicken_coops?searchQOwner[chickens.owner.name]=ob')->toArray();
+
+        $this->assertJsonContains(['totalItems' => 2]);
+        $this->assertCount(2, $response['member']);
+    }
+
     /**
      * @throws \Throwable
      */
     protected function setUp(): void
     {
-        $this->recreateSchema([$this->isMongoDB() ? DocumentChicken::class : Chicken::class, $this->isMongoDB() ? DocumentChickenCoop::class : ChickenCoop::class]);
+        $this->recreateSchema([$this->isMongoDB() ? DocumentChicken::class : Chicken::class, $this->isMongoDB() ? DocumentChickenCoop::class : ChickenCoop::class, $this->isMongoDB() ? DocumentOwner::class : Owner::class]);
         $this->loadFixtures();
     }
 
@@ -62,27 +142,58 @@ final class FreeTextQueryFilterTest extends ApiTestCase
         $manager = $this->getManager();
         $chickenClass = $this->isMongoDB() ? DocumentChicken::class : Chicken::class;
         $coopClass = $this->isMongoDB() ? DocumentChickenCoop::class : ChickenCoop::class;
+        $ownerClass = $this->isMongoDB() ? DocumentOwner::class : Owner::class;
+
+        $owner1 = new $ownerClass();
+        $owner1->setName('Alice');
+
+        $owner2 = new $ownerClass();
+        $owner2->setName('Bob');
+
+        $manager->persist($owner1);
+        $manager->persist($owner2);
+        $manager->flush();
 
         $chickenCoop1 = new $coopClass();
         $chickenCoop2 = new $coopClass();
+        $chickenCoop3 = new $coopClass();
 
         $chicken1 = new $chickenClass();
         $chicken1->setName('978020137962');
         $chicken1->setEan('978020137962');
         $chicken1->setChickenCoop($chickenCoop1);
+        $chicken1->setOwner($owner1);
 
         $chicken2 = new $chickenClass();
         $chicken2->setName('Henriette');
         $chicken2->setEan('978020137963');
         $chicken2->setChickenCoop($chickenCoop2);
+        $chicken2->setOwner($owner2);
+
+        $chicken3 = new $chickenClass();
+        $chicken3->setName('Gertrude');
+        $chicken3->setEan('978020137964');
+        $chicken3->setChickenCoop($chickenCoop3);
+        $chicken3->setOwner($owner1);
+
+        $chicken4 = new $chickenClass();
+        $chicken4->setName('Violette');
+        $chicken4->setEan('978020137965');
+        $chicken4->setChickenCoop($chickenCoop3);
+        $chicken4->setOwner($owner2);
 
         $chickenCoop1->addChicken($chicken1);
         $chickenCoop2->addChicken($chicken2);
+        $chickenCoop3->addChicken($chicken3);
+        $chickenCoop3->addChicken($chicken4);
 
         $manager->persist($chicken1);
         $manager->persist($chicken2);
+        $manager->persist($chicken3);
+        $manager->persist($chicken4);
         $manager->persist($chickenCoop1);
         $manager->persist($chickenCoop2);
+        $manager->persist($chickenCoop3);
         $manager->flush();
     }
 }

--- a/tests/Functional/Parameters/PartialSearchFilterTest.php
+++ b/tests/Functional/Parameters/PartialSearchFilterTest.php
@@ -16,8 +16,10 @@ namespace ApiPlatform\Tests\Functional\Parameters;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\Chicken as DocumentChicken;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\ChickenCoop as DocumentChickenCoop;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Owner as DocumentOwner;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Chicken;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ChickenCoop;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Owner;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Doctrine\ODM\MongoDB\MongoDBException;
@@ -38,7 +40,7 @@ final class PartialSearchFilterTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [Chicken::class, ChickenCoop::class];
+        return [Chicken::class, ChickenCoop::class, Owner::class];
     }
 
     /**
@@ -47,8 +49,8 @@ final class PartialSearchFilterTest extends ApiTestCase
     protected function setUp(): void
     {
         $entities = $this->isMongoDB()
-            ? [DocumentChicken::class, DocumentChickenCoop::class]
-            : [Chicken::class, ChickenCoop::class];
+            ? [DocumentChicken::class, DocumentChickenCoop::class, DocumentOwner::class]
+            : [Chicken::class, ChickenCoop::class, Owner::class];
 
         $this->recreateSchema($entities);
         $this->loadFixtures();
@@ -141,6 +143,208 @@ final class PartialSearchFilterTest extends ApiTestCase
         ];
     }
 
+    #[DataProvider('partialSearchFilterWithOneToManyRelationProvider')]
+    public function testPartialSearchFilterWithOneToManyRelation(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredCoops = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredCoops, \sprintf('Expected %d coops for URL %s', $expectedCount, $url));
+
+        $allChickenNames = [];
+        foreach ($filteredCoops as $coop) {
+            foreach ($coop['chickens'] as $chickenIri) {
+                $chickenResponse = self::createClient()->request('GET', $chickenIri);
+                $chickenData = $chickenResponse->toArray();
+                $allChickenNames[] = $chickenData['name'];
+            }
+        }
+
+        sort($allChickenNames);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $allChickenNames, 'The chicken names in coops do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithOneToManyRelationProvider(): \Generator
+    {
+        yield 'filter coops by chicken name (chickens.name) containing "ertrude"' => [
+            '/chicken_coops?chickenNamePartial=ertrude',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) containing "riette"' => [
+            '/chicken_coops?chickenNamePartial=riette',
+            1,
+            ['Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) containing "e"' => [
+            '/chicken_coops?chickenNamePartial=e',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with no matching entities' => [
+            '/chicken_coops?chickenNamePartial=Zebra',
+            0,
+            [],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "xx"' => [
+            '/chicken_coops?chickenNamePartial=xx',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names "rude" OR "iette"' => [
+            '/chicken_coops?chickenNamePartial[]=rude&chickenNamePartial[]=iette',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names, one matching "Gert," the other not matching "Zebra"' => [
+            '/chicken_coops?chickenNamePartial[]=Gert&chickenNamePartial[]=Zebra',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names without matches' => [
+            '/chicken_coops?chickenNamePartial[]=Toto&chickenNamePartial[]=Match',
+            0,
+            [],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "%"' => [
+            '/chicken_coops?chickenNamePartial=%25',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "_"' => [
+            '/chicken_coops?chickenNamePartial=%5F',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "\\"' => [
+            '/chicken_coops?chickenNamePartial=%5C',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "\\_"' => [
+            '/chicken_coops?chickenNamePartial=%5C%5F',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+    }
+
+    #[DataProvider('partialSearchFilterWithOneToManyRelationWithPropertyPlaceholderProvider')]
+    public function testPartialSearchFilterWithOneToManyRelationWithPropertyPlaceholder(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredCoops = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredCoops, \sprintf('Expected %d coops for URL %s', $expectedCount, $url));
+
+        $allChickenNames = [];
+        foreach ($filteredCoops as $coop) {
+            foreach ($coop['chickens'] as $chickenIri) {
+                $chickenResponse = self::createClient()->request('GET', $chickenIri);
+                $chickenData = $chickenResponse->toArray();
+                $allChickenNames[] = $chickenData['name'];
+            }
+        }
+
+        sort($allChickenNames);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $allChickenNames, 'The chicken names in coops do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithOneToManyRelationWithPropertyPlaceholderProvider(): \Generator
+    {
+        yield 'filter coops by chicken name (chickens.name) containing "ertrude" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=ertrude',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) containing "riette" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=riette',
+            1,
+            ['Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) containing "e" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=e',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with no matching entities using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=Zebra',
+            0,
+            [],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "xx" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=xx',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names "rude" OR "iette" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name][]=rude&searchChickenNamePartial[chickens.name][]=iette',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names, one matching "Gert," the other not matching "Zebra" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name][]=Gert&searchChickenNamePartial[chickens.name][]=Zebra',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) with multiple partial names without matches using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name][]=Toto&searchChickenNamePartial[chickens.name][]=Match',
+            0,
+            [],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "%" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=%25',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "_" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=%5F',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "\\" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=%5C',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken name (chickens.name) "\\_" using :property placeholder' => [
+            '/chicken_coops?searchChickenNamePartial[chickens.name]=%5C%5F',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+    }
+
     #[DataProvider('partialSearchMultiByteFilterProvider')]
     public function testPartialSearchMultiByteFilter(string $url, int $expectedCount, array $expectedNames): void
     {
@@ -175,6 +379,178 @@ final class PartialSearchFilterTest extends ApiTestCase
             '/chickens?namePartial[]=g%C3%99',
             1,
             ['GÀgù'],
+        ];
+    }
+
+    #[DataProvider('partialSearchFilterWithTwoLevelTraversalProvider')]
+    public function testPartialSearchFilterWithTwoLevelTraversal(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredCoops = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredCoops, \sprintf('Expected %d coops for URL %s', $expectedCount, $url));
+
+        $allChickenNames = [];
+        foreach ($filteredCoops as $coop) {
+            foreach ($coop['chickens'] as $chickenIri) {
+                $chickenResponse = self::createClient()->request('GET', $chickenIri);
+                $chickenData = $chickenResponse->toArray();
+                $allChickenNames[] = $chickenData['name'];
+            }
+        }
+
+        sort($allChickenNames);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $allChickenNames, 'The chicken names in coops do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithTwoLevelTraversalProvider(): \Generator
+    {
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "Alice"' => [
+            '/chicken_coops?chickenOwnerNamePartial=Alice',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "Bob"' => [
+            '/chicken_coops?chickenOwnerNamePartial=Bob',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "b"' => [
+            '/chicken_coops?chickenOwnerNamePartial=b',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+    }
+
+    #[DataProvider('partialSearchFilterWithTwoLevelTraversalWithPropertyPlaceholderProvider')]
+    public function testPartialSearchFilterWithTwoLevelTraversalWithPropertyPlaceholder(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredCoops = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredCoops, \sprintf('Expected %d coops for URL %s', $expectedCount, $url));
+
+        $allChickenNames = [];
+        foreach ($filteredCoops as $coop) {
+            foreach ($coop['chickens'] as $chickenIri) {
+                $chickenResponse = self::createClient()->request('GET', $chickenIri);
+                $chickenData = $chickenResponse->toArray();
+                $allChickenNames[] = $chickenData['name'];
+            }
+        }
+
+        sort($allChickenNames);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $allChickenNames, 'The chicken names in coops do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithTwoLevelTraversalWithPropertyPlaceholderProvider(): \Generator
+    {
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "Alice" using :property placeholder' => [
+            '/chicken_coops?searchChickenOwnerNamePartial[chickens.owner.name]=Alice',
+            1,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù'],
+        ];
+
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "Bob" using :property placeholder' => [
+            '/chicken_coops?searchChickenOwnerNamePartial[chickens.owner.name]=Bob',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+
+        yield 'filter coops by chicken owner name (chickens.owner.name) containing "b" using :property placeholder' => [
+            '/chicken_coops?searchChickenOwnerNamePartial[chickens.owner.name]=b',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx', 'GÀgù', 'Henriette'],
+        ];
+    }
+
+    #[DataProvider('partialSearchFilterWithManyToOneRelationProvider')]
+    public function testPartialSearchFilterWithManyToOneRelation(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredChickens = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredChickens, \sprintf('Expected %d chickens for URL %s', $expectedCount, $url));
+
+        $names = array_map(static fn ($chicken) => $chicken['name'], $filteredChickens);
+        sort($names);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $names, 'The chicken names do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithManyToOneRelationProvider(): \Generator
+    {
+        yield 'filter chickens by owner name (owner.name) containing "Alice"' => [
+            '/chickens?ownerNamePartial=Alice',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx'],
+        ];
+
+        yield 'filter chickens by owner name (owner.name) containing "Bob"' => [
+            '/chickens?ownerNamePartial=Bob',
+            2,
+            ['Henriette', 'GÀgù'],
+        ];
+
+        yield 'filter chickens by owner name (owner.name) containing "b"' => [
+            '/chickens?ownerNamePartial=b',
+            2,
+            ['Henriette', 'GÀgù'],
+        ];
+    }
+
+    #[DataProvider('partialSearchFilterWithManyToOneRelationWithPropertyPlaceholderProvider')]
+    public function testPartialSearchFilterWithManyToOneRelationWithPropertyPlaceholder(string $url, int $expectedCount, array $expectedChickenNames): void
+    {
+        $response = self::createClient()->request('GET', $url);
+        $this->assertResponseIsSuccessful();
+
+        $responseData = $response->toArray();
+        $filteredChickens = $responseData['member'];
+
+        $this->assertCount($expectedCount, $filteredChickens, \sprintf('Expected %d chickens for URL %s', $expectedCount, $url));
+
+        $names = array_map(static fn ($chicken) => $chicken['name'], $filteredChickens);
+        sort($names);
+        sort($expectedChickenNames);
+
+        $this->assertSame($expectedChickenNames, $names, 'The chicken names do not match the expected values.');
+    }
+
+    public static function partialSearchFilterWithManyToOneRelationWithPropertyPlaceholderProvider(): \Generator
+    {
+        yield 'filter chickens by owner name (owner.name) containing "Alice" using :property placeholder' => [
+            '/chickens?searchOwnerNamePartial[owner.name]=Alice',
+            2,
+            ['Gertrude', 'xx_%_\\_%_xx'],
+        ];
+
+        yield 'filter chickens by owner name (owner.name) containing "Bob" using :property placeholder' => [
+            '/chickens?searchOwnerNamePartial[owner.name]=Bob',
+            2,
+            ['Henriette', 'GÀgù'],
+        ];
+
+        yield 'filter chickens by owner name (owner.name) containing "b" using :property placeholder' => [
+            '/chickens?searchOwnerNamePartial[owner.name]=b',
+            2,
+            ['Henriette', 'GÀgù'],
         ];
     }
 
@@ -240,6 +616,17 @@ final class PartialSearchFilterTest extends ApiTestCase
 
         $chickenClass = $this->isMongoDB() ? DocumentChicken::class : Chicken::class;
         $coopClass = $this->isMongoDB() ? DocumentChickenCoop::class : ChickenCoop::class;
+        $ownerClass = $this->isMongoDB() ? DocumentOwner::class : Owner::class;
+
+        $owner1 = new $ownerClass();
+        $owner1->setName('Alice');
+
+        $owner2 = new $ownerClass();
+        $owner2->setName('Bob');
+
+        $manager->persist($owner1);
+        $manager->persist($owner2);
+        $manager->flush();
 
         $chickenCoop1 = new $coopClass();
         $chickenCoop2 = new $coopClass();
@@ -247,18 +634,22 @@ final class PartialSearchFilterTest extends ApiTestCase
         $chicken1 = new $chickenClass();
         $chicken1->setName('Gertrude');
         $chicken1->setChickenCoop($chickenCoop1);
+        $chicken1->setOwner($owner1);
 
         $chicken2 = new $chickenClass();
         $chicken2->setName('Henriette');
         $chicken2->setChickenCoop($chickenCoop2);
+        $chicken2->setOwner($owner2);
 
         $chicken3 = new $chickenClass();
         $chicken3->setName('xx_%_\\_%_xx');
         $chicken3->setChickenCoop($chickenCoop1);
+        $chicken3->setOwner($owner1);
 
         $chicken4 = new $chickenClass();
         $chicken4->setName('GÀgù');
         $chicken4->setChickenCoop($chickenCoop1);
+        $chicken4->setOwner($owner2);
 
         $chickenCoop1->addChicken($chicken1);
         $chickenCoop1->addChicken($chicken3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main <!-- see below -->
| Tickets       | . <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | . <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

## Description

This PR introduces support for relation traversal in the following filters:
- PartialSearchFilter
- ExactFilter
- OrFilter
- FreeTextQueryFilter

It allows filtering across nested associations.

## Exemples

### OneToMany relation filtering

Filter on a related entity property using `property` parameter:

```php
new QueryParameter(
    filter: new PartialSearchFilter(),
    property: 'chickens.name',
),
```

### Multi-level relation traversal

Filter on deeply nested properties:

```php
new QueryParameter(
    filter: new PartialSearchFilter(),
    property: 'chickens.owner.name',
),
```

### Multiple properties with placeholder

Filter using the `:property` placeholder:

```php
'search[:property]' => new QueryParameter(
    filter: new PartialSearchFilter(),
    properties: ['chickens.name', 'chickens.ean'],
),
```