### PR TITLE
fix: remove extra empty lines insertion in SymfonyServiceClassConstantFixer

### DIFF
--- a/tests/Fixer/SymfonyServiceClassConstantFixer.php
+++ b/tests/Fixer/SymfonyServiceClassConstantFixer.php
@@ -335,7 +335,6 @@ final class SymfonyServiceClassConstantFixer extends AbstractFixer
             }
 
             $tokensToInsert[] = new Token(';');
-            $tokensToInsert[] = new Token([\T_WHITESPACE, "\n"]);
         }
 
         $tokens->insertAt($insertIndex + 1, $tokensToInsert);


### PR DESCRIPTION
Related to #7706

## Description

When running PHP CS Fixer, extra empty lines are added when `use` statements are added by `SymfonyServiceClassConstantFixer::insertImports()`.

## How to reproduce

1. `git revert 26302584a973c326dc627bda98895095cdd5bc54` (or just modify a file manually)
2. `vendor/bin/php-cs-fixer fix`
3. get extra empty lines

## Before

![Capture d’écran 2026-02-15 015656](https://github.com/user-attachments/assets/a53efe6c-60e3-463f-b6c2-dc4d5df3df1d)

## After

![Capture d’écran 2026-02-15 015903](https://github.com/user-attachments/assets/7321fd1b-e535-45e1-bf19-06ff82db3913)

