### PR TITLE
feat(laravel): split render logic from error handler

### DIFF
--- a/src/Laravel/Exception/ErrorHandler.php
+++ b/src/Laravel/Exception/ErrorHandler.php
@@ -13,229 +13,41 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Laravel\Exception;
 
-use ApiPlatform\Laravel\ApiResource\Error;
-use ApiPlatform\Laravel\Controller\ApiPlatformController;
-use ApiPlatform\Metadata\Exception\InvalidUriVariableException;
-use ApiPlatform\Metadata\Exception\ProblemExceptionInterface;
-use ApiPlatform\Metadata\Exception\StatusAwareExceptionInterface;
-use ApiPlatform\Metadata\HttpOperation;
-use ApiPlatform\Metadata\IdentifiersExtractorInterface;
-use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
-use ApiPlatform\Metadata\ResourceClassResolverInterface;
-use ApiPlatform\Metadata\Util\ContentNegotiationTrait;
-use ApiPlatform\State\Util\OperationRequestInitiatorTrait;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Auth\AuthenticationException;
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionsHandler;
-use Negotiation\Negotiator;
-use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as SymfonyHttpExceptionInterface;
-use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 
 class ErrorHandler extends ExceptionsHandler
 {
-    use ContentNegotiationTrait;
-    use OperationRequestInitiatorTrait;
-
-    public static mixed $error;
-
-    /**
-     * @param array<class-string, int> $exceptionToStatus
-     * @param array<string, string[]>  $errorFormats
-     */
     public function __construct(
         Container $container,
-        ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
-        private readonly ApiPlatformController $apiPlatformController,
-        private readonly ?IdentifiersExtractorInterface $identifiersExtractor = null,
-        private readonly ?ResourceClassResolverInterface $resourceClassResolver = null,
-        ?Negotiator $negotiator = null,
-        private readonly ?array $exceptionToStatus = null,
-        private readonly ?bool $debug = false,
-        private readonly ?array $errorFormats = null,
+        private readonly ErrorRenderer $errorRenderer,
         private readonly ?ExceptionHandler $decorated = null,
     ) {
-        $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
-        $this->negotiator = $negotiator;
         parent::__construct($container);
     }
 
     public function render($request, \Throwable $exception)
     {
-        $apiOperation = $this->initializeOperation($request);
-
-        if (!$apiOperation) {
-            // For non-API operations, first check if any renderable callbacks on this
-            // ErrorHandler instance can handle the exception (issue #7466).
-            $response = $this->renderViaCallbacks($request, $exception);
+        if ($this->errorRenderer->shouldRender($request, $exception)) {
+            $response = $this->errorRenderer->render($request, $exception);
 
             if ($response) {
                 return $response;
             }
-
-            // If no callbacks handled it, delegate to the decorated handler if available
-            // to preserve custom exception handler classes (issue #7058).
-            return $this->decorated ? $this->decorated->render($request, $exception) : parent::render($request, $exception);
         }
 
-        $formats = $this->errorFormats ?? ['jsonproblem' => ['application/problem+json']];
-        $format = $request->getRequestFormat() ?? $this->getRequestFormat($request, $formats, false);
+        // If it's not an API operation, or the renderer wasn't able to generate
+        // a response, first check if any renderable callbacks on this ErrorHandler
+        // instance can handle the exception (issue #7466).
+        $response = $this->renderViaCallbacks($request, $exception);
 
-        if ($this->resourceClassResolver->isResourceClass($exception::class)) {
-            $resourceCollection = $this->resourceMetadataCollectionFactory->create($exception::class);
-
-            $operation = null;
-            foreach ($resourceCollection as $resource) {
-                foreach ($resource->getOperations() as $op) {
-                    foreach ($op->getOutputFormats() ?? [] as $key => $value) {
-                        if ($key === $format) {
-                            $operation = $op;
-                            break 3;
-                        }
-                    }
-                }
-            }
-
-            // No operation found for the requested format, we take the first available
-            if (!$operation) {
-                $operation = $resourceCollection->getOperation();
-            }
-            $errorResource = $exception;
-            if ($errorResource instanceof ProblemExceptionInterface && $operation instanceof HttpOperation) {
-                $statusCode = $this->getStatusCode($apiOperation, $operation, $exception);
-                $operation = $operation->withStatus($statusCode);
-                if ($errorResource instanceof StatusAwareExceptionInterface) {
-                    $errorResource->setStatus($statusCode);
-                }
-            }
-        } else {
-            // Create a generic, rfc7807 compatible error according to the wanted format
-            $operation = $this->resourceMetadataCollectionFactory->create(Error::class)->getOperation($this->getFormatOperation($format));
-            // status code may be overridden by the exceptionToStatus option
-            $statusCode = 500;
-            if ($operation instanceof HttpOperation) {
-                $statusCode = $this->getStatusCode($apiOperation, $operation, $exception);
-                $operation = $operation->withStatus($statusCode);
-            }
-
-            $errorResource = Error::createFromException($exception, $statusCode);
-        }
-
-        /** @var HttpOperation $operation */
-        if (!$operation->getProvider()) {
-            static::$error = $errorResource;
-            $operation = $operation->withProvider([self::class, 'provide']);
-        }
-
-        // For our swagger Ui errors
-        if ('html' === $format) {
-            $operation = $operation->withOutputFormats(['html' => ['text/html']]);
-        }
-
-        $identifiers = [];
-        try {
-            $identifiers = $this->identifiersExtractor?->getIdentifiersFromItem($errorResource, $operation) ?? [];
-        } catch (\Exception $e) {
-        }
-
-        $normalizationContext = $operation->getNormalizationContext() ?? [];
-        if (!($normalizationContext['api_error_resource'] ?? false)) {
-            $normalizationContext += ['api_error_resource' => true];
-        }
-
-        if (!isset($normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES])) {
-            $normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES] = true === $this->debug ? [] : ['originalTrace'];
-        }
-
-        $operation = $operation->withNormalizationContext($normalizationContext);
-
-        $dup = $request->duplicate(null, null, []);
-        $dup->setMethod('GET');
-        $dup->attributes->set('_api_resource_class', $operation->getClass());
-        $dup->attributes->set('_api_previous_operation', $apiOperation);
-        $dup->attributes->set('_api_operation', $operation);
-        $dup->attributes->set('_api_operation_name', $operation->getName());
-        $dup->attributes->set('exception', $exception);
-        // These are for swagger
-        $dup->attributes->set('_api_original_route', $request->attributes->get('_route'));
-        $dup->attributes->set('_api_original_uri_variables', $request->attributes->get('_api_uri_variables'));
-        $dup->attributes->set('_api_original_route_params', $request->attributes->get('_route_params'));
-        $dup->attributes->set('_api_requested_operation', $request->attributes->get('_api_requested_operation'));
-
-        foreach ($identifiers as $name => $value) {
-            $dup->attributes->set($name, $value);
-        }
-
-        try {
-            $response = $this->apiPlatformController->__invoke($dup);
-
+        if ($response) {
             return $response;
-        } catch (\Throwable $e) {
-            return $this->decorated ? $this->decorated->render($request, $exception) : parent::render($request, $exception);
-        }
-    }
-
-    private function getStatusCode(?HttpOperation $apiOperation, ?HttpOperation $errorOperation, \Throwable $exception): int
-    {
-        $exceptionToStatus = array_merge(
-            $apiOperation ? $apiOperation->getExceptionToStatus() ?? [] : [],
-            $errorOperation ? $errorOperation->getExceptionToStatus() ?? [] : [],
-            $this->exceptionToStatus ?? []
-        );
-
-        foreach ($exceptionToStatus as $class => $status) {
-            if (is_a($exception::class, $class, true)) {
-                return $status;
-            }
         }
 
-        if ($exception instanceof AuthenticationException) {
-            return 401;
-        }
-
-        if ($exception instanceof AuthorizationException) {
-            return 403;
-        }
-
-        if ($exception instanceof SymfonyHttpExceptionInterface) {
-            return $exception->getStatusCode();
-        }
-
-        if ($exception instanceof RequestExceptionInterface || $exception instanceof InvalidUriVariableException) {
-            return 400;
-        }
-
-        // if ($exception instanceof ValidationException) {
-        //     return 422;
-        // }
-
-        if ($status = $errorOperation?->getStatus()) {
-            return $status;
-        }
-
-        return 500;
-    }
-
-    private function getFormatOperation(?string $format): string
-    {
-        return match ($format) {
-            'json' => '_api_errors_problem',
-            'jsonproblem' => '_api_errors_problem',
-            'jsonld' => '_api_errors_hydra',
-            'jsonapi' => '_api_errors_jsonapi',
-            'html' => '_api_errors_problem', // This will be intercepted by the SwaggerUiProvider
-            default => '_api_errors_problem',
-        };
-    }
-
-    public static function provide(): mixed
-    {
-        if ($data = static::$error) {
-            return $data;
-        }
-
-        throw new \LogicException(\sprintf('We could not find the thrown exception in the %s.', self::class));
+        // If no callbacks handled it, delegate to the decorated handler if available
+        // to preserve custom exception handler classes (issue #7058).
+        return $this->decorated ? $this->decorated->render($request, $exception) : parent::render($request, $exception);
     }
 }

