### PR TITLE
fix(metadata): sort parameters by priority after pattern expansion

### DIFF
--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -223,6 +223,8 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             $parameters->add($key, $parameter->withPriority($priority));
         }
 
+        $parameters->sort();
+
         return $parameters;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7762
| License       | MIT
| Doc PR        | ∅

Parameters expanded from `:property` placeholders were not re-sorted after priorities were assigned, causing iteration order to depend on insertion order rather than declared priority.
