### PR TITLE
fix(validator): fallback to message when detail is uninitialized

### DIFF
--- a/src/State/Tests/ErrorProviderTest.php
+++ b/src/State/Tests/ErrorProviderTest.php
@@ -14,18 +14,33 @@ declare(strict_types=1);
 namespace ApiPlatform\State\Tests;
 
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\ApiResource\Error;
 use ApiPlatform\State\ErrorProvider;
+use ApiPlatform\Validator\Exception\ValidationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class ErrorProviderTest extends TestCase
 {
+    public function testCreateFromExceptionWithValidationException(): void
+    {
+        $violation = new ConstraintViolation('This value is too long.', null, [], null, 'name', 'toolong');
+        $exception = new ValidationException(new ConstraintViolationList([$violation]));
+        $error = Error::createFromException($exception, 422);
+
+        $this->assertSame('An error occurred', $error->getTitle());
+        $this->assertSame($exception->getMessage(), $error->getDetail());
+        $this->assertSame(422, $error->getStatus());
+    }
+
     public function testErrorProviderProduction(): void
     {
         $provider = new ErrorProvider(debug: false);
         $request = Request::create('/');
         $request->attributes->set('exception', new \Exception());
-        /** @var \ApiPlatform\State\ApiResource\Error */
+        /** @var Error */
         $error = $provider->provide(new Get(), [], ['request' => $request]);
         $this->assertEquals('Internal Server Error', $error->getDetail());
     }

--- a/src/Validator/Exception/ValidationException.php
+++ b/src/Validator/Exception/ValidationException.php
@@ -111,6 +111,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
         if ($message instanceof ConstraintViolationListInterface) {
             $this->constraintViolationList = $message;
             parent::__construct($this->__toString(), $code ?? 0, $previous);
+            $this->detail = $this->getMessage();
 
             return;
         }
@@ -119,6 +120,7 @@ class ValidationException extends RuntimeException implements ConstraintViolatio
 
         trigger_deprecation('api_platform/core', '5.0', \sprintf('The "%s" exception will have a "%s" first argument in 5.x.', self::class, ConstraintViolationListInterface::class));
         parent::__construct($message ?: $this->__toString(), $code ?? 0, $previous);
+        $this->detail = $this->getMessage();
     }
 
     public function getId(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7843
| License       | MIT
| Doc PR        | ∅

ValidationException::$detail is a typed property with no default, causing an error when getDetail()/getDescription() are called before setDetail(). Fallback to getMessage() which contains the violation list.