### PR TITLE
fix(doctrine): reset nested_properties_info for non-nested properties in FreeTextQueryFilter

### DIFF
--- a/src/Doctrine/Orm/Filter/FreeTextQueryFilter.php
+++ b/src/Doctrine/Orm/Filter/FreeTextQueryFilter.php
@@ -55,12 +55,12 @@ final class FreeTextQueryFilter implements FilterInterface, ManagerRegistryAware
             $subParameter = $parameter->withProperty($property);
 
             $nestedPropertiesInfo = $parameter->getExtraProperties()['nested_properties_info'] ?? [];
-            if (isset($nestedPropertiesInfo[$property])) {
-                $subParameter = $subParameter->withExtraProperties([
-                    ...$subParameter->getExtraProperties(),
-                    'nested_properties_info' => [$property => $nestedPropertiesInfo[$property]],
-                ]);
-            }
+            $subParameter = $subParameter->withExtraProperties([
+                ...$subParameter->getExtraProperties(),
+                'nested_properties_info' => isset($nestedPropertiesInfo[$property])
+                    ? [$property => $nestedPropertiesInfo[$property]]
+                    : [],
+            ]);
 
             $this->filter->apply(
                 $qb,

--- a/tests/Fixtures/TestBundle/Entity/FreeTextArticle.php
+++ b/tests/Fixtures/TestBundle/Entity/FreeTextArticle.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\FreeTextQueryFilter;
+use ApiPlatform\Doctrine\Orm\Filter\OrFilter;
+use ApiPlatform\Doctrine\Orm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'search' => new QueryParameter(
+                    filter: new FreeTextQueryFilter(new OrFilter(new PartialSearchFilter(caseSensitive: true))),
+                    properties: ['content', 'tag.content'],
+                ),
+            ],
+        ),
+    ]
+)]
+class FreeTextArticle
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $content;
+
+    #[ORM\ManyToOne(targetEntity: FreeTextTag::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?FreeTextTag $tag = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function getTag(): ?FreeTextTag
+    {
+        return $this->tag;
+    }
+
+    public function setTag(?FreeTextTag $tag): self
+    {
+        $this->tag = $tag;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/FreeTextTag.php
+++ b/tests/Fixtures/TestBundle/Entity/FreeTextTag.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class FreeTextTag
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private string $content;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+}

--- a/tests/Functional/Parameters/FreeTextQueryFilterNestedTest.php
+++ b/tests/Functional/Parameters/FreeTextQueryFilterNestedTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FreeTextArticle;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FreeTextTag;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class FreeTextQueryFilterNestedTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [FreeTextArticle::class, FreeTextTag::class];
+    }
+
+    /**
+     * Tests that FreeTextQueryFilter with mixed nested and non-nested properties
+     * generates correct SQL aliases (non-nested properties should not use the join alias).
+     */
+    public function testMixedNestedAndNonNestedProperties(): void
+    {
+        $client = $this->createClient();
+
+        // Should match article1 by root content
+        $response = $client->request('GET', '/free_text_articles?search=root-match')->toArray();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        // Should match article2 by tag.content
+        $response = $client->request('GET', '/free_text_articles?search=tag-match')->toArray();
+        $this->assertJsonContains(['totalItems' => 1]);
+
+        // Should match both articles (article1 root content contains "shared", article3 tag content contains "shared")
+        $response = $client->request('GET', '/free_text_articles?search=shared')->toArray();
+        $this->assertJsonContains(['totalItems' => 2]);
+
+        // Should match nothing
+        $response = $client->request('GET', '/free_text_articles?search=nonexistent')->toArray();
+        $this->assertJsonContains(['totalItems' => 0]);
+    }
+
+    protected function setUp(): void
+    {
+        $this->recreateSchema([FreeTextArticle::class, FreeTextTag::class]);
+        $this->loadFixtures();
+    }
+
+    private function loadFixtures(): void
+    {
+        $manager = $this->getManager();
+
+        $tag1 = new FreeTextTag();
+        $tag1->setContent('unrelated-tag');
+
+        $tag2 = new FreeTextTag();
+        $tag2->setContent('tag-match-value');
+
+        $tag3 = new FreeTextTag();
+        $tag3->setContent('shared-tag');
+
+        $manager->persist($tag1);
+        $manager->persist($tag2);
+        $manager->persist($tag3);
+
+        // article1: root content matches "root-match" and "shared", tag does not
+        $article1 = new FreeTextArticle();
+        $article1->setContent('root-match-shared');
+        $article1->setTag($tag1);
+
+        // article2: root content does not match, but tag matches "tag-match"
+        $article2 = new FreeTextArticle();
+        $article2->setContent('nothing-special');
+        $article2->setTag($tag2);
+
+        // article3: root content does not match "shared", but tag matches "shared"
+        $article3 = new FreeTextArticle();
+        $article3->setContent('nothing-here');
+        $article3->setTag($tag3);
+
+        $manager->persist($article1);
+        $manager->persist($article2);
+        $manager->persist($article3);
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes #7845
| License       | MIT
| Doc PR        | ∅

Non-nested properties incorrectly inherited the full nested_properties_info map, causing addNestedParameterJoins to pick up wrong join aliases via reset(). Always override nested_properties_info: scoped entry for nested, empty for non-nested.
