### PR TITLE
fix(validator): handle nested groups and group sequences

### DIFF
--- a/src/Symfony/Tests/Fixtures/DummyValidatedEntityWithGroupSequence.php
+++ b/src/Symfony/Tests/Fixtures/DummyValidatedEntityWithGroupSequence.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
-#[Assert\GroupSequence(['dummy', 'DummyValidatedEntityWithGroupSequence'])]
+#[Assert\GroupSequence(['dummy', 'DummyValidatedEntityWithGroupSequence', ['dummy2'], new Assert\GroupSequence(['dummy3'])])]
 class DummyValidatedEntityWithGroupSequence
 {
     /**
@@ -72,6 +72,18 @@ class DummyValidatedEntityWithGroupSequence
      */
     #[Assert\NotNull(groups: ['dummy'])]
     public $dummyGroup;
+
+    /**
+     * @var string A dummy group
+     */
+    #[Assert\NotNull(groups: ['dummy2'])]
+    public $dummyGroup2;
+
+    /**
+     * @var string A dummy group
+     */
+    #[Assert\NotNull(groups: ['dummy3'])]
+    public $dummyGroup3;
 
     /**
      * @var string A dummy url

--- a/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -142,13 +142,14 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
     }
 
-    public function testCreateWithPropertyWithRequiredConstraintsAndGroupSequence(): void
+    #[DataProvider('createWithPropertyWithRequiredConstraintsAndGroupSequenceDataProvider')]
+    public function testCreateWithPropertyWithRequiredConstraintsAndGroupSequence(string $propertyName): void
     {
         $propertyMetadata = (new ApiProperty())->withDescription('A dummy group')->withReadable(true)->withWritable(true);
         $expectedPropertyMetadata = $propertyMetadata->withRequired(true);
 
         $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
-        $decoratedPropertyMetadataFactory->create(DummyValidatedEntityWithGroupSequence::class, 'dummyGroup', [])->willReturn($propertyMetadata)->shouldBeCalled();
+        $decoratedPropertyMetadataFactory->create(DummyValidatedEntityWithGroupSequence::class, $propertyName, [])->willReturn($propertyMetadata)->shouldBeCalled();
 
         $validatorClassMetadata = new ClassMetadata(DummyValidatedEntityWithGroupSequence::class);
         (new AttributeLoader())->loadClassMetadata($validatorClassMetadata);
@@ -161,9 +162,19 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
             $decoratedPropertyMetadataFactory->reveal(),
             []
         );
-        $resultedPropertyMetadata = $validatorPropertyMetadataFactory->create(DummyValidatedEntityWithGroupSequence::class, 'dummyGroup');
+        $resultedPropertyMetadata = $validatorPropertyMetadataFactory->create(DummyValidatedEntityWithGroupSequence::class, $propertyName);
 
         $this->assertEquals($expectedPropertyMetadata, $resultedPropertyMetadata);
+    }
+
+    /**
+     * @return iterable<array{string}>
+     */
+    public static function createWithPropertyWithRequiredConstraintsAndGroupSequenceDataProvider(): iterable
+    {
+        yield ['dummyGroup'];
+        yield ['dummyGroup2'];
+        yield ['dummyGroup3'];
     }
 
     public function testCreateWithPropertyWithRightValidationGroupsAndRequiredConstraints(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 for bugfix
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Follow up of https://github.com/api-platform/core/pull/7784

GroupSequence->groups is `array<string|string[]|GroupSequence>` but was treated like a `array<string>`