### PR TITLE
fix(JsonSchema): avoid schema name collision when an operation name is already used by another class

### DIFF
--- a/src/JsonSchema/DefinitionNameFactory.php
+++ b/src/JsonSchema/DefinitionNameFactory.php
@@ -36,7 +36,7 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
     public function create(string $className, string $format = 'json', ?string $inputOrOutputClass = null, ?Operation $operation = null, array $serializerContext = []): string
     {
         if ($operation) {
-            $prefix = $operation->getShortName();
+            $prefix = $this->createPrefixFromOperation($operation);
         }
 
         if (!isset($prefix)) {
@@ -80,6 +80,24 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
     private function encodeDefinitionName(string $name): string
     {
         return preg_replace('/[^a-zA-Z0-9.\-_]/', '.', $name);
+    }
+
+    private function createPrefixFromOperation(Operation $operation): ?string
+    {
+        $name = $operation->getShortName();
+
+        if (!isset($this->prefixCache[$name])) {
+            $this->prefixCache[$name] = $operation->getClass();
+
+            return $name;
+        }
+
+        if ($this->prefixCache[$name] === $operation->getClass()) {
+            return $name;
+        }
+
+        // This will fallback to using `createPrefixFromClass`
+        return null;
     }
 
     private function createPrefixFromClass(string $fullyQualifiedClassName, int $namespaceParts = 1): string

--- a/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
+++ b/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
@@ -105,4 +105,24 @@ final class DefinitionNameFactoryTest extends TestCase
             $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, 'jsonhal')
         );
     }
+
+    public function testCreateDifferentPrefixesForClassesWithTheSameOperationShortName(): void
+    {
+        $definitionNameFactory = new DefinitionNameFactory();
+
+        self::assertEquals(
+            'DummyClass.jsonapi',
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, 'jsonapi', null, new Get(class: Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, shortName: 'DummyClass'))
+        );
+
+        self::assertEquals(
+            'Module.DummyClass.jsonapi',
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceB\Module\DummyClass::class, 'jsonapi', null, new Get(class: Fixtures\DefinitionNameFactory\NamespaceB\Module\DummyClass::class, shortName: 'DummyClass'))
+        );
+
+        self::assertEquals(
+            'NamespaceC.Module.DummyClass.jsonapi',
+            $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceC\Module\DummyClass::class, 'jsonapi', null, new Get(class: Fixtures\DefinitionNameFactory\NamespaceC\Module\DummyClass::class, shortName: 'DummyClass'))
+        );
+    }
 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.2
| License       | MIT

When two API resources have the same class short name but are in different namespace, the schema section of OpenApi specs will only keep the first one.

Given 
```yaml
NamespaceA\MyResource:
  - propertyA: string

NamespaceB\MyResource:
  - propertyB: string
```

The current buggy behavior will produce a openapi.json like this with only one schema => 
```JSON
{
  "components": {
    "schemas": {
      "MyResource": {
        "type": "object",
        "properties": {
          "propertyA": {
            "type": "string"
          }
        }
      }
    }
  }
}
```

So this leads to operations that use `NamespaceB\MyResource` will references to `NamespaceA\MyResource` schema.

