### PR TITLE
fix(laravel): clear SkolemIriConverter state between requests

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -163,7 +163,9 @@ use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\SerializerContextBuilderInterface;
 use Illuminate\Config\Repository as ConfigRepository;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Negotiation\Negotiator;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -1234,6 +1236,10 @@ class ApiPlatformProvider extends ServiceProvider
             $typeBuilder = $this->app->make(ContextAwareTypeBuilderInterface::class);
             $typeBuilder->setFieldsBuilderLocator(new ServiceLocator(['api_platform.graphql.fields_builder' => $fieldsBuilder]));
         }
+
+        Event::listen(RequestHandled::class, function (): void {
+            $this->app->make(SkolemIriConverter::class)->reset();
+        });
 
         $this->loadRoutesFrom(__DIR__.'/routes/api.php');
     }

--- a/src/Laravel/Routing/SkolemIriConverter.php
+++ b/src/Laravel/Routing/SkolemIriConverter.php
@@ -42,6 +42,12 @@ final class SkolemIriConverter implements IriConverterInterface
         $this->objectHashMap = new \SplObjectStorage();
     }
 
+    public function reset(): void
+    {
+        $this->objectHashMap = new \SplObjectStorage();
+        $this->classHashMap = [];
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | #7829
| License       | MIT
| Doc PR        | ∅

* Add reset() method to clear $objectHashMap and $classHashMap
* Listen to RequestHandled event to reset state, preventing memory leak in Octane/long-running setups