### PR TITLE
fix(laravel): improve UI selection for documentation

### DIFF
--- a/src/Laravel/ApiPlatformDeferredProvider.php
+++ b/src/Laravel/ApiPlatformDeferredProvider.php
@@ -185,7 +185,7 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
             $config = $app['config'];
             $tagged = iterator_to_array($app->tagged(ProcessorInterface::class));
 
-            if ($config->get('api-platform.swagger_ui.enabled', false)) {
+            if ($config->get('api-platform.swagger_ui.enabled', false) || $config->get('api-platform.redoc.enabled', false) || $config->get('api-platform.scalar.enabled', false)) {
                 // TODO: tag SwaggerUiProcessor instead?
                 $tagged['api_platform.swagger_ui.processor'] = $app->make(SwaggerUiProcessor::class);
             }
@@ -216,7 +216,7 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
             $config = $app['config'];
             $formats = $config->get('api-platform.formats');
 
-            if ($config->get('api-platform.swagger_ui.enabled', false) && !isset($formats['html'])) {
+            if (($config->get('api-platform.swagger_ui.enabled', false) || $config->get('api-platform.redoc.enabled', false) || $config->get('api-platform.scalar.enabled', false)) && !isset($formats['html'])) {
                 $formats['html'] = ['text/html'];
             }
 

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -406,7 +406,13 @@ class ApiPlatformProvider extends ServiceProvider
             /** @var ConfigRepository */
             $config = $app['config'];
 
-            return new SwaggerUiProvider($app->make(ReadProvider::class), $app->make(OpenApiFactoryInterface::class), $config->get('api-platform.swagger_ui.enabled', false), $config->get('api-platform.scalar.enabled', false));
+            return new SwaggerUiProvider(
+                decorated: $app->make(ReadProvider::class),
+                openApiFactory: $app->make(OpenApiFactoryInterface::class),
+                swaggerUiEnabled: $config->get('api-platform.swagger_ui.enabled', false),
+                scalarEnabled: $config->get('api-platform.scalar.enabled', false),
+                redocEnabled: $config->get('api-platform.redoc.enabled', false)
+            );
         });
 
         $this->app->singleton(DeserializeProvider::class, static function (Application $app) {
@@ -747,8 +753,10 @@ class ApiPlatformProvider extends ServiceProvider
                 oauthClientId: $config->get('api-platform.swagger_ui.oauth.clientId'),
                 oauthClientSecret: $config->get('api-platform.swagger_ui.oauth.clientSecret'),
                 oauthPkce: $config->get('api-platform.swagger_ui.oauth.pkce', false),
+                swaggerEnabled: $config->get('api-platform.swagger_ui.enabled', false),
                 scalarEnabled: $config->get('api-platform.scalar.enabled', false),
                 scalarExtraConfiguration: $config->get('api-platform.scalar.extra_configuration', []),
+                redocEnabled: $config->get('api-platform.redoc.enabled', false),
             );
         });
 
@@ -762,7 +770,20 @@ class ApiPlatformProvider extends ServiceProvider
             /** @var ConfigRepository */
             $config = $app['config'];
 
-            return new DocumentationController($app->make(ResourceNameCollectionFactoryInterface::class), $config->get('api-platform.title') ?? '', $config->get('api-platform.description') ?? '', $config->get('api-platform.version') ?? '', $app->make(OpenApiFactoryInterface::class), $app->make(ProviderInterface::class), $app->make(ProcessorInterface::class), $app->make(Negotiator::class), $config->get('api-platform.docs_formats'), $config->get('api-platform.swagger_ui.enabled', false), $config->get('api-platform.scalar.enabled', false));
+            return new DocumentationController(
+                resourceNameCollectionFactory: $app->make(ResourceNameCollectionFactoryInterface::class),
+                title: $config->get('api-platform.title') ?? '',
+                description: $config->get('api-platform.description') ?? '',
+                version: $config->get('api-platform.version') ?? '',
+                openApiFactory: $app->make(OpenApiFactoryInterface::class),
+                provider: $app->make(ProviderInterface::class),
+                processor: $app->make(ProcessorInterface::class),
+                negotiator: $app->make(Negotiator::class),
+                documentationFormats: $config->get('api-platform.docs_formats'),
+                swaggerUiEnabled: $config->get('api-platform.swagger_ui.enabled', false),
+                scalarEnabled: $config->get('api-platform.scalar.enabled', false),
+                redocEnabled: $config->get('api-platform.redoc.enabled', false),
+            );
         });
 
         $this->app->singleton(EntrypointController::class, static function (Application $app) {

--- a/src/Laravel/Controller/DocumentationController.php
+++ b/src/Laravel/Controller/DocumentationController.php
@@ -54,6 +54,7 @@ final class DocumentationController
         private readonly array $documentationFormats = [OpenApiNormalizer::JSON_FORMAT => ['application/vnd.openapi+json'], OpenApiNormalizer::FORMAT => ['application/json']],
         private readonly bool $swaggerUiEnabled = true,
         private readonly bool $scalarEnabled = true,
+        private readonly bool $redocEnabled = true,
     ) {
         $this->negotiator = $negotiator ?? new Negotiator();
     }
@@ -95,7 +96,7 @@ final class DocumentationController
             outputFormats: $this->documentationFormats
         );
 
