### PR TITLE
Introduce legacy_filter_metadata

### DIFF
--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -53,6 +53,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         private readonly ?ContainerInterface $filterLocator = null,
         private readonly ?NameConverterInterface $nameConverter = null,
         private readonly ?LoggerInterface $logger = null,
+        private readonly bool $withLegacyFilterMetadata = true,
     ) {
     }
 
@@ -269,7 +270,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
 
         $parameter = $this->addFilterMetadata($parameter);
 
-        if ($filter instanceof FilterInterface) {
+        if ($filter instanceof FilterInterface && $this->withLegacyFilterMetadata) {
             try {
                 return $this->getLegacyFilterMetadata($parameter, $operation, $filter);
             } catch (RuntimeException $exception) {

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -85,6 +85,7 @@ final class Configuration implements ConfigurationInterface
                 ->end()
                 ->booleanNode('show_webby')->defaultTrue()->info('If true, show Webby on the documentation page')->end()
                 ->booleanNode('use_symfony_listeners')->defaultFalse()->info(sprintf('Uses Symfony event listeners instead of the %s.', MainController::class))->end()
+                ->booleanNode('legacy_filter_metadata')->defaultTrue()->info('Read the deprecated `getDescription` method to generate filters metadata.')->end()
                 ->scalarNode('name_converter')->defaultNull()->info('Specify a name converter to use.')->end()
                 ->scalarNode('asset_package')->defaultNull()->info('Specify an asset package name to use.')->end()
                 ->scalarNode('path_segment_name_generator')->defaultValue('api_platform.metadata.path_segment_name_generator.underscore')->info('Specify a path name generator to use.')->end()

--- a/src/Symfony/Bundle/Resources/config/metadata/resource.php
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.php
@@ -151,6 +151,7 @@ return function (ContainerConfigurator $container) {
             service('api_platform.filter_locator')->ignoreOnInvalid(),
             service('api_platform.name_converter')->ignoreOnInvalid(),
             service('logger')->ignoreOnInvalid(),
+            '%api_platform.legacy_filter_metadata%',
         ]);
 
     $services->set('api_platform.metadata.resource.metadata_collection_factory.cached', CachedResourceMetadataCollectionFactory::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | TODO
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

POC for https://github.com/api-platform/core/issues/7361#issuecomment-3884099164

It's unclear to me if
- it should be on main since it's a new feature/deprecation related
- or it should be on 4.2 because it's fixing a wrong behavior with the legacy filter metadata having error while generating schema.