### PR TITLE
Reproducer for nested class transformer bug

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
@@ -36,6 +36,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 class MappedResourceWithRelation
 {
     public ?string $id = null;
+    public string $classTransformCall = 'none';
     #[Map(if: false)]
     public ?string $relationName = null;
     #[Map(target: 'related')]

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelationRelated.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelationRelated.php
@@ -34,4 +34,5 @@ class MappedResourceWithRelationRelated
 {
     public string $id;
     public string $name;
+    public string $classTransformCall = 'none';
 }

--- a/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationEntity.php
@@ -14,11 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceWithRelation;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceWithRelationRelated;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\ObjectMapper\Attribute\Map;
 
 #[ORM\Entity]
-#[Map(target: MappedResourceWithRelation::class)]
+#[Map(target: MappedResourceWithRelation::class, transform: [MappedResourceWithRelationEntity::class, 'transformClass'])]
 class MappedResourceWithRelationEntity
 {
     #[ORM\Id, ORM\Column]
@@ -57,5 +58,11 @@ class MappedResourceWithRelationEntity
         $this->related = $related;
 
         return $this;
+    }
+
+    public static function transformClass($value, $source): mixed
+    {
+        $value->classTransformCall = 'MappedResourceWithRelationEntity';
+        return $value;
     }
 }

--- a/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationRelatedEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedResourceWithRelationRelatedEntity.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\ObjectMapper\Attribute\Map;
 
 #[ORM\Entity]
-#[Map(target: MappedResourceWithRelationRelated::class)]
+#[Map(target: MappedResourceWithRelationRelated::class, transform: [MappedResourceWithRelationRelatedEntity::class, 'transformClass'])] // Fail if transform used ?
 class MappedResourceWithRelationRelatedEntity
 {
     #[ORM\Id, ORM\Column, ORM\GeneratedValue]
@@ -35,5 +35,11 @@ class MappedResourceWithRelationRelatedEntity
     public function setId(?int $id = null)
     {
         $this->id = $id;
+    }
+
+    public static function transformClass($value, $source): mixed
+    {
+        $value->classTransformCall = 'MappedResourceWithRelationRelatedEntity';
+        return $value;
     }
 }

--- a/tests/Functional/MappingTest.php
+++ b/tests/Functional/MappingTest.php
@@ -161,6 +161,7 @@ final class MappingTest extends ApiTestCase
             'id' => '4',
             'relationName' => 'test',
             'relation' => '/mapped_resource_with_relation_relateds/1',
+            'classTransformCall' => 'MappedResourceWithRelationEntity',
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Maybe https://github.com/symfony/symfony/issues/63449 on Symfony
| License       | MIT

I have a bug when using ObjectMapper with entities that have relationships, combined with [Class-Level Transformation](https://symfony.com/doc/current/object_mapper.html#class-level-transformation). It appears to be invoked with incorrect parameters (parent ?) when relationships between mapped classes are involved.