### PR TITLE
chore: fix PHPStan error

### DIFF
--- a/src/Laravel/Tests/GraphQlTest.php
+++ b/src/Laravel/Tests/GraphQlTest.php
@@ -83,7 +83,7 @@ class GraphQlTest extends TestCase
         // Create books in reverse alphabetical order to test the 'asc' order
         BookFactory::new()
             ->count(10)
-            ->sequence(static fn ($sequence) => ['name' => \chr(\ord('z') - ((($sequence->index % 26) + 26) % 26))]) // ASCII codes starting from 'z'
+            ->sequence(static fn ($sequence) => ['name' => \chr(max(0, min(255, 122 - (int) $sequence->index)))]) // ASCII codes starting from 'z'
             ->has(AuthorFactory::new())
             ->create();
 


### PR DESCRIPTION
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Fix the followig error: 
```
Error: Parameter #1 $codepoint of function chr expects int<0, 255>, (float|int) given.
 ------ -------------------------------------------------------------- 
  Line   Tests/GraphQlTest.php                                         
 ------ -------------------------------------------------------------- 
  86     Parameter #1 $codepoint of function chr expects int<0, 255>,  
         (float|int) given.                                            
         🪪  argument.type                                             
 ------ --------------------------------------------------------------
```
