### PR TITLE
fix(laravel): add init-scalar-ui.js to Laravel’s assets

### DIFF
--- a/src/Laravel/public/init-scalar-ui.js
+++ b/src/Laravel/public/init-scalar-ui.js
@@ -1,0 +1,12 @@
+'use strict';
+
+window.onload = function() {
+    var data = JSON.parse(document.getElementById('swagger-data').innerText);
+
+    var config = Object.assign({
+        content: data.spec,
+        theme: 'default',
+    }, data.scalarExtraConfiguration || {});
+
+    Scalar.createApiReference('#swagger-ui', config);
+};


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

In #7817 support was added for Scalar UI for documentation. The javascript asset was added to the Symfony package and also referenced in the Laravel blade file, but the asset was missing from the Laravel package.

<img width="915" height="89" alt="image" src="https://github.com/user-attachments/assets/e566b0d0-2a24-49a4-bd7c-b36d3aa3ba78" />

There's also a minor styling issue where the content falls underneath the header:
<img width="1686" height="659" alt="image" src="https://github.com/user-attachments/assets/8c262d76-4276-48f3-9e49-1771e4b5d37e" />

The same styling issue is present when using redoc, which currently isn't supported in Laravel because it's not being checked/applied in `swagger-ui.blade.php`.