-        if ('html' === $format && ($this->swaggerUiEnabled || $this->scalarEnabled)) {
+        if ('html' === $format && ($this->swaggerUiEnabled || $this->scalarEnabled || $this->redocEnabled)) {
             $operation = $operation->withProcessor('api_platform.swagger_ui.processor')->withWrite(true);
         }
 

--- a/src/Laravel/State/SwaggerUiProcessor.php
+++ b/src/Laravel/State/SwaggerUiProcessor.php
@@ -44,8 +44,10 @@ final class SwaggerUiProcessor implements ProcessorInterface
         private readonly ?string $oauthClientId = null,
         private readonly ?string $oauthClientSecret = null,
         private readonly bool $oauthPkce = false,
+        private readonly bool $swaggerEnabled = false,
         private readonly bool $scalarEnabled = false,
         private readonly array $scalarExtraConfiguration = [],
+        private readonly bool $redocEnabled = false,
     ) {
     }
 
@@ -97,7 +99,7 @@ final class SwaggerUiProcessor implements ProcessorInterface
 
         $swaggerData['scalarExtraConfiguration'] = $this->scalarExtraConfiguration;
 
-        return new Response(view('api-platform::swagger-ui', $swaggerContext + ['swagger_data' => $swaggerData, 'scalar_enabled' => $this->scalarEnabled]), 200);
+        return new Response(view('api-platform::swagger-ui', $swaggerContext + ['swagger_data' => $swaggerData, 'ui' => $this->getUi()]), 200);
     }
 
     /**
@@ -116,5 +118,26 @@ final class SwaggerUiProcessor implements ProcessorInterface
         }
 
         throw new RuntimeException(\sprintf('The operation "%s" cannot be found in the Swagger specification.', $swaggerData['operationId']));
+    }
+
+    private function getUi(): string
+    {
+        $requested = request()->query('ui');
+
+        $available = array_keys(array_filter([
+            'swagger' => $this->swaggerEnabled,
+            'redoc' => $this->redocEnabled,
+            'scalar' => $this->scalarEnabled,
+        ]));
+
+        if ([] === $available) {
+            throw new RuntimeException('No documentation UI is enabled.');
+        }
+
+        if (\in_array($requested, $available, true)) {
+            return $requested;
+        }
+
+        return $available[0];
     }
 }

--- a/src/Laravel/State/SwaggerUiProvider.php
+++ b/src/Laravel/State/SwaggerUiProvider.php
@@ -39,6 +39,7 @@ final class SwaggerUiProvider implements ProviderInterface
         private readonly OpenApiFactoryInterface $openApiFactory,
         private readonly bool $swaggerUiEnabled = true,
         private readonly bool $scalarEnabled = false,
+        private readonly bool $redocEnabled = false,
     ) {
     }
 
@@ -53,7 +54,7 @@ final class SwaggerUiProvider implements ProviderInterface
             !($operation instanceof HttpOperation)
             || !($request = $context['request'] ?? null)
             || 'html' !== $request->getRequestFormat()
-            || (!$this->swaggerUiEnabled && !$this->scalarEnabled)
+            || (!$this->swaggerUiEnabled && !$this->scalarEnabled && !$this->redocEnabled)
             || true === ($operation->getExtraProperties()['_api_disable_swagger_provider'] ?? false)
         ) {
             return $this->decorated->provide($operation, $uriVariables, $context);

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -97,6 +97,10 @@ return [
         AuthorizationException::class => 403,
     ],
 
+    'redoc' => [
+        'enabled' => true,
+    ],
+
     'scalar' => [
         'enabled' => true,
         'extra_configuration' => [],

--- a/src/Laravel/resources/views/swagger-ui.blade.php
+++ b/src/Laravel/resources/views/swagger-ui.blade.php
@@ -213,9 +213,12 @@
         @endif
 
         <div id="swagger-ui" class="api-platform"></div>
-        @if (($scalar_enabled ?? false) && request()->query('ui') === 'scalar')
+        @if ($ui === 'scalar')
             <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
             <script src="/vendor/api-platform/init-scalar-ui.js"></script>
+        @elseif ($ui === 'redoc')
+            <script src="/vendor/api-platform/redoc/redoc.standalone.js"></script>
+            <script src="/vendor/api-platform/init-redoc-ui.js"></script>
         @else
             <script src="/vendor/api-platform/swagger-ui/swagger-ui-bundle.js"></script>
             <script src="/vendor/api-platform/swagger-ui/swagger-ui-standalone-preset.js"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

With the recent addition of Scalar in #7817 and the mentioned issue of Redoc on Laravel in #7825, this PR improves the logic that chooses which UI should be shown.

Wherever in the code it checked for `swagger_ui.enabled`, it now also checks for `redoc` and `scalar`. As long as any one of those is true, the documentation will be rendered.

If no UI is explicitly given in the query parameters, it will take the first available UI. The order is: 1) swagger, 2) redoc, 3) scalar.

If the the requested UI is not available, it will also fallback to the first available UI.

If none are enabled, it will throw an exception. Although it should never even get here, because if none of the UIs are enabled, it should already have failed earlier in the process.

---

The minor styling issue with Redoc, where part of the content is underneath the header:
<img width="1684" height="518" alt="image" src="https://github.com/user-attachments/assets/14678148-6be3-4c5c-978e-f8f34329bef7" />