--- a/src/Laravel/Exception/ErrorRenderer.php
+++ b/src/Laravel/Exception/ErrorRenderer.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Exception;
+
+use ApiPlatform\Laravel\ApiResource\Error;
+use ApiPlatform\Laravel\Controller\ApiPlatformController;
+use ApiPlatform\Metadata\Exception\InvalidUriVariableException;
+use ApiPlatform\Metadata\Exception\ProblemExceptionInterface;
+use ApiPlatform\Metadata\Exception\StatusAwareExceptionInterface;
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\IdentifiersExtractorInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
+use ApiPlatform\Metadata\Util\ContentNegotiationTrait;
+use ApiPlatform\State\Util\OperationRequestInitiatorTrait;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Negotiation\Negotiator;
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface as SymfonyHttpExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+class ErrorRenderer
+{
+    use ContentNegotiationTrait;
+    use OperationRequestInitiatorTrait;
+
+    public static mixed $error;
+
+    /**
+     * @param array<class-string, int> $exceptionToStatus
+     * @param array<string, string[]>  $errorFormats
+     */
+    public function __construct(
+        ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private readonly ApiPlatformController $apiPlatformController,
+        private readonly ?IdentifiersExtractorInterface $identifiersExtractor = null,
+        private readonly ?ResourceClassResolverInterface $resourceClassResolver = null,
+        ?Negotiator $negotiator = null,
+        private readonly ?array $exceptionToStatus = null,
+        private readonly ?bool $debug = false,
+        private readonly ?array $errorFormats = null,
+    ) {
+        $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
+        $this->negotiator = $negotiator;
+    }
+
+    public function shouldRender($request, \Throwable $throwable)
+    {
+        $apiOperation = $this->initializeOperation($request);
+
+        return null !== $apiOperation;
+    }
+
+    public function render($request, \Throwable $exception)
+    {
+        $apiOperation = $this->initializeOperation($request);
+
+        $formats = $this->errorFormats ?? ['jsonproblem' => ['application/problem+json']];
+        $format = $request->getRequestFormat() ?? $this->getRequestFormat($request, $formats, false);
+
+        if ($this->resourceClassResolver->isResourceClass($exception::class)) {
+            $resourceCollection = $this->resourceMetadataCollectionFactory->create($exception::class);
+
+            $operation = null;
+            foreach ($resourceCollection as $resource) {
+                foreach ($resource->getOperations() as $op) {
+                    foreach ($op->getOutputFormats() ?? [] as $key => $value) {
+                        if ($key === $format) {
+                            $operation = $op;
+                            break 3;
+                        }
+                    }
+                }
+            }
+
+            // No operation found for the requested format, we take the first available
+            if (!$operation) {
+                $operation = $resourceCollection->getOperation();
+            }
+            $errorResource = $exception;
+            if ($errorResource instanceof ProblemExceptionInterface && $operation instanceof HttpOperation) {
+                $statusCode = $this->getStatusCode($apiOperation, $operation, $exception);
+                $operation = $operation->withStatus($statusCode);
+                if ($errorResource instanceof StatusAwareExceptionInterface) {
+                    $errorResource->setStatus($statusCode);
+                }
+            }
+        } else {
+            // Create a generic, rfc7807 compatible error according to the wanted format
+            $operation = $this->resourceMetadataCollectionFactory->create(Error::class)->getOperation($this->getFormatOperation($format));
+            // status code may be overridden by the exceptionToStatus option
+            $statusCode = 500;
+            if ($operation instanceof HttpOperation) {
+                $statusCode = $this->getStatusCode($apiOperation, $operation, $exception);
+                $operation = $operation->withStatus($statusCode);
+            }
+
+            $errorResource = Error::createFromException($exception, $statusCode);
+        }
+
+        /** @var HttpOperation $operation */
+        if (!$operation->getProvider()) {
+            static::$error = $errorResource;
+            $operation = $operation->withProvider([self::class, 'provide']);
+        }
+
+        // For our swagger Ui errors
+        if ('html' === $format) {
+            $operation = $operation->withOutputFormats(['html' => ['text/html']]);
+        }
+
+        $identifiers = [];
+        try {
+            $identifiers = $this->identifiersExtractor?->getIdentifiersFromItem($errorResource, $operation) ?? [];
+        } catch (\Exception $e) {
+        }
+
+        $normalizationContext = $operation->getNormalizationContext() ?? [];
+        if (!($normalizationContext['api_error_resource'] ?? false)) {
+            $normalizationContext += ['api_error_resource' => true];
+        }
+
+        if (!isset($normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES])) {
+            $normalizationContext[AbstractObjectNormalizer::IGNORED_ATTRIBUTES] = true === $this->debug ? [] : ['originalTrace'];
+        }
+
+        $operation = $operation->withNormalizationContext($normalizationContext);
+
+        $dup = $request->duplicate(null, null, []);
+        $dup->setMethod('GET');
+        $dup->attributes->set('_api_resource_class', $operation->getClass());
+        $dup->attributes->set('_api_previous_operation', $apiOperation);
+        $dup->attributes->set('_api_operation', $operation);
+        $dup->attributes->set('_api_operation_name', $operation->getName());
+        $dup->attributes->set('exception', $exception);
+        // These are for swagger
+        $dup->attributes->set('_api_original_route', $request->attributes->get('_route'));
+        $dup->attributes->set('_api_original_uri_variables', $request->attributes->get('_api_uri_variables'));
+        $dup->attributes->set('_api_original_route_params', $request->attributes->get('_route_params'));
+        $dup->attributes->set('_api_requested_operation', $request->attributes->get('_api_requested_operation'));
+
+        foreach ($identifiers as $name => $value) {
+            $dup->attributes->set($name, $value);
+        }
+
+        try {
+            return $this->apiPlatformController->__invoke($dup);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function getStatusCode(?HttpOperation $apiOperation, ?HttpOperation $errorOperation, \Throwable $exception): int
+    {
+        $exceptionToStatus = array_merge(
+            $apiOperation ? $apiOperation->getExceptionToStatus() ?? [] : [],
+            $errorOperation ? $errorOperation->getExceptionToStatus() ?? [] : [],
+            $this->exceptionToStatus ?? []
+        );
+
+        foreach ($exceptionToStatus as $class => $status) {
+            if (is_a($exception::class, $class, true)) {
+                return $status;
+            }
+        }
+
+        if ($exception instanceof AuthenticationException) {
+            return 401;
+        }
+
+        if ($exception instanceof AuthorizationException) {
+            return 403;
+        }
+
+        if ($exception instanceof SymfonyHttpExceptionInterface) {
+            return $exception->getStatusCode();
+        }
+
+        if ($exception instanceof RequestExceptionInterface || $exception instanceof InvalidUriVariableException) {
+            return 400;
+        }
+
+        // if ($exception instanceof ValidationException) {
+        //     return 422;
+        // }
+
+        if ($status = $errorOperation?->getStatus()) {
+            return $status;
+        }
+
+        return 500;
+    }
+
+    private function getFormatOperation(?string $format): string
+    {
+        return match ($format) {
+            'json' => '_api_errors_problem',
+            'jsonproblem' => '_api_errors_problem',
+            'jsonld' => '_api_errors_hydra',
+            'jsonapi' => '_api_errors_jsonapi',
+            'html' => '_api_errors_problem', // This will be intercepted by the SwaggerUiProvider
+            default => '_api_errors_problem',
+        };
+    }
+
+    public static function provide(): mixed
+    {
+        if ($data = static::$error) {
+            return $data;
+        }
+
+        throw new \LogicException(\sprintf('We could not find the thrown exception in the %s.', self::class));
+    }
+}

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -168,4 +168,8 @@ return [
     //         'purger' => ApiPlatform\HttpCache\SouinPurger::class,
     //     ],
     // ],
+
+    'error_handler' => [
+        'extend_laravel_handler' => true,
+    ],
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | 
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

I have run into issues with the error handler a few times already. This PR aims to give the developer more control over error handling.

For the sake of clarity, let's define 2 terms:
- extended handler: API platform's handler that is instantiated in ApiPlatformDeferredProvider
- original handler: the handler that existed before extending and is passed to the extended handler

Factual observations:
- The `Illuminate\Contracts\Debug\ExceptionHandler` gets extended in the service provider, which passes the original handler  to the extended handler as `$decorated`.
- The extended handler checks if it is dealing with an API operation.
  - If it is, it runs the API platform logic. 
  - If it is not, it checks if there is a decorated handler
    - If there is, it calls the decorated handler's `render` method
    - If there is not, it calls the `render` method of the parent of the extended handler

Let's assume we add our own logic to `withExceptions` in bootstrap/app.php, everything defined in there is applied to the extended handler and not the original handler. So when falling through because it's not an API operation, and due to the fact that the decorated handler exists, `map` and `respond` doesn't work.

With the changes in this PR, the ErrorHandler is split up from the ErrorRenderer and a config is created to disable extending the original handler. My reasoning behind this is to allow developers to maintain full control over the exception handler. The ErrorRenderer can then still be called by the developer to run that logic when dealing with API operations.

The config has defaults that doesn't change anything for users. You'd have to explicitly disable the current behaviour.

In case you disable it, you can call the ErrorRenderer yourself in `respond`. For example:
```php
$exceptions->respond(function (Response $response, Throwable $exception, Request $request) {
    if ($this->apiPlatformRenderer->shouldRender($request, $exception)) {
        return $this->apiPlatformRenderer->render($request, $exception)
            ?? $response;
    }

    // Other custom logic
})
```

<details>
<summary>Reproduction</summary>

On a clean Laravel installation, create two exceptions (MyException and MyOtherException).

```php
// bootstrap/app.php
withExceptions(function (Exceptions $exceptions): void {
    $exceptions->map(MyException::class, MyOtherException::class);

    // or

    $exceptions->respond(function(Response $response, Throwable $e, Request $request) {
        return response()->view('error', [
            'status' => $response->getStatusCode(),
            'title' => get_class($e),
            'message' => $e->getMessage(),
        ]);
    });
})
````

<img width="401" height="226" alt="image" src="https://github.com/user-attachments/assets/f26ab689-c651-4577-9a42-794806fd3b82" />

<img width="670" height="298" alt="image" src="https://github.com/user-attachments/assets/28d7b97a-bd9a-42d5-a522-9023da9184a4" />

<img width="370" height="125" alt="image" src="https://github.com/user-attachments/assets/c5ef2ba0-ea67-40d1-8cd5-3392a2ff8103" />

Install api-platform/laravel, in both scenarios:

<img width="504" height="304" alt="image" src="https://github.com/user-attachments/assets/0c7460b2-c62c-4bbb-8666-47941941279e" />
</details>
