### PR TITLE
Add a maker to create an API Resource

### DIFF
--- a/src/Symfony/Bundle/Resources/config/maker.php
+++ b/src/Symfony/Bundle/Resources/config/maker.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use ApiPlatform\Symfony\Maker\MakeApiResource;
 use ApiPlatform\Symfony\Maker\MakeFilter;
 use ApiPlatform\Symfony\Maker\MakeStateProcessor;
 use ApiPlatform\Symfony\Maker\MakeStateProvider;
@@ -29,6 +30,10 @@ return static function (ContainerConfigurator $container) {
         ->tag('maker.command');
 
     $services->set('api_platform.maker.command.filter', MakeFilter::class)
+        ->args([param('api_platform.maker.namespace_prefix')])
+        ->tag('maker.command');
+
+    $services->set('api_platform.maker.command.api_resource', MakeApiResource::class)
         ->args([param('api_platform.maker.namespace_prefix')])
         ->tag('maker.command');
 };

--- a/src/Symfony/Maker/MakeApiResource.php
+++ b/src/Symfony/Maker/MakeApiResource.php
@@ -1,0 +1,292 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Maker;
+
+use Symfony\Bundle\MakerBundle\ConsoleStyle;
+use Symfony\Bundle\MakerBundle\DependencyBuilder;
+use Symfony\Bundle\MakerBundle\Generator;
+use Symfony\Bundle\MakerBundle\InputConfiguration;
+use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+final class MakeApiResource extends AbstractMaker
+{
+    private const OPERATION_CHOICES = [
+        'Get',
+        'GetCollection',
+        'Post',
+        'Put',
+        'Patch',
+        'Delete',
+    ];
+
+    private const FIELD_TYPES = [
+        'string',
+        'int',
+        'float',
+        'bool',
+        'array',
+        \DateTimeImmutable::class,
+    ];
+
+    public function __construct(private readonly string $namespacePrefix = '')
+    {
+    }
+
+    public static function getCommandName(): string
+    {
+        return 'make:api-resource';
+    }
+
+    public static function getCommandDescription(): string
+    {
+        return 'Creates an API Platform resource';
+    }
+
+    public function configureCommand(Command $command, InputConfiguration $inputConfig): void
+    {
+        $command
+            ->addArgument('name', InputArgument::REQUIRED, 'Choose a class name for your API resource (e.g. <fg=yellow>BookResource</>)')
+            ->addOption('namespace-prefix', 'p', InputOption::VALUE_REQUIRED, 'Specify the namespace prefix to use for the resource class', $this->namespacePrefix.'ApiResource')
+            ->setHelp(file_get_contents(__DIR__.'/Resources/help/MakeApiResource.txt'));
+    }
+
+    public function configureDependencies(DependencyBuilder $dependencies): void
+    {
+    }
+
+    public function generate(InputInterface $input, ConsoleStyle $io, Generator $generator): void
+    {
+        $namespacePrefix = trim($input->getOption('namespace-prefix'), '\\').'\\';
+
+        [$fields, $validatedFields] = $this->getFields($io);
+
+        $operations = $this->getOperations($io);
+
+        [$providerClass, $providerShort] = $this->getStateProvider($io, $input, $generator, $operations);
+        [$processorClass, $processorShort] = $this->getStateProcessor($io, $input, $generator, $operations);
+
+        $resourceDetails = $generator->createClassNameDetails($input->getArgument('name'), $namespacePrefix);
+
+        $generator->generateClass(
+            $resourceDetails->getFullName(),
+            __DIR__.'/Resources/skeleton/ApiResource.php.tpl',
+            [
+                'fields' => $fields,
+                'operations' => $operations,
+                'has_validator' => class_exists(NotBlank::class) && \count($validatedFields) > 0,
+                'validated_fields' => $validatedFields,
+                'provider_class' => $providerClass,
+                'provider_short' => $providerShort,
+                'processor_class' => $processorClass,
+                'processor_short' => $processorShort,
+            ],
+        );
+
+        if ($providerClass) {
+            $generator->generateClass(
+                $providerClass,
+                __DIR__.'/Resources/skeleton/ApiResourceStateProvider.php.tpl',
+                [
+                    'operations' => $operations,
+                ]
+            );
+        }
+
+        if ($processorClass) {
+            $generator->generateClass(
+                $processorClass,
+                __DIR__.'/Resources/skeleton/ApiResourceStateProcessor.php.tpl',
+                [
+                    'operations' => $operations,
+                ]
+            );
+        }
+
+        $generator->writeChanges();
+
+        $this->writeSuccessMessage($io);
+
+        $generatedFiles = [$resourceDetails->getFullName()];
+        if ($providerClass) {
+            $generatedFiles[] = $providerClass;
+        }
+        if ($processorClass) {
+            $generatedFiles[] = $processorClass;
+        }
+
+        $io->text([
+            'Generated classes:',
+            ...array_map(static fn (string $class) => \sprintf(' - <info>%s</info>', $class), $generatedFiles),
+        ]);
+    }
+
+    private function getFields(ConsoleStyle $io): array
+    {
+        $fields = [];
+        $validatedFields = [];
+        $io->writeln('');
+        $io->writeln('Add fields to your API resource (press <info>enter</info> with an empty name to stop):');
+        while (true) {
+            $fieldName = $io->ask('Field name (press <info>enter</info> to stop adding fields)');
+            if (!$fieldName) {
+                break;
+            }
+
+            $question = new Question('Field type (enter <comment>?</comment> to see types)', 'string');
+            $question->setAutocompleterValues(self::FIELD_TYPES);
+            $fieldType = $io->askQuestion($question);
+
+            if ('?' === $fieldType) {
+                foreach (self::FIELD_TYPES as $item) {
+                    $io->writeln(\sprintf(' * <comment>%s</>', $item));
+                }
+                $fieldType = null;
+                continue;
+            }
+
+            if ($fieldType && class_exists('\\'.$fieldType) && \in_array('\\'.$fieldType, self::FIELD_TYPES, true)) {
+                $fieldType = '\\'.$fieldType;
+            }
+
+            do {
+                if ($fieldType && !\in_array($fieldType, self::FIELD_TYPES, true)) {
+                    foreach ($fieldType as $item) {
+                        $io->writeln(\sprintf(' * <comment>%s</>', $item));
+                    }
+                    $io->error(\sprintf('Invalid field type "%s".', $fieldType));
+                    $io->writeln('');
+                    $fieldType = null;
+                }
+            } while (null === $fieldType);
+
+            $nullable = $io->confirm('Can this field be null?', false);
+
+            if (!$nullable && $io->confirm('Should this field be validated as not blank/not null?', true)) {
+                if (!class_exists(NotBlank::class)) {
+                    $io->warning('symfony/validator is not installed. Skipping validation constraint.');
+                } else {
+                    $validatedFields[] = $fieldName;
+                }
+            }
+
+            $fields[] = [
+                'name' => $fieldName,
+                'type' => $fieldType,
+                'nullable' => $nullable,
+            ];
+        }
+
+        return [$fields, $validatedFields];
+    }
+
+    /**
+     * @return string[] $operations
+     */
+    private function getOperations(ConsoleStyle $io): array
+    {
+        $operations = [];
+
+        $io->writeln('');
+        $io->writeln('Select operations for your API resource:');
+        while (true) {
+            $remaining = array_values(array_diff(self::OPERATION_CHOICES, $operations));
+            if (0 === \count($remaining)) {
+                break;
+            }
+
+            $question = new Question('Add operation (enter <comment>?</comment> to see all operations, leave empty to skip)');
+            $question->setAutocompleterValues($remaining);
+            $operation = $io->askQuestion($question);
+
+            if (null === $operation) {
+                break;
+            }
+
+            if ('?' === $operation) {
+                foreach ($remaining as $item) {
+                    $io->writeln(\sprintf(' * <comment>%s</>', $item));
+                }
+                $operation = null;
+                continue;
+            }
+
+            if ($operation && !\in_array($operation, $remaining, true)) {
+                foreach ($remaining as $item) {
+                    $io->writeln(\sprintf(' * <comment>%s</>', $item));
+                }
+                $io->error(\sprintf('Invalid operation "%s".', $operation));
+                $io->writeln('');
+                $operation = null;
+                continue;
+            }
+
+            $operations[] = $operation;
+            $io->writeln(\sprintf(' <info>✓</info> Added <comment>%s</comment> operation', $operation));
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @param string[] $operations
+     *
+     * @return array [?string, ?string]
+     */
+    private function getStateProvider(ConsoleStyle $io, InputInterface $input, Generator $generator, array $operations): array
+    {
+        $providerClass = null;
+        $providerShort = null;
+
+        if ($io->confirm('Do you want to create a StateProvider?', false)) {
+            $providerName = $input->getArgument('name');
+            if (!str_ends_with($providerName, 'Provider')) {
+                $providerName .= 'Provider';
+            }
+            $providerDetails = $generator->createClassNameDetails($providerName, $this->namespacePrefix.'State\\');
+            $providerClass = $providerDetails->getFullName();
+            $providerShort = $providerDetails->getShortName();
+        }
+
+        return [$providerClass, $providerShort];
+    }
+
+    /**
+     * @param string[] $operations
+     *
+     * @return array [?string, ?string]
+     */
+    private function getStateProcessor(ConsoleStyle $io, InputInterface $input, Generator $generator, array $operations): array
+    {
+        $processorClass = null;
+        $processorShort = null;
+
+        if ($io->confirm('Do you want to create a StateProcessor?', false)) {
+            $processorName = $input->getArgument('name');
+            if (!str_ends_with($processorName, 'Processor')) {
+                $processorName .= 'Processor';
+            }
+            $processorDetails = $generator->createClassNameDetails($processorName, $this->namespacePrefix.'State\\');
+            $processorClass = $processorDetails->getFullName();
+            $processorShort = $processorDetails->getShortName();
+        }
+
+        return [$processorClass, $processorShort];
+    }
+}

--- a/src/Symfony/Maker/Resources/help/MakeApiResource.txt
+++ b/src/Symfony/Maker/Resources/help/MakeApiResource.txt
@@ -1,0 +1,7 @@
+The <info>%command.name%</info> command generates a new API Platform ApiResource class (DTO) with optional fields, operations, state provider, and state processor.
+
+<info>php %command.full_name% BookResource</info>
+
+If the argument is missing, the command will ask for the class name interactively.
+
+The command will guide you through adding <info>fields</info>, selecting <info>operations</info>, and optionally generating a <info>StateProvider</info> and <info>StateProcessor</info>.

--- a/src/Symfony/Maker/Resources/skeleton/ApiResource.php.tpl
+++ b/src/Symfony/Maker/Resources/skeleton/ApiResource.php.tpl
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+echo "<?php\n";
+?>
+
+namespace <?php echo $namespace; ?>;
+
+use ApiPlatform\Metadata\ApiResource;
+<?php foreach ($operations as $op): ?>
+use ApiPlatform\Metadata\<?php echo $op; ?>;
+<?php endforeach; ?>
+<?php if ($provider_class): ?>
+use <?php echo $provider_class; ?>;
+<?php endif; ?>
+<?php if ($processor_class): ?>
+use <?php echo $processor_class; ?>;
+<?php endif; ?>
+<?php if ($has_validator): ?>
+use Symfony\Component\Validator\Constraints as Assert;
+<?php endif; ?>
+
+#[ApiResource(
+<?php if ($operations): ?>
+    operations: [
+<?php foreach ($operations as $op): ?>
+        new <?php echo $op; ?>(),
+<?php endforeach; ?>
+    ],
+<?php endif; ?>
+<?php if ($provider_class): ?>
+    provider: <?php echo $provider_short; ?>::class,
+<?php endif; ?>
+<?php if ($processor_class): ?>
+    processor: <?php echo $processor_short; ?>::class,
+<?php endif; ?>
+)]
+class <?php echo $class_name."\n"; ?>
+{
+<?php foreach ($fields as $i => $field): ?>
+<?php $type = $field['nullable'] ? '?'.$field['type'] : $field['type']; ?>
+<?php if (in_array($field['name'], $validated_fields, true)): ?>
+    #[Assert\NotBlank]
+<?php endif; ?>
+    public <?php echo $type; ?> $<?php echo $field['name']; ?><?php echo $field['nullable'] ? ' = null' : ''; ?>;
+<?php if ($i < count($fields) - 1): ?>
+
+<?php endif; ?>
+<?php endforeach; ?>
+}

