### PR TITLE
docs: update usage of PHP-CS-Fixer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ exit 0
 
 ## Changing a version constraint
 
-Preferably change the version inside the root `composer.json`, then use `composer blend --all` to re-map the depedency accross each sub-project automatically. 
+Preferably change the version inside the root `composer.json`, then use `composer blend --all` to re-map the dependency across each sub-project automatically. 
 
 # License and Copyright Attribution
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | .
| License       | MIT
| Doc PR        | .

We can run PHP-CS-Fixer from the `vendor/` directory since it’s a `dev` dependency: https://github.com/api-platform/core/blob/c0a8d88b767721b40499c57e7d1166cca5fb179e/composer.json#L138