### PR TITLE
Fix : Expose operation input class when defined in item normalizer

### DIFF
--- a/src/State/Provider/DeserializeProvider.php
+++ b/src/State/Provider/DeserializeProvider.php
@@ -100,7 +100,8 @@ final class DeserializeProvider implements ProviderInterface, StopwatchAwareInte
         unset($serializerContext[SerializerContextBuilderInterface::ASSIGN_OBJECT_TO_POPULATE]);
 
         try {
-            $data = $this->serializer->deserialize((string) $request->getContent(), $serializerContext['deserializer_type'] ?? $operation->getClass(), $format, $serializerContext);
+            $class = $operation->getInput()['class'] ?? $operation->getClass();
+            $data = $this->serializer->deserialize((string) $request->getContent(), $serializerContext['deserializer_type'] ?? $class, $format, $serializerContext);
         } catch (PartialDenormalizationException $e) {
             if (!class_exists(ConstraintViolationList::class)) {
                 throw $e;

--- a/src/State/Tests/Provider/DeserializeProviderTest.php
+++ b/src/State/Tests/Provider/DeserializeProviderTest.php
@@ -232,4 +232,23 @@ class DeserializeProviderTest extends TestCase
         $request->attributes->set('input_format', 'format');
         $provider->provide($operation, ['id' => 1], ['request' => $request]);
     }
+
+    public function testDeserializeWithInputClass(): void
+    {
+        $serializerContext = [];
+        $operation = new Post(deserialize: true, class: \stdClass::class, input: ['class' => 'InputClass']);
+        $decorated = $this->createStub(ProviderInterface::class);
+        $decorated->method('provide')->willReturn(null);
+
+        $serializerContextBuilder = $this->createMock(SerializerContextBuilderInterface::class);
+        $serializerContextBuilder->expects($this->once())->method('createFromRequest')->willReturn($serializerContext);
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())->method('deserialize')->with('test', 'InputClass', 'format', ['uri_variables' => ['id' => 1]] + $serializerContext)->willReturn(new \stdClass());
+
+        $provider = new DeserializeProvider($decorated, $serializer, $serializerContextBuilder);
+        $request = new Request(content: 'test');
+        $request->headers->set('CONTENT_TYPE', 'ok');
+        $request->attributes->set('input_format', 'format');
+        $provider->provide($operation, ['id' => 1], ['request' => $request]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| License       | MIT

To ensure backward compatibility with clients that send integer IDs instead of IRIs, I decorated api_platform.serializer.normalizer.item in my project.

I need to retrieve the operation’s input class, when defined, in order to properly convert IDs into IRIs with the correct resource type before delegating back to Api Platform.