--- a/src/Symfony/Maker/Resources/skeleton/ApiResourceStateProcessor.php.tpl
+++ b/src/Symfony/Maker/Resources/skeleton/ApiResourceStateProcessor.php.tpl
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+echo "<?php\n";
+?>
+
+namespace <?php echo $namespace; ?>;
+
+<?php foreach ($operations as $op): ?>
+use ApiPlatform\Metadata\<?php echo $op; ?>;
+<?php endforeach; ?>
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+class <?php echo $class_name; ?> implements ProcessorInterface
+{
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+<?php foreach ($operations as $op): ?>
+        if ($operation instanceof <?php echo $op; ?>) {
+            // TODO: process state for <?php echo $op; ?> operation
+        }
+
+<?php endforeach; ?>
+<?php if (!$operations): ?>
+        // Handle the state
+<?php endif; ?>
+
+        return null;
+    }
+}

--- a/src/Symfony/Maker/Resources/skeleton/ApiResourceStateProvider.php.tpl
+++ b/src/Symfony/Maker/Resources/skeleton/ApiResourceStateProvider.php.tpl
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+echo "<?php\n";
+?>
+
+namespace <?php echo $namespace; ?>;
+
+<?php foreach ($operations as $op): ?>
+use ApiPlatform\Metadata\<?php echo $op; ?>;
+<?php endforeach; ?>
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class <?php echo $class_name; ?> implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+<?php foreach ($operations as $op): ?>
+        if ($operation instanceof <?php echo $op; ?>) {
+            // TODO: provide state for <?php echo $op; ?> operation
+        }
+
+<?php endforeach; ?>
+<?php if (!$operations): ?>
+        // Retrieve the state from somewhere
+<?php endif; ?>
+        return null;
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/EntityApiResource.fixture
+++ b/tests/Fixtures/Symfony/Maker/EntityApiResource.fixture
@@ -1,0 +1,18 @@
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use App\State\BookProcessor;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new Post(),
+    ],
+    processor: BookProcessor::class,
+)]
+class Book
+{
+    #[Assert\NotBlank]
+    public string $name;
+}

