### PR TITLE
fix(symfony): do not exclude resources from DI

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -270,10 +270,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             Put::class,
             ApiResource::class,
         ] as $class) {
-            $container->registerAttributeForAutoconfiguration($class, static function (ChildDefinition $definition) use ($class): void {
+            $container->registerAttributeForAutoconfiguration($class, static function (ChildDefinition $definition): void {
                 $definition->setAbstract(true)
-                    ->addTag('api_platform.resource')
-                    ->addTag('container.excluded', ['source' => 'by #['.(new \ReflectionClass($class))->getShortName().'] attribute']);
+                    ->addTag('api_platform.resource');
             });
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

From 4.2 to 4.3 ApiPlatform started to add the container.excluded tag to a lot of classes breaking some applications which was using Resource as Service.
Even if it might be an unwanted pattern from ApiPlatform, it would be great avoiding to introduce a BC break in a minor version.

I'm trying to remove the tag to see the impacts.