### PR TITLE
fix(serializer): apply API Platform name converter to input/output DTOs

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -116,6 +116,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return true;
         }
 
+        if (isset($context['api_platform_output']) && ($context['resource_class'] ?? null) === $class) {
+            return true;
+        }
+
         return $this->resourceClassResolver->isResourceClass($class);
     }
 
@@ -147,6 +151,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             unset($context['output'], $context['operation'], $context['operation_name']);
             $context['resource_class'] = $outputClass;
             $context['api_sub_level'] = true;
+            $context['api_platform_output'] = true;
             $context[self::ALLOW_EXTRA_ATTRIBUTES] = false;
 
             return $this->serializer->normalize($data, $format, $context);
@@ -216,6 +221,10 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             return true;
         }
 
+        if (isset($context['api_platform_input']) && ($context['resource_class'] ?? null) === $type) {
+            return true;
+        }
+
         return $this->localCache[$type] ?? $this->localCache[$type] = $this->resourceClassResolver->isResourceClass($type);
     }
 
@@ -233,6 +242,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             unset($context['input'], $context['operation'], $context['operation_name'], $context['uri_variables']);
             $context['resource_class'] = $inputClass;
+            $context['api_platform_input'] = true;
 
             try {
                 return $this->serializer->denormalize($data, $inputClass, $format, $context);

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1894,6 +1894,53 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertEquals(array_keys($operationCacheKey), [\sprintf('%s%s%s%s', Dummy::class, 'operation_name', 'root_operation_name', 'n')]);
         $this->assertEquals(current($operationCacheKey), ['serializer_groups' => ['group'], 'api_allow_update' => false]);
     }
+
+    public function testSupportsDenormalizationWithApiPlatformInputContext(): void
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false);
+
+        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), null, null, [], null, null) extends AbstractItemNormalizer {};
+
+        $this->assertFalse($normalizer->supportsDenormalization([], \stdClass::class));
+        $this->assertTrue($normalizer->supportsDenormalization([], \stdClass::class, null, [
+            'api_platform_input' => true,
+            'resource_class' => \stdClass::class,
+        ]));
+        $this->assertFalse($normalizer->supportsDenormalization([], \stdClass::class, null, [
+            'api_platform_input' => true,
+            'resource_class' => 'SomeOtherClass',
+        ]));
+    }
+
+    public function testSupportsNormalizationWithApiPlatformOutputContext(): void
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(\stdClass::class)->willReturn(false);
+
+        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), null, null, [], null, null) extends AbstractItemNormalizer {};
+
+        $std = new \stdClass();
+        $this->assertFalse($normalizer->supportsNormalization($std));
+        $this->assertTrue($normalizer->supportsNormalization($std, null, [
+            'api_platform_output' => true,
+            'resource_class' => \stdClass::class,
+        ]));
+        $this->assertFalse($normalizer->supportsNormalization($std, null, [
+            'api_platform_output' => true,
+            'resource_class' => 'SomeOtherClass',
+        ]));
+    }
 }
 
 class ObjectWithBasicProperties

--- a/tests/Fixtures/TestBundle/ApiResource/DummyDtoNameConverted.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DummyDtoNameConverted.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\InputDtoWithNameConverter;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\OutputDtoWithNameConverter;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/dummy_dto_name_converted/{id}',
+            output: OutputDtoWithNameConverter::class,
+            provider: [self::class, 'provide'],
+        ),
+        new Post(
+            uriTemplate: '/dummy_dto_name_converted',
+            input: InputDtoWithNameConverter::class,
+            processor: [self::class, 'process'],
+            provider: [self::class, 'provide'],
+        ),
+    ]
+)]
+class DummyDtoNameConverted
+{
+    public function __construct(
+        public ?int $id = null,
+        public ?string $nameConverted = null,
+    ) {
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self(id: 1, nameConverted: 'converted');
+    }
+
+    /**
+     * @param InputDtoWithNameConverter $data
+     */
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self(id: 1, nameConverted: $data->nameConverted);
+    }
+}

--- a/tests/Fixtures/TestBundle/Dto/InputDtoWithNameConverter.php
+++ b/tests/Fixtures/TestBundle/Dto/InputDtoWithNameConverter.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+class InputDtoWithNameConverter
+{
+    public ?string $nameConverted = null;
+}

--- a/tests/Fixtures/TestBundle/Dto/OutputDtoWithNameConverter.php
+++ b/tests/Fixtures/TestBundle/Dto/OutputDtoWithNameConverter.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+class OutputDtoWithNameConverter
+{
+    public ?string $nameConverted = null;
+}

--- a/tests/Functional/InputOutputNameConverterTest.php
+++ b/tests/Functional/InputOutputNameConverterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DummyDtoNameConverted;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Tests that API Platform's name converter is applied to input and output DTOs.
+ *
+ * Reproduces and validates the fix for issue #7705:
+ * https://github.com/api-platform/core/issues/7705
+ *
+ * After PR #7691 isolated AP's name converter from Symfony's global serializer,
+ * input/output DTOs stopped getting the AP name converter because
+ * supportsDenormalization/supportsNormalization rejected them on re-entry
+ * (the input/output context keys were unset before re-entering the serializer).
+ */
+final class InputOutputNameConverterTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [DummyDtoNameConverted::class];
+    }
+
+    public function testInputDtoNameConverterIsApplied(): void
+    {
+        $response = self::createClient()->request('POST', '/dummy_dto_name_converted', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['name_converted' => 'converted'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $data = $response->toArray();
+        $this->assertSame('converted', $data['name_converted']);
+    }
+
+    public function testOutputDtoNameConverterIsApplied(): void
+    {
+        $response = self::createClient()->request('GET', '/dummy_dto_name_converted/1');
+
+        $this->assertResponseIsSuccessful();
+        $data = $response->toArray();
+        $this->assertArrayHasKey('name_converted', $data);
+        $this->assertSame('converted', $data['name_converted']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes #7705
| License       | MIT
| Doc PR        | ∅

When denormalizing input DTOs, the serializer re-enters without the `input` context key, causing `supportsDenormalization()` to reject the DTO. It falls through to Symfony's ObjectNormalizer which lacks AP's name converter. A new `api_platform_input` context flag ensures the DTO is handled by AbstractItemNormalizer.