--- a/tests/Fixtures/Symfony/Maker/EntityApiResourceStateProcessor.fixture
+++ b/tests/Fixtures/Symfony/Maker/EntityApiResourceStateProcessor.fixture
@@ -1,0 +1,18 @@
+namespace App\State;
+
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+
+class BookProcessor implements ProcessorInterface
+{
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof Post) {
+            // TODO: process state for Post operation
+        }
+
+
+        return null;
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/FieldsApiResource.fixture
+++ b/tests/Fixtures/Symfony/Maker/FieldsApiResource.fixture
@@ -1,0 +1,20 @@
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use App\State\BookStateProvider;
+
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+    ],
+    provider: BookStateProvider::class,
+)]
+class Book
+{
+    public string $title;
+
+    public ?int $price = null;
+}

--- a/tests/Fixtures/Symfony/Maker/FieldsApiResourceStateProvider.fixture
+++ b/tests/Fixtures/Symfony/Maker/FieldsApiResourceStateProvider.fixture
@@ -1,0 +1,22 @@
+namespace App\State;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+
+class BookStateProvider implements ProviderInterface
+{
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof Get) {
+            // TODO: provide state for Get operation
+        }
+
+        if ($operation instanceof GetCollection) {
+            // TODO: provide state for GetCollection operation
+        }
+
+        return null;
+    }
+}

