### PR TITLE
fix(laravel): make api-platform/mcp optional (#7824)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1475,3 +1475,10 @@ jobs:
           composer require api-platform/laravel:"@dev" -W
           php ./artisan api-platform:install
         working-directory: 'test-api-platform-install'
+      - name: Smoke test
+        run: |
+          php ./artisan serve &
+          sleep 2
+          curl -f http://127.0.0.1:8000/api || exit 1
+          kill %1
+        working-directory: 'test-api-platform-install'

--- a/src/Laravel/ApiPlatformDeferredProvider.php
+++ b/src/Laravel/ApiPlatformDeferredProvider.php
@@ -201,15 +201,18 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
             return new CallableProvider(new ServiceLocator($tagged));
         });
 
+        $providers = [ItemProvider::class, CollectionProvider::class, ErrorProvider::class];
+
         if (class_exists(ToolProvider::class)) {
             $this->app->singleton(ToolProvider::class, static function (Application $app) {
                 return new ToolProvider(
                     $app->make(ObjectMapper::class)
                 );
             });
+            $providers[] = ToolProvider::class;
         }
 
-        $this->autoconfigure($classes, ProviderInterface::class, [ItemProvider::class, CollectionProvider::class, ErrorProvider::class, ToolProvider::class]);
+        $this->autoconfigure($classes, ProviderInterface::class, $providers);
 
         $this->app->singleton(ResourceMetadataCollectionFactoryInterface::class, function (Application $app) {
             /** @var ConfigRepository $config */
@@ -377,7 +380,7 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
      */
     public function provides(): array
     {
-        return [
+        $provides = [
             CallableProvider::class,
             CallableProcessor::class,
             ItemProvider::class,
@@ -390,7 +393,12 @@ class ApiPlatformDeferredProvider extends ServiceProvider implements DeferrableP
             'api_platform.graphql.state_provider.parameter',
             FieldsBuilderEnumInterface::class,
             ExceptionHandlerInterface::class,
-            ToolProvider::class,
         ];
+
+        if (class_exists(ToolProvider::class)) {
+            $provides[] = ToolProvider::class;
+        }
+
+        return $provides;
     }
 }

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -941,7 +941,9 @@ class ApiPlatformProvider extends ServiceProvider
             $this->registerGraphQl();
         }
 
-        $this->registerMcp();
+        if (class_exists(McpController::class)) {
+            $this->registerMcp();
+        }
 
         $this->app->singleton(JsonApiEntrypointNormalizer::class, static function (Application $app) {
             return new JsonApiEntrypointNormalizer(
@@ -1096,10 +1098,6 @@ class ApiPlatformProvider extends ServiceProvider
 
     private function registerMcp(): void
     {
-        if (!class_exists(McpController::class)) {
-            return;
-        }
-
         $this->app->singleton(Registry::class, static function (Application $app) {
             return new Registry(
                 null, // event dispatcher (todo)

--- a/src/Laravel/composer.json
+++ b/src/Laravel/composer.json
@@ -35,7 +35,6 @@
         "api-platform/json-schema": "^4.3",
         "api-platform/jsonld": "^4.3",
         "api-platform/metadata": "^4.3",
-        "api-platform/mcp": "^4.3",
         "api-platform/openapi": "^4.3",
         "api-platform/serializer": "^4.3",
         "api-platform/state": "^4.3",
@@ -56,6 +55,7 @@
     "require-dev": {
         "api-platform/graphql": "^4.3",
         "api-platform/http-cache": "^4.3",
+        "api-platform/mcp": "^4.3",
         "doctrine/dbal": "^4.0",
         "larastan/larastan": "^2.0 || ^3.0",
         "laravel/sanctum": "^4.0",
@@ -86,6 +86,7 @@
     "suggest": {
         "api-platform/graphql": "Enable GraphQl support.",
         "api-platform/http-cache": "Enable HTTP Cache support.",
+        "api-platform/mcp": "Enable MCP (Model Context Protocol) support for AI agents.",
         "phpstan/phpdoc-parser": "To support extracting metadata from PHPDoc."
     },
     "extra": {

--- a/src/Mcp/composer.json
+++ b/src/Mcp/composer.json
@@ -31,6 +31,7 @@
         "api-platform/metadata": "^4.3",
         "api-platform/json-schema": "^4.3",
         "mcp/sdk": "^0.4.0",
+        "symfony/object-mapper": "^7.4 || ^8.0",
         "symfony/polyfill-php85": "^1.32"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7824
| License       | MIT
| Doc PR        | ∅

* Move api-platform/mcp from require to suggest+require-dev
* Guard ToolProvider and registerMcp() with class_exists checks
* Add HTTP smoke test to laravel-e2e CI job

