### PR TITLE
fix(elasticsearch): mono-repo v9 support

### DIFF
--- a/src/Elasticsearch/composer.json
+++ b/src/Elasticsearch/composer.json
@@ -27,7 +27,7 @@
         "api-platform/metadata": "^4.2",
         "api-platform/serializer": "^4.2.4",
         "api-platform/state": "^4.2.4",
-        "elasticsearch/elasticsearch": "^7.17 || ^8.4",
+        "elasticsearch/elasticsearch": "^7.17 || ^8.4 || ^9.0",
         "symfony/cache": "^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^6.4 || ^7.0 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.0 || ^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hello,

The supported Elasticsearch version defined in `api-platform/core` is not synchronized with the version specified in the sub package `api-platform/elasticsearch`.

This PR fixes this difference.

Regards