--- a/tests/Fixtures/Symfony/Maker/MinimalApiResource.fixture
+++ b/tests/Fixtures/Symfony/Maker/MinimalApiResource.fixture
@@ -1,0 +1,9 @@
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(
+)]
+class Minimal
+{
+}

--- a/tests/Fixtures/Symfony/Maker/NamespacedMinimalApiResource.fixture
+++ b/tests/Fixtures/Symfony/Maker/NamespacedMinimalApiResource.fixture
@@ -1,0 +1,9 @@
+namespace App\Api\Resource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(
+)]
+class Minimal
+{
+}

--- a/tests/Symfony/Maker/MakeApiResourceTest.php
+++ b/tests/Symfony/Maker/MakeApiResourceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Symfony\Maker;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MakeApiResourceTest extends KernelTestCase
+{
+    protected function setup(): void
+    {
+        (new Filesystem())->remove(self::tempDir());
+    }
+
+    public function testMakeMinimalResource(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:api-resource'));
+        $tester->setInputs([
+            '',     // no fields
+            '',     // no operations
+            'no',   // provider
+            'no',   // processor
+        ]);
+        $tester->execute(['name' => 'Minimal']);
+
+        $resourceFile = self::tempFile('src/ApiResource/Minimal.php');
+        $this->assertFileExists($resourceFile);
+
+        $expected = preg_replace('~\R~u', "\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/MinimalApiResource.fixture'));
+        $result = preg_replace('~\R~u', "\n", file_get_contents($resourceFile));
+        $this->assertStringContainsString($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
+    public function testMakeResourceWithValidation(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:api-resource'));
+        $tester->setInputs([
+            'name',                 // field name
+            'string',               // type: string
+            'no',                   // nullable
+            'yes',                  // validated
+            '',                     // stop fields
+            'Post',                 // Post
+            '',                     // no more operations
+            'no',                   // provider
+            'yes',                  // processor
+        ]);
+        $tester->execute(['name' => 'Book']);
+
+        $resourceFile = self::tempFile('src/ApiResource/Book.php');
+        $processorFile = self::tempFile('src/State/BookProcessor.php');
+        $this->assertFileExists($resourceFile);
+        $this->assertFileExists($processorFile);
+
+        $expectedResource = preg_replace('~\R~u', "\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/EntityApiResource.fixture'));
+        $resultResource = preg_replace('~\R~u', "\n", file_get_contents($resourceFile));
+        $this->assertStringContainsString($expectedResource, $resultResource);
+
+        $expectedProcessor = preg_replace('~\R~u', "\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/EntityApiResourceStateProcessor.fixture'));
+        $resultProcessor = preg_replace('~\R~u', "\n", file_get_contents($processorFile));
+        $this->assertStringContainsString($expectedProcessor, $resultProcessor);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
+    public function testMakeResourceWithCustomNamespace(): void
+    {
+        $tester = new CommandTester((new Application(self::bootKernel()))->find('make:api-resource'));
+        $tester->setInputs([
+            '',     // no fields
+            '',     // no operations
+            'no',   // provider
+            'no',   // processor
+        ]);
+        $tester->execute(['name' => 'Minimal', '--namespace-prefix' => 'Api\\Resource\\']);
+
+        $resourceFile = self::tempFile('src/Api/Resource/Minimal.php');
+        $this->assertFileExists($resourceFile);
+
+        $expected = preg_replace('~\R~u', "\n", file_get_contents(__DIR__.'/../../Fixtures/Symfony/Maker/NamespacedMinimalApiResource.fixture'));
+        $result = preg_replace('~\R~u', "\n", file_get_contents($resourceFile));
+        $this->assertStringContainsString($expected, $result);
+
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('Success!', $display);
+    }
+
+    private static function tempDir(): string
+    {
+        return __DIR__.'/../../Fixtures/app/var/tmp';
+    }
+
+    private static function tempFile(string $path): string
+    {
+        return \sprintf('%s/%s', self::tempDir(), $path);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Not discussed yet
| License       | MIT
| Doc PR        | Not yet

Behavior:

* If necessary, asks for the class name (like for `make:entity`)
* Asks to add fields (with very straightforward types, to not overwhelm the maker)
* Asks to add Operations
* Asks to add a StateProvider class
* Asks to add a StateProcessor class
* Generates the code :rocket: 

WDYT?

The PR is already ready, but discussion on its goals can be done here, if you have comments.

I might need to make several more tests for different combinations of options, I'll check that after some discussion if it's necessary :+1: 
