### PR TITLE
fix(laravel): exclude .blade.php files from recursive class scan

### DIFF
--- a/src/Laravel/ApiPlatformDeferredProvider.php
+++ b/src/Laravel/ApiPlatformDeferredProvider.php
@@ -100,7 +100,7 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
     public function register(): void
     {
         $directory = app_path();
-        $classes = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([$directory], '(?!.*Test\.php$)');
+        $classes = ReflectionClassRecursiveIterator::getReflectionClassesFromDirectories([$directory], '(?!.*(?:Test|\.blade)\.php$)');
 
         $this->autoconfigure($classes, QueryExtensionInterface::class, [FilterQueryExtension::class]);
         $this->app->singleton(ItemProvider::class, static function (Application $app) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The deferred provider scans app_path() for PHP classes but the ignore regex only excluded *Test.php files. Blade templates (*.blade.php) were matched and require_once'd, causing raw template content to be printed to stdout.