### PR TITLE
fix(validator): skip ValidateProcessor when ObjectMapper is not used

### DIFF
--- a/src/Symfony/EventListener/ValidateProcessorListener.php
+++ b/src/Symfony/EventListener/ValidateProcessorListener.php
@@ -45,6 +45,13 @@ final class ValidateProcessorListener
             return;
         }
 
+        // Only validate at the processor level when ObjectMapper is used (canMap() is true).
+        // Without ObjectMapper, the validate listener already handles validation,
+        // so running it again here would cause duplicate validation.
+        if (!$operation->canMap()) {
+            return;
+        }
+
         if (null === $operation->canWrite()) {
             $operation = $operation->withWrite(!$request->isMethodSafe());
         }

--- a/src/Symfony/Validator/State/ValidateProcessor.php
+++ b/src/Symfony/Validator/State/ValidateProcessor.php
@@ -44,6 +44,13 @@ final class ValidateProcessor implements ProcessorInterface
             return $this->decorated ? $this->decorated->process($data, $operation, $uriVariables, $context) : $data;
         }
 
+        // Only validate at the processor level when ObjectMapper is used (canMap() is true).
+        // Without ObjectMapper, ValidateProvider already handles validation in the provider chain,
+        // so running it again here would cause duplicate external API calls and DB queries.
+        if (!$operation->canMap()) {
+            return $this->decorated ? $this->decorated->process($data, $operation, $uriVariables, $context) : $data;
+        }
+
         $this->validator->validate($data, $operation->getValidationContext() ?? []);
 
         return $this->decorated ? $this->decorated->process($data, $operation, $uriVariables, $context) : $data;

--- a/tests/Fixtures/TestBundle/ApiResource/ValidateOnce.php
+++ b/tests/Fixtures/TestBundle/ApiResource/ValidateOnce.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Tests\Fixtures\TestBundle\Validator\CountableConstraint;
+
+/**
+ * Resource without ObjectMapper to test that validation runs only once.
+ *
+ * The CountableConstraint validator increments a static counter on each call.
+ * Without the fix, ValidateProvider + ValidateProcessor both trigger validation,
+ * causing the counter to reach 2 instead of 1.
+ */
+#[Post(
+    shortName: 'ValidateOnce',
+    uriTemplate: '/validate_once',
+    provider: [self::class, 'provide'],
+    processor: [self::class, 'process'],
+)]
+#[Get(
+    shortName: 'ValidateOnce',
+    uriTemplate: '/validate_once/{id}',
+    provider: [self::class, 'provide'],
+)]
+class ValidateOnce
+{
+    #[ApiProperty(identifier: true)]
+    public ?int $id = null;
+
+    #[CountableConstraint]
+    public string $name = '';
+
+    public static function provide(): self
+    {
+        $s = new self();
+        $s->id = 1;
+        $s->name = 'test';
+
+        return $s;
+    }
+
+    public static function process(self $data): self
+    {
+        $data->id = 1;
+
+        return $data;
+    }
+}

--- a/tests/Fixtures/TestBundle/Validator/CountableConstraint.php
+++ b/tests/Fixtures/TestBundle/Validator/CountableConstraint.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * A constraint that counts how many times its validator is invoked.
+ * Used to verify that validation is not run more than once per request.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+class CountableConstraint extends Constraint
+{
+}

--- a/tests/Fixtures/TestBundle/Validator/CountableConstraintValidator.php
+++ b/tests/Fixtures/TestBundle/Validator/CountableConstraintValidator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validator that counts invocations via a static counter.
+ * Reset the counter before each test with CountableConstraintValidator::$count = 0.
+ */
+class CountableConstraintValidator extends ConstraintValidator
+{
+    public static int $count = 0;
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        ++self::$count;
+    }
+}

