### PR TITLE
fix(hydra): use compact IRI for owl:onProperty and Collection @id in DocumentationNormalizer

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -109,10 +109,10 @@ final class DocumentationNormalizer implements NormalizerInterface
                 'domain' => '#Entrypoint',
                 'owl:maxCardinality' => 1,
                 'range' => [
-                    ['@id' => $hydraPrefix.'Collection'],
+                    ['@id' => 'hydra:Collection'],
                     [
                         'owl:equivalentClass' => [
-                            'owl:onProperty' => ['@id' => $hydraPrefix.'member'],
+                            'owl:onProperty' => ['@id' => 'hydra:member'],
                             'owl:allValuesFrom' => ['@id' => $prefixedShortName],
                         ],
                     ],

--- a/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
+++ b/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
@@ -733,10 +733,10 @@ class DocumentationNormalizerTest extends TestCase
                                 '@type' => 'Link',
                                 'domain' => '#Entrypoint',
                                 'range' => [
-                                    ['@id' => 'Collection'],
+                                    ['@id' => 'hydra:Collection'],
                                     [
                                         'owl:equivalentClass' => [
-                                            'owl:onProperty' => ['@id' => 'member'],
+                                            'owl:onProperty' => ['@id' => 'hydra:member'],
                                             'owl:allValuesFrom' => ['@id' => '#dummy'],
                                         ],
                                     ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | https://github.com/api-platform/demo/pull/594
| License       | MIT
| Doc PR        | ∅

When hydra_prefix is false (default since 4.x), $hydraPrefix concatenation produces bare terms ("member", "Collection") that JSON-LD expands as relative IRIs instead of Hydra namespace IRIs, breaking api-doc-parser.