### PR TITLE
test(serializer): cover controller use case for name converter on input DTOs

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/DummyDtoNameConverted.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DummyDtoNameConverted.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Post;
+use ApiPlatform\Tests\Fixtures\TestBundle\Controller\InputDtoWithNameConverterController;
 use ApiPlatform\Tests\Fixtures\TestBundle\Dto\InputDtoWithNameConverter;
 use ApiPlatform\Tests\Fixtures\TestBundle\Dto\OutputDtoWithNameConverter;
 
@@ -32,6 +33,12 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Dto\OutputDtoWithNameConverter;
             input: InputDtoWithNameConverter::class,
             processor: [self::class, 'process'],
             provider: [self::class, 'provide'],
+        ),
+        new Post(
+            uriTemplate: '/dummy_dto_name_converted_controller',
+            controller: InputDtoWithNameConverterController::class,
+            input: InputDtoWithNameConverter::class,
+            output: InputDtoWithNameConverter::class,
         ),
     ]
 )]

--- a/tests/Fixtures/TestBundle/Controller/InputDtoWithNameConverterController.php
+++ b/tests/Fixtures/TestBundle/Controller/InputDtoWithNameConverterController.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Controller;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\InputDtoWithNameConverter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Reproduces the controller use case from issue #7705:
+ * the name converter must be applied when deserializing input DTOs via SerializerInterface.
+ */
+class InputDtoWithNameConverterController extends AbstractController
+{
+    public function __construct(
+        private readonly SerializerInterface $serializer,
+    ) {
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $input = $this->serializer->deserialize($request->getContent(), InputDtoWithNameConverter::class, 'json');
+
+        return new JsonResponse($input);
+    }
+}

--- a/tests/Functional/InputOutputNameConverterTest.php
+++ b/tests/Functional/InputOutputNameConverterTest.php
@@ -63,4 +63,23 @@ final class InputOutputNameConverterTest extends ApiTestCase
         $this->assertArrayHasKey('name_converted', $data);
         $this->assertSame('converted', $data['name_converted']);
     }
+
+    /**
+     * Reproduces the controller use case from issue #7705:
+     * when a custom controller deserializes the input DTO via SerializerInterface,
+     * the API Platform name converter must still be applied.
+     *
+     * @see https://github.com/api-platform/core/issues/7705
+     */
+    public function testInputDtoNameConverterIsAppliedWithController(): void
+    {
+        $response = self::createClient()->request('POST', '/dummy_dto_name_converted_controller', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['name_converted' => 'converted'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $data = $response->toArray(false);
+        $this->assertSame('converted', $data['nameConverted']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | https://github.com/api-platform/core/issues/7705
| License       | MIT
| Doc PR        | ∅

Ensures the API Platform name converter is applied when a custom controller deserializes input DTOs via SerializerInterface directly.