### PR TITLE
fix(state): handle partial pagination with object mapper

### DIFF
--- a/src/State/Pagination/MappedObjectPartialPaginator.php
+++ b/src/State/Pagination/MappedObjectPartialPaginator.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Pagination;
+
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+
+final class MappedObjectPartialPaginator implements \IteratorAggregate, PartialPaginatorInterface
+{
+    public function __construct(
+        private readonly iterable $entities,
+        private readonly ObjectMapperInterface $mapper,
+        private readonly string $resourceClass,
+        private readonly float $currentPage = 1.0,
+        private readonly float $itemsPerPage = 30.0,
+        private readonly int $count = 0,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return $this->count;
+    }
+
+    public function getCurrentPage(): float
+    {
+        return $this->currentPage;
+    }
+
+    public function getItemsPerPage(): float
+    {
+        return $this->itemsPerPage;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->entities as $entity) {
+            yield $this->mapper->map($entity, $this->resourceClass);
+        }
+    }
+}

--- a/src/State/Provider/ObjectMapperProvider.php
+++ b/src/State/Provider/ObjectMapperProvider.php
@@ -16,7 +16,9 @@ namespace ApiPlatform\State\Provider;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use ApiPlatform\State\Pagination\MappedObjectPaginator;
+use ApiPlatform\State\Pagination\MappedObjectPartialPaginator;
 use ApiPlatform\State\Pagination\PaginatorInterface;
+use ApiPlatform\State\Pagination\PartialPaginatorInterface;
 use ApiPlatform\State\ProviderInterface;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 
@@ -61,6 +63,15 @@ final class ObjectMapperProvider implements ProviderInterface
                 $data->getCurrentPage(),
                 $data->getLastPage(),
                 $data->getItemsPerPage(),
+            );
+        } elseif ($data instanceof PartialPaginatorInterface) {
+            $data = new MappedObjectPartialPaginator(
+                $data,
+                $this->objectMapper,
+                $class,
+                $data->getCurrentPage(),
+                $data->getItemsPerPage(),
+                \count($data),
             );
         } elseif (\is_array($data)) {
             foreach ($data as &$v) {

--- a/tests/Fixtures/TestBundle/ApiResource/PartialPaginationMappedResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/PartialPaginationMappedResource.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Odm\State\Options;
+use ApiPlatform\JsonLd\ContextBuilder;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\PartialPaginationMappedDocument;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            paginationPartial: true,
+            paginationItemsPerPage: 3,
+            normalizationContext: [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false],
+        ),
+    ],
+    stateOptions: new Options(documentClass: PartialPaginationMappedDocument::class),
+)]
+#[Map(target: PartialPaginationMappedDocument::class)]
+final class PartialPaginationMappedResource
+{
+    #[Map(if: false)]
+    public ?int $id = null;
+
+    #[Map(target: 'name')]
+    public string $title;
+}

--- a/tests/Fixtures/TestBundle/Document/PartialPaginationMappedDocument.php
+++ b/tests/Fixtures/TestBundle/Document/PartialPaginationMappedDocument.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\PartialPaginationMappedResource;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ODM\Document]
+#[Map(target: PartialPaginationMappedResource::class)]
+class PartialPaginationMappedDocument
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[Map(target: 'title')]
+    #[ODM\Field(type: 'string')]
+    private string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/Functional/Doctrine/PartialPaginationMappedTest.php
+++ b/tests/Functional/Doctrine/PartialPaginationMappedTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Doctrine;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\PartialPaginationMappedResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\PartialPaginationMappedDocument;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class PartialPaginationMappedTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [PartialPaginationMappedResource::class];
+    }
+
+    public function testPartialPaginationWithObjectMapper(): void
+    {
+        if (!$this->isMongoDB()) {
+            $this->markTestSkipped('MongoDB only test.');
+        }
+
+        if (!$this->getContainer()->has('api_platform.object_mapper')) {
+            $this->markTestSkipped('ObjectMapper not installed');
+        }
+
+        $this->recreateSchema([PartialPaginationMappedDocument::class]);
+        $this->loadFixtures();
+
+        $client = self::createClient();
+        $r = $client->request('GET', '/partial_pagination_mapped_resources');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            '@id' => '/partial_pagination_mapped_resources',
+            'member' => [
+                ['title' => 'Item 1'],
+                ['title' => 'Item 2'],
+                ['title' => 'Item 3'],
+            ],
+            'view' => [
+                '@type' => 'PartialCollectionView',
+                'next' => '/partial_pagination_mapped_resources?page=2',
+            ],
+        ]);
+        $this->assertCount(3, $r->toArray()['member']);
+
+        $r = $client->request('GET', '/partial_pagination_mapped_resources?page=2');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains([
+            'view' => [
+                '@type' => 'PartialCollectionView',
+                'previous' => '/partial_pagination_mapped_resources?page=1',
+                'next' => '/partial_pagination_mapped_resources?page=3',
+            ],
+        ]);
+        $this->assertCount(3, $r->toArray()['member']);
+    }
+
+    private function loadFixtures(): void
+    {
+        $manager = $this->getManager();
+
+        for ($i = 1; $i <= 10; ++$i) {
+            $doc = new PartialPaginationMappedDocument();
+            $doc->setName('Item '.$i);
+            $manager->persist($doc);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | ∅
| License       | MIT
| Doc PR        | ∅

ObjectMapperProvider only handled PaginatorInterface, but ODM's PartialPaginator implements PartialPaginatorInterface which doesn't extend PaginatorInterface, causing mapping to fail on the paginator object itself.
