### PR TITLE
fix(openapi): allow Operations to override global options in getPaginationParameters

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -798,10 +798,6 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
     private function getPaginationParameters(CollectionOperationInterface|HttpOperation $operation): array
     {
-        if (!$this->paginationOptions->isPaginationEnabled()) {
-            return [];
-        }
-
         $parameters = [];
 
         if ($operation->getPaginationEnabled() ?? $this->paginationOptions->isPaginationEnabled()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | 
| License       | MIT
| Doc PR        | N/A

If I understand correctly, this code is preventing a `page` parameter from showing up in OpenAPI docs, in the situation where pagination is disabled globally but enabled on an individual Operation.

Line 801 is short-circuit returning if `!$this->paginationOptions->isPaginationEnabled()` (from the global options), so then it never gets a chance to reach line 807 and check the Operation options with the global options as a fallback.