### PR TITLE
fix(laravel): do not exclude custom primary keys matching HasMany foreign keys

### DIFF
--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Laravel\Eloquent\Metadata;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
@@ -77,7 +78,10 @@ final class ModelMetadata
         $indexes = $schema->getIndexes($table);
         $relations = $this->getRelations($model);
 
-        $foreignKeys = array_flip(array_filter(array_column($relations, 'foreign_key')));
+        // Only exclude BelongsTo foreign keys — those are local columns on this model's table.
+        // HasMany/HasOne foreign keys reference the related table and should not be excluded.
+        $belongsToRelations = array_filter($relations, static fn ($r) => is_a($r['type'], BelongsTo::class, true));
+        $foreignKeys = array_flip(array_filter(array_column($belongsToRelations, 'foreign_key')));
         $attributes = [];
 
         foreach ($columns as $column) {

--- a/src/Laravel/Tests/Eloquent/Metadata/ModelMetadataTest.php
+++ b/src/Laravel/Tests/Eloquent/Metadata/ModelMetadataTest.php
@@ -20,6 +20,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Book;
+use Workbench\App\Models\Device;
 
 /**
  * @author Tobias Oitzinger <tobiasoitzinger@gmail.com>
@@ -79,5 +80,23 @@ final class ModelMetadataTest extends TestCase
 
         $metadata = new ModelMetadata();
         $this->assertCount(1, $metadata->getRelations($model));
+    }
+
+    /**
+     * When a model has a custom primary key (e.g. device_id) and a HasMany
+     * relation whose foreign key on the related table has the same name,
+     * the primary key must not be excluded from getAttributes().
+     *
+     * Only BelongsTo foreign keys are local columns that should be excluded.
+     * HasMany/HasOne foreign keys reference the related model's table.
+     */
+    public function testCustomPrimaryKeyNotExcludedByHasManyForeignKey(): void
+    {
+        $model = new Device();
+        $metadata = new ModelMetadata();
+        $attributes = $metadata->getAttributes($model);
+
+        $this->assertArrayHasKey('device_id', $attributes, 'Primary key "device_id" should not be excluded from attributes when it matches a HasMany foreign key name.');
+        $this->assertTrue($attributes['device_id']['primary'], 'The device_id attribute should be marked as primary key.');
     }
 }

--- a/src/Laravel/workbench/app/Models/Device.php
+++ b/src/Laravel/workbench/app/Models/Device.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Model with a custom primary key (device_id) that matches the foreign
+ * key name on the related Port model. Used to test that ModelMetadata
+ * does not incorrectly exclude the primary key from the attribute list.
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(),
+        new Get(),
+    ],
+)]
+class Device extends Model
+{
+    protected $primaryKey = 'device_id';
+    protected $fillable = ['hostname'];
+
+    public function ports(): HasMany
+    {
+        return $this->hasMany(Port::class, 'device_id', 'device_id');
+    }
+}

--- a/src/Laravel/workbench/app/Models/Port.php
+++ b/src/Laravel/workbench/app/Models/Port.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Child model with a foreign key (device_id) that matches the parent
+ * model's primary key name. Not an API resource itself.
+ */
+class Port extends Model
+{
+    protected $primaryKey = 'port_id';
+    protected $fillable = ['device_id', 'name'];
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(Device::class, 'device_id', 'device_id');
+    }
+}

--- a/src/Laravel/workbench/database/migrations/2026_03_01_000000_create_custom_pk_tables.php
+++ b/src/Laravel/workbench/database/migrations/2026_03_01_000000_create_custom_pk_tables.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/*
+ * Tables for testing custom primary key handling in ModelMetadata.
+ *
+ * Uses the common convention of <table>_id as primary key, where the
+ * PK name on the parent table matches the FK name on the child table.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('devices', static function (Blueprint $table): void {
+            $table->increments('device_id');
+            $table->string('hostname');
+            $table->timestamps();
+        });
+
+        Schema::create('ports', static function (Blueprint $table): void {
+            $table->increments('port_id');
+            $table->unsignedInteger('device_id');
+            $table->string('name');
+            $table->foreign('device_id')->references('device_id')->on('devices');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ports');
+        Schema::dropIfExists('devices');
+    }
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7190
| License       | MIT


## Summary

`ModelMetadata::getAttributes()` collects all foreign key names from discovered relations and excludes matching columns from the attribute list. For `HasMany`/`HasOne` relations, `getForeignKeyName()` returns the foreign key on the **related** table, not on the current model's table. When a model's primary key name matches a `HasMany` foreign key name (e.g. `devices.device_id` referenced by `ports.device_id`), the primary key is incorrectly excluded.

Only `BelongsTo` foreign keys are local columns that should be excluded from the attribute list.

| Relation type | `getForeignKeyName()` returns | Column lives on |
|---|---|---|
| `BelongsTo` | local FK column (e.g. `ports.device_id`) | **current** model |
| `HasMany` / `HasOne` | remote FK column (e.g. `ports.device_id`) | **related** model |
| `BelongsToMany` | pivot FK column | pivot table |

### Impact

When the primary key is excluded:
- Identifier discovery fails (no primary key in property collection)
- `Get` route is not registered
- IRI generation fails ("Unable to generate an IRI for the item of type ...")

### Reproduction

https://github.com/Jellyfrog/api-platform-bug/commit/c617ad8143e9769e2c72dd26de4494dc367f1726#diff-56d0c99da95b2d1d1621c1b694577893589ba6560b344eab93142ccad8c49ff6

Please note I used AI to generate the fix.