### PR TITLE
refactor: use imported Group instead of FQCN

### DIFF
--- a/src/Hal/Tests/Serializer/CollectionNormalizerTest.php
+++ b/src/Hal/Tests/Serializer/CollectionNormalizerTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\PartialPaginatorInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -30,7 +31,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class CollectionNormalizerTest extends TestCase
 {
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testSupportsNormalize(): void
     {
         $resourceClassResolverMock = $this->createMock(ResourceClassResolverInterface::class);

--- a/src/Hal/Tests/Serializer/ItemNormalizerTest.php
+++ b/src/Hal/Tests/Serializer/ItemNormalizerTest.php
@@ -29,6 +29,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MaxDepthDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -73,7 +74,7 @@ class ItemNormalizerTest extends TestCase
         $normalizer->denormalize(['foo'], 'Foo');
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testSupportsNormalization(): void
     {
         $std = new \stdClass();

--- a/src/Hal/Tests/Serializer/ObjectNormalizerTest.php
+++ b/src/Hal/Tests/Serializer/ObjectNormalizerTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Hal\Serializer;
 use ApiPlatform\Hal\Serializer\ObjectNormalizer;
 use ApiPlatform\Hal\Tests\Fixtures\Dummy;
 use ApiPlatform\Metadata\IriConverterInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -42,7 +43,7 @@ class ObjectNormalizerTest extends TestCase
         $normalizer->denormalize(['foo'], 'Foo');
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testSupportsNormalization(): void
     {
         $std = new \stdClass();

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -43,6 +43,7 @@ use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\PropertyCollectionIriOnlyR
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\RelatedDummy;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\SecuredDummy;
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -65,7 +66,7 @@ class AbstractItemNormalizerTest extends TestCase
 {
     use ProphecyTrait;
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testSupportNormalizationAndSupportDenormalization(): void
     {
         $std = new \stdClass();

--- a/tests/Functional/BackedEnumPropertyTest.php
+++ b/tests/Functional/BackedEnumPropertyTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Pet;
 use ApiPlatform\Tests\Fixtures\TestBundle\Enum\GenderTypeEnum;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpClient\HttpOptions;
 
 final class BackedEnumPropertyTest extends ApiTestCase
@@ -53,7 +54,7 @@ final class BackedEnumPropertyTest extends ApiTestCase
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testGraphQl(): void
     {
         $person = $this->createPerson();

--- a/tests/Functional/BackedEnumResourceTest.php
+++ b/tests/Functional/BackedEnumResourceTest.php
@@ -22,6 +22,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\BackedEnumStringResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6264\Availability;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6264\AvailabilityStatus;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpClient\HttpOptions;
 
 final class BackedEnumResourceTest extends ApiTestCase
@@ -512,7 +513,7 @@ GRAPHQL;
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerEnumItemsGraphQl')]
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testItemGraphql(string $query, array $variables, array $expected): void
     {
         $options = (new HttpOptions())
@@ -524,7 +525,7 @@ GRAPHQL;
         $this->assertJsonEquals($expected);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testCollectionGraphQl(): void
     {
         $query = <<<'GRAPHQL'
@@ -551,7 +552,7 @@ GRAPHQL;
         ]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testItemGraphQlInteger(): void
     {
         $query = <<<'GRAPHQL'

--- a/tests/Functional/Parameters/ParameterTest.php
+++ b/tests/Functional/Parameters/ParameterTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\TranslateValidationError;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WithParameter;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 final class ParameterTest extends ApiTestCase
 {
@@ -82,7 +83,7 @@ final class ParameterTest extends ApiTestCase
      * Because of the openapiContext deprecation.
      * TODO: only select a few classes to generate the docs for a faster test.
      */
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testDisableOpenApi(): void
     {
         $response = self::createClient()->request('GET', 'docs', ['headers' => ['accept' => 'application/vnd.openapi+json']]);

--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Crud;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317\Issue6317;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5625\Currency;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -64,7 +65,7 @@ class OpenApiCommandTest extends KernelTestCase
         $this->assertJson($this->tester->getDisplay());
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testExecuteWithYaml(): void
     {
         $this->tester->run(['command' => 'api:openapi:export', '--yaml' => true]);

--- a/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
+++ b/tests/Problem/Serializer/ConstraintViolationNormalizerTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Problem\Serializer;
 
 use ApiPlatform\Problem\Serializer\ConstraintViolationListNormalizer;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -30,7 +31,7 @@ class ConstraintViolationNormalizerTest extends TestCase
 {
     use ProphecyTrait;
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testSupportNormalization(): void
     {
         $nameConverterProphecy = $this->prophesize(NameConverterInterface::class);

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -33,6 +33,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Model\ResourceInterface;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -161,7 +162,7 @@ JSON;
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerFormats')]
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testAssertMatchesResourceCollectionJsonSchemaKeepSerializationContext(string $format, string $mimeType): void
     {
         $this->recreateSchema([Issue6146Parent::class, Issue6146Child::class]);
@@ -202,7 +203,7 @@ JSON;
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerFormats')]
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testAssertMatchesResourceItemJsonSchemaWithCustomJson(string $format, string $mimeType): void
     {
         $this->recreateSchema([JsonSchemaContextDummy::class]);
@@ -218,7 +219,7 @@ JSON;
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerFormats')]
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testAssertMatchesResourceItemJsonSchemaOutput(string $format, string $mimeType): void
     {
         $this->recreateSchema([DummyDtoInputOutput::class]);
@@ -235,7 +236,7 @@ JSON;
     }
 
     #[\PHPUnit\Framework\Attributes\DataProvider('providerFormats')]
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testAssertMatchesResourceItemAndCollectionJsonSchemaOutputWithContext(string $format, string $mimeType): void
     {
         $this->recreateSchema([User::class]);
@@ -256,7 +257,7 @@ JSON;
         $this->assertMatchesResourceCollectionJsonSchema(User::class, null, $format, ['groups' => ['api-test-case-group']]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testAssertMatchesResourceItemAndCollectionJsonSchemaOutputWithRangeAssertions(): void
     {
         $this->recreateSchema([NumericValidated::class]);
@@ -297,7 +298,7 @@ JSON;
         $this->assertArraySubset([1, 2], [1, 2, 3]);
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('orm')]
+    #[Group('orm')]
     public function testFindIriBy(): void
     {
         $this->recreateSchema([Dummy::class, RelatedOwnedDummy::class, RelatedDummy::class]);
@@ -325,7 +326,7 @@ JSON;
         $this->assertResponseIsSuccessful();
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('mercure')]
+    #[Group('mercure')]
     public function testGetMercureMessages(): void
     {
         self::bootKernel(['environment' => 'mercure']);

--- a/tests/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
+++ b/tests/Symfony/Bundle/Twig/ApiPlatformProfilerPanelTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -60,7 +61,7 @@ final class ApiPlatformProfilerPanelTest extends WebTestCase
         $this->assertSame('Not an API Platform resource', $block->filterXPath('//div[@class="sf-toolbar-info-piece"][./b[contains(., "Resource Class")]]/span')->html());
     }
 
-    #[\PHPUnit\Framework\Attributes\Group('legacy')]
+    #[Group('legacy')]
     public function testDebugBarContent(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
```php
#[\PHPUnit\Framework\Attributes\Group('…')]
```
to
```php
#[Group('…')]
```