--- a/tests/Functional/ValidateProcessorTest.php
+++ b/tests/Functional/ValidateProcessorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ValidateOnce;
+use ApiPlatform\Tests\Fixtures\TestBundle\Validator\CountableConstraintValidator;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Tests that validation is not run twice for resources without ObjectMapper.
+ *
+ * ValidateProvider (provider chain) and ValidateProcessor (processor chain) should
+ * not both validate the same data. ValidateProcessor should only run when
+ * ObjectMapper is used (canMap() is true).
+ */
+class ValidateProcessorTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [
+            ValidateOnce::class,
+        ];
+    }
+
+    public function testValidationRunsOnlyOnceWithoutObjectMapper(): void
+    {
+        CountableConstraintValidator::$count = 0;
+
+        self::createClient()->request('POST', '/validate_once', [
+            'json' => ['name' => 'test'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(1, CountableConstraintValidator::$count, 'Validation should run exactly once for resources without ObjectMapper.');
+    }
+}

--- a/tests/Symfony/Validator/State/ValidateProcessorTest.php
+++ b/tests/Symfony/Validator/State/ValidateProcessorTest.php
@@ -31,7 +31,7 @@ class ValidateProcessorTest extends TestCase
         $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->once())->method('validate')->with($obj, $validationContext);
         $processor = new ValidateProcessor($decorated, $validator);
-        $processor->process($obj, new Post(validationContext: $validationContext));
+        $processor->process($obj, new Post(map: true, validationContext: $validationContext));
     }
 
     public function testNoValidate(): void
@@ -75,7 +75,7 @@ class ValidateProcessorTest extends TestCase
         $validator = $this->createMock(ValidatorInterface::class);
         $validator->expects($this->once())->method('validate')->with($obj, $validationContext);
         $processor = new ValidateProcessor($decorated, $validator);
-        $processor->process($obj, new Post(validationContext: $validationContext));
+        $processor->process($obj, new Post(map: true, validationContext: $validationContext));
     }
 
     public function testDecoratorChainContinues(): void
@@ -110,5 +110,28 @@ class ValidateProcessorTest extends TestCase
         $processor = new ValidateProcessor($decorated, $validator);
         // Delete operations typically have write: false
         $processor->process($obj, new Post(write: false));
+    }
+
+    public function testSkipsWhenCanMapIsNull(): void
+    {
+        $obj = new \stdClass();
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->expects($this->once())->method('process')->with($obj)->willReturn($obj);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())->method('validate');
+        $processor = new ValidateProcessor($decorated, $validator);
+        // Default: map is null (no ObjectMapper), ValidateProvider already validated
+        $processor->process($obj, new Post());
+    }
+
+    public function testSkipsWhenCanMapIsFalse(): void
+    {
+        $obj = new \stdClass();
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->expects($this->once())->method('process')->with($obj)->willReturn($obj);
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->never())->method('validate');
+        $processor = new ValidateProcessor($decorated, $validator);
+        $processor->process($obj, new Post(map: false));
     }
 }


### PR DESCRIPTION
## Summary

`ValidateProcessor` (added in #7731) runs unconditionally in the processor chain, causing **double validation** for resources that don't use ObjectMapper (`#[Map]` attributes). Since `ValidateProvider` already validates in the provider chain, running `ValidateProcessor` again on the same (unmapped) data duplicates all constraint validators — including external API calls and DB queries.

This PR adds a `canMap()` check to both `ValidateProcessor` (state mode) and `ValidateProcessorListener` (event listener mode) so that processor-level validation only runs when `ObjectMapperInputProcessor` actually performed a DTO-to-entity mapping.

Fixes #7846

## Changes

- `ValidateProcessor`: skip validation when `canMap()` is `null` or `false`
- `ValidateProcessorListener`: same check, early return when `canMap()` is not `true`
- Updated existing unit tests (`testValidate`, `testPassesValidationContext`) to use `map: true`
- Added unit tests: `testSkipsWhenCanMapIsNull`, `testSkipsWhenCanMapIsFalse`
- Added functional test with a `CountableConstraintValidator` that asserts validation runs exactly once for a resource without ObjectMapper

## Test plan

- [x] Unit tests cover `ValidateProcessor` with `map: true`, `map: false`, and `map: null`
- [x] Functional test (`ValidateProcessorTest`) POSTs to a resource without `#[Map]` and asserts the validator is called exactly once
- [ ] CI runs the functional test in both modes (default state-based + `USE_SYMFONY_LISTENERS=1`)

Bug discovered and fix contributed by https://askara.ai, a healthcare-focused AI platform.