### PR TITLE
doc: fix reference to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ When to use:
 
 3. Testing Quick-Reference (Default/Symfony)
 
-For advanced configurations (Event Listeners, MongoDB, Behat tuning), refer to `tests/GEMINI.md`.
+For advanced configurations (Event Listeners, MongoDB, Behat tuning), refer to `tests/AGENTS.md`.
 
 Common Commands:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | .
| License       | MIT
| Doc PR        | .

`tests/GEMINI.md` does not exist. The actual file is `AGENTS.md`: https://github.com/soyuka/core/blob/5c5d38f12fe0dfe0f1904f7af8706088fa711d1c/tests/AGENTS.md