### PR TITLE
fix(hydra): expose alternate routes in entrypoint with indexed keys

### DIFF
--- a/src/Hydra/Serializer/EntrypointNormalizer.php
+++ b/src/Hydra/Serializer/EntrypointNormalizer.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\Exception\OperationNotFoundException;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -31,8 +32,12 @@ final class EntrypointNormalizer implements NormalizerInterface
 {
     public const FORMAT = 'jsonld';
 
-    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory, private readonly IriConverterInterface $iriConverter, private readonly UrlGeneratorInterface $urlGenerator)
-    {
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory,
+        private readonly IriConverterInterface $iriConverter,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
     }
 
     /**
@@ -50,13 +55,29 @@ final class EntrypointNormalizer implements NormalizerInterface
             $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
 
             foreach ($resourceMetadata as $resource) {
-                if ($resource->getExtraProperties()['is_alternate_resource_metadata'] ?? false) {
-                    continue;
-                }
+                $isAlternate = $resource->getExtraProperties()['is_alternate_resource_metadata'] ?? false;
 
                 foreach ($resource->getOperations() as $operation) {
-                    $key = lcfirst($resource->getShortName());
-                    if (true === $operation->getHideHydraOperation() || !$operation instanceof CollectionOperationInterface || isset($entrypoint[$key])) {
+                    $baseKey = lcfirst($resource->getShortName());
+                    $key = $baseKey;
+
+                    if (true === $operation->getHideHydraOperation() || !$operation instanceof CollectionOperationInterface) {
+                        continue;
+                    }
+
+                    // If this is an alternate and the key already exists, generate an indexed key
+                    if ($isAlternate && isset($entrypoint[$key])) {
+                        // Find the next available index
+                        $index = 1;
+                        while (isset($entrypoint[$baseKey.'_'.$index])) {
+                            ++$index;
+                        }
+                        $key = $baseKey.'_'.$index;
+
+                        if ($this->logger) {
+                            $this->logger->warning('Multiple ApiResource declarations with the same shortName "{shortName}" for class "{class}"; consider using distinct shortNames.', ['shortName' => $resource->getShortName(), 'class' => $resourceClass]);
+                        }
+                    } elseif (isset($entrypoint[$key])) {
                         continue;
                     }
 

--- a/tests/Fixtures/TestBundle/ApiResource/MultiRouteBook.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MultiRouteBook.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * ApiResource with multiple routes to test entrypoint behavior.
+ *
+ * This resource demonstrates the issue where multiple ApiResource declarations
+ * with different URIs result in the entrypoint advertising only the FIRST route,
+ * even when it should advertise the public one.
+ *
+ * Current behavior (BUG):
+ * - Admin route (/admin/multi_route_books) is declared FIRST
+ * - Entrypoint advertises the admin route only
+ * - Public route (/multi_route_books) works but is never advertised
+ *
+ * Expected behavior (AFTER FIX):
+ * - Entrypoint should advertise the public route (/multi_route_books)
+ * - Both routes should remain functional
+ */
+#[ApiResource(
+    uriTemplate: '/admin/multi_route_books',
+    operations: [
+        new GetCollection(
+            itemUriTemplate: '/admin/multi_route_books/{id}',
+            provider: [self::class, 'provideCollection'],
+        ),
+        new Get(
+            uriTemplate: '/admin/multi_route_books/{id}',
+            uriVariables: ['id'],
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+#[ApiResource(
+    uriTemplate: '/multi_route_books',
+    operations: [
+        new GetCollection(
+            itemUriTemplate: '/multi_route_books/{id}',
+            provider: [self::class, 'provideCollection'],
+        ),
+        new Get(
+            uriTemplate: '/multi_route_books/{id}',
+            uriVariables: ['id'],
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+class MultiRouteBook
+{
+    #[ApiProperty(identifier: true)]
+    public int $id;
+
+    public string $title;
+
+    public string $isbn;
+
+    public function __construct(int $id = 0, string $title = '', string $isbn = '')
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->isbn = $isbn;
+    }
+
+    /**
+     * Provider for GetCollection operations.
+     *
+     * @return array<MultiRouteBook>
+     */
+    public static function provideCollection(): array
+    {
+        return [
+            new self(1, 'The API Platform Book', '978-1-491-904-75-1'),
+            new self(2, 'GraphQL in Action', '978-1-617-29513-2'),
+        ];
+    }
+
+    /**
+     * Provider for Get operation (single item).
+     */
+    public static function provide(Operation $operation, array $uriVariables = []): self
+    {
+        $id = (int) ($uriVariables['id'] ?? 1);
+        $books = [
+            1 => new self(1, 'The API Platform Book', '978-1-491-904-75-1'),
+            2 => new self(2, 'GraphQL in Action', '978-1-617-29513-2'),
+        ];
+
+        return $books[$id] ?? $books[1];
+    }
+}

--- a/tests/Functional/MultiRouteEntrypointTest.php
+++ b/tests/Functional/MultiRouteEntrypointTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MultiRouteBook;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Functional test for entrypoint with multiple ApiResource declarations.
+ *
+ * Tests that when a resource has multiple #[ApiResource] attributes with different
+ * URIs but the same shortName, both routes are exposed in the entrypoint with indexed keys.
+ */
+class MultiRouteEntrypointTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [MultiRouteBook::class];
+    }
+
+    /**
+     * Test that the entrypoint exposes both routes with indexed keys.
+     *
+     * When multiple ApiResource declarations exist with the same shortName,
+     * they are exposed in the entrypoint with numeric suffixes:
+     * - multiRouteBook: /admin/multi_route_books (first declaration)
+     * - multiRouteBook_1: /multi_route_books (second declaration, alternate)
+     *
+     * A warning is logged to guide users toward using distinct shortNames.
+     */
+    public function testEntrypointExposesMultipleRoutesWithIndexedKeys(): void
+    {
+        $response = self::createClient()->request('GET', 'index', [
+            'headers' => ['accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+
+        // Both routes should be advertised with indexed keys
+        $this->assertArrayHasKey('multiRouteBook', $data);
+        $this->assertEquals('/admin/multi_route_books', $data['multiRouteBook']);
+
+        $this->assertArrayHasKey('multiRouteBook_1', $data);
+        $this->assertEquals('/multi_route_books', $data['multiRouteBook_1']);
+    }
+}


### PR DESCRIPTION
When a resource has multiple ApiResource declarations with different URIs but the same shortName, both routes are now exposed in the entrypoint with numeric suffixes (e.g., multiRouteBook, multiRouteBook_1). A warning log message guides users to use distinct shortNames instead.

* Include alternate resources in entrypoint instead of skipping them
* Generate indexed keys for colliding shortNames to prevent data loss
* Add logger to warn users about duplicate shortNames
* Add functional test to verify entrypoint exposes all routes
