### PR TITLE
fix(odm): partial pagination limit the documents entering $facet

### DIFF
--- a/src/Doctrine/Odm/Extension/PaginationExtension.php
+++ b/src/Doctrine/Odm/Extension/PaginationExtension.php
@@ -67,6 +67,11 @@ final class PaginationExtension implements AggregationResultCollectionExtensionI
          */
         $repository = $manager->getRepository($resourceClass);
 
+        // Limit the documents entering $facet to avoid buffering the whole result set
+        if (!$doesCount && $limit > 0) {
+            $aggregationBuilder->limit($offset + $limit);
+        }
+
         $facet = $aggregationBuilder->facet();
         $addFields = $aggregationBuilder->addFields();
 

--- a/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
+++ b/src/Doctrine/Odm/Tests/Extension/PaginationExtensionTest.php
@@ -259,6 +259,24 @@ class PaginationExtensionTest extends TestCase
         $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', (new GetCollection())->withPaginationEnabled(true)->withPaginationClientEnabled(true)->withPaginationMaximumItemsPerPage(80), $context);
     }
 
+    public function testApplyToCollectionWithPartialPagination(): void
+    {
+        $pagination = new Pagination([
+            'partial' => true,
+            'page_parameter_name' => '_page',
+        ]);
+
+        $aggregationBuilderProphecy = $this->mockAggregationBuilder(20, 20, true);
+
+        $context = ['filters' => ['_page' => 2, 'itemsPerPage' => 20]];
+
+        $extension = new PaginationExtension(
+            $this->managerRegistryProphecy->reveal(),
+            $pagination
+        );
+        $extension->applyToCollection($aggregationBuilderProphecy->reveal(), 'Foo', (new GetCollection())->withPaginationEnabled(true)->withPaginationPartial(true)->withPaginationClientEnabled(true)->withPaginationItemsPerPage(20), $context);
+    }
+
     public function testSupportsResult(): void
     {
         $pagination = new Pagination();
@@ -430,11 +448,14 @@ class PaginationExtensionTest extends TestCase
         $this->assertInstanceOf(PaginatorInterface::class, $result);
     }
 
-    private function mockAggregationBuilder(int $expectedOffset, int $expectedLimit): ObjectProphecy
+    private function mockAggregationBuilder(int $expectedOffset, int $expectedLimit, bool $partial = false): ObjectProphecy
     {
         $countProphecy = $this->prophesize(Count::class);
         $countAggregationBuilderProphecy = $this->prophesize(Builder::class);
-        $countAggregationBuilderProphecy->count('count')->shouldBeCalled()->willReturn($countProphecy->reveal());
+
+        if (!$partial) {
+            $countAggregationBuilderProphecy->count('count')->shouldBeCalled()->willReturn($countProphecy->reveal());
+        }
 
         $repositoryProphecy = $this->prophesize(DocumentRepository::class);
 
@@ -448,10 +469,17 @@ class PaginationExtensionTest extends TestCase
 
         if ($expectedLimit > 0) {
             $resultsAggregationBuilderProphecy = $this->prophesize(Builder::class);
-            $repositoryProphecy->createAggregationBuilder()->shouldBeCalled()->willReturn(
-                $resultsAggregationBuilderProphecy->reveal(),
-                $countAggregationBuilderProphecy->reveal()
-            );
+
+            if ($partial) {
+                $repositoryProphecy->createAggregationBuilder()->shouldBeCalled()->willReturn(
+                    $resultsAggregationBuilderProphecy->reveal()
+                );
+            } else {
+                $repositoryProphecy->createAggregationBuilder()->shouldBeCalled()->willReturn(
+                    $resultsAggregationBuilderProphecy->reveal(),
+                    $countAggregationBuilderProphecy->reveal()
+                );
+            }
 
             $skipProphecy = $this->prophesize(Skip::class);
             $skipProphecy->limit($expectedLimit)->shouldBeCalled()->willReturn($skipProphecy->reveal());
@@ -467,8 +495,10 @@ class PaginationExtensionTest extends TestCase
             $addFieldsProphecy->literal([])->shouldBeCalled()->willReturn($addFieldsProphecy->reveal());
         }
 
-        $facetProphecy->field('count')->shouldBeCalled()->willReturn($facetProphecy->reveal());
-        $facetProphecy->pipeline($countProphecy)->shouldBeCalled()->willReturn($facetProphecy->reveal());
+        if (!$partial) {
+            $facetProphecy->field('count')->shouldBeCalled()->willReturn($facetProphecy->reveal());
+            $facetProphecy->pipeline($countProphecy)->shouldBeCalled()->willReturn($facetProphecy->reveal());
+        }
 
         $addFieldsProphecy->field('__api_first_result__')->shouldBeCalled()->willReturn($addFieldsProphecy->reveal());
         $addFieldsProphecy->literal($expectedOffset)->shouldBeCalled()->willReturn($addFieldsProphecy->reveal());
@@ -476,6 +506,11 @@ class PaginationExtensionTest extends TestCase
         $addFieldsProphecy->literal($expectedLimit)->shouldBeCalled()->willReturn($addFieldsProphecy->reveal());
 
         $aggregationBuilderProphecy = $this->prophesize(Builder::class);
+
+        if ($partial && $expectedLimit > 0) {
+            $aggregationBuilderProphecy->limit($expectedOffset + $expectedLimit)->shouldBeCalled();
+        }
+
         $aggregationBuilderProphecy->facet()->shouldBeCalled()->willReturn($facetProphecy->reveal());
         $aggregationBuilderProphecy->addFields()->shouldBeCalled()->willReturn($addFieldsProphecy->reveal());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2 <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->
With partial pagination the whole result set gets buffered into `$facet` which hits  `internalQueryFacetBufferSizeBytes` on large collections and silently truncates results.

Added a `$limit` before `$facet` to cap documents entering it (`offset + limit`), only when partial pagination is enabled since the count sub-pipeline needs the full set.