### PR TITLE
fix(metadata): allow GraphQL-only resources without identifiers (#3975)

### DIFF
--- a/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
+++ b/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
@@ -99,6 +99,9 @@ trait MetadataCollectionFactoryTrait
             }
 
             if ($metadata instanceof GraphQlOperation) {
+                if (-1 === $index) {
+                    $resources[++$index] = $this->getResourceWithDefaults($resourceClass, $shortName, new ApiResource());
+                }
                 [$key, $operation] = $this->getOperationWithDefaults($resources[$index], $metadata);
                 $graphQlOperations = $resources[$index]->getGraphQlOperations();
                 $graphQlOperations[$key] = $operation;

--- a/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactory.php
@@ -73,7 +73,7 @@ final class NotExposedOperationResourceMetadataCollectionFactory implements Reso
         [$key, $operation] = $this->getOperationWithDefaults($resource, new NotExposed(), true, ['uriTemplate', 'uriVariables']); // @phpstan-ignore-line $resource is defined if count > 0
 
         if (!$this->linkFactory->createLinksFromIdentifiers($operation)) {
-            $operation = $operation->withUriTemplate(self::$skolemUriTemplate);
+            $operation = $operation->withUriTemplate(self::$skolemUriTemplate)->withUriVariables([]);
         }
 
         $operations->add($key, $operation)->sort(); // @phpstan-ignore-line $operation exists

--- a/src/Metadata/Tests/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/NotExposedOperationResourceMetadataCollectionFactoryTest.php
@@ -232,7 +232,7 @@ class NotExposedOperationResourceMetadataCollectionFactoryTest extends TestCase
                     types: ['https://schema.org/Book'],
                     operations: [
                         '_api_AttributeResource_get_collection' => new GetCollection(controller: 'api_platform.action.placeholder', shortName: 'AttributeResource', class: AttributeResource::class),
-                        '_api_AttributeResource_get' => new NotExposed(uriTemplate: '/.well-known/genid/{id}', controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false, extraProperties: ['generated_operation' => true], types: ['https://schema.org/Book']),
+                        '_api_AttributeResource_get' => new NotExposed(uriTemplate: '/.well-known/genid/{id}', uriVariables: [], controller: 'api_platform.action.not_exposed', shortName: 'AttributeResource', class: AttributeResource::class, output: false, read: false, extraProperties: ['generated_operation' => true], types: ['https://schema.org/Book']),
                     ],
                     class: AttributeResource::class
                 ),

--- a/tests/Fixtures/TestBundle/ApiResource/Issue3975/ActionSimulation.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue3975/ActionSimulation.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue3975;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+
+#[ApiResource(
+    operations: [],
+    graphQlOperations: [
+        new Query(
+            resolver: ActionSimulationResolver::class,
+            args: [
+                'actionId' => ['type' => 'String!'],
+                'structureEntityIds' => ['type' => '[String!]'],
+            ],
+            read: false,
+            name: 'get'
+        ),
+    ]
+)]
+class ActionSimulation
+{
+    public string $simulation = '0';
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue3975/ActionSimulationResolver.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue3975/ActionSimulationResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue3975;
+
+use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
+
+class ActionSimulationResolver implements QueryItemResolverInterface
+{
+    public function __invoke(?object $item, array $context): object
+    {
+        $simulation = new ActionSimulation();
+        $simulation->simulation = 'test';
+
+        return $simulation;
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -285,6 +285,10 @@ services:
         tags:
             - name: 'messenger.message_handler'
 
+    ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue3975\ActionSimulationResolver:
+        tags:
+            - name: 'api_platform.graphql.resolver'
+
     app.graphql.query_resolver.dummy_custom_item:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\GraphQl\Resolver\DummyCustomQueryItemResolver'
         tags:

--- a/tests/Functional/GraphQl/Issue3975Test.php
+++ b/tests/Functional/GraphQl/Issue3975Test.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue3975\ActionSimulation;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class Issue3975Test extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [ActionSimulation::class];
+    }
+
+    public function testGraphQlOnlyQueryWithProvider(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+{
+  getActionSimulation(actionId: "abc123", structureEntityIds: ["s1", "s2"]) {
+    simulation
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json);
+        $this->assertEquals('test', $json['data']['getActionSimulation']['simulation']);
+    }
+
+    public function testGraphQlOnlyQueryWithId(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+{
+  getActionSimulation(actionId: "abc123") {
+    id
+    simulation
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json);
+        $this->assertNotNull($json['data']['getActionSimulation']['id']);
+        $this->assertEquals('test', $json['data']['getActionSimulation']['simulation']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Fixes #3975
| License       | MIT
| Doc PR        | ∅

* Allow standalone #[Query] without #[ApiResource] by creating a default resource in MetadataCollectionFactoryTrait
* Set empty uriVariables on NotExposed skolem operations to prevent UriTemplateFactory from inferring a non-existent {id} variable

In some cases NotExposed was being set an uriVariable although it had non on the class.