### PR TITLE
fix(serializer): evaluate ApiProperty security on input DTOs

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Exception\AccessDeniedException;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Exception\ItemNotFoundException;
+use ApiPlatform\Metadata\Exception\PropertyNotFoundException;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -276,10 +277,6 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         $previousObject = $this->clone($objectToPopulate);
         $object = parent::denormalize($data, $type, $format, $context);
 
-        if (!$this->resourceClassResolver->isResourceClass($type)) {
-            return $object;
-        }
-
         // Bypass the post-denormalize attribute revert logic if the object could not be
         // cloned since we cannot possibly revert any changes made to it.
         if (null !== $objectToPopulate && null === $previousObject) {
@@ -296,7 +293,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         // Revert attributes that aren't allowed to be changed after a post-denormalize check
         foreach (array_keys($data) as $attribute) {
             $attribute = $this->nameConverter ? $this->nameConverter->denormalize((string) $attribute) : $attribute;
-            $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $attribute, $options);
+
+            try {
+                $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $attribute, $options);
+            } catch (PropertyNotFoundException) {
+                continue;
+            }
+
             $attributeExtraProperties = $propertyMetadata->getExtraProperties();
             $throwOnPropertyAccessDenied = $attributeExtraProperties['throw_on_access_denied'] ?? $throwOnAccessDenied;
             if (!\in_array($attribute, $propertyNames, true)) {
@@ -500,12 +503,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
      */
     protected function canAccessAttribute(?object $object, string $attribute, array $context = []): bool
     {
-        if (!$this->resourceClassResolver->isResourceClass($context['resource_class'])) {
+        $options = $this->getFactoryOptions($context);
+
+        try {
+            $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $attribute, $options);
+        } catch (PropertyNotFoundException) {
             return true;
         }
-
-        $options = $this->getFactoryOptions($context);
-        $propertyMetadata = $this->propertyMetadataFactory->create($context['resource_class'], $attribute, $options);
         $security = $propertyMetadata->getSecurity() ?? $propertyMetadata->getPolicy();
         if (null !== $this->resourceAccessChecker && $security) {
             return $this->resourceAccessChecker->isGranted($context['resource_class'], $security, [

--- a/tests/Fixtures/TestBundle/ApiResource/DummyDtoSecuredInput.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DummyDtoSecuredInput.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\SecuredInputDto;
+
+#[ApiResource(
+    operations: [
+        new Get(provider: [self::class, 'provide']),
+        new Patch(input: SecuredInputDto::class, processor: [self::class, 'process'], provider: [self::class, 'provide']),
+    ]
+)]
+class DummyDtoSecuredInput
+{
+    public ?int $id = null;
+
+    public ?string $title = null;
+
+    public ?string $adminOnly = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        $entity = new self();
+        $entity->id = (int) $uriVariables['id'];
+        $entity->title = 'existing title';
+        $entity->adminOnly = 'existing admin value';
+
+        return $entity;
+    }
+
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        if (!$data instanceof SecuredInputDto) {
+            throw new \InvalidArgumentException('Expected SecuredInputDto');
+        }
+
+        $entity = $context['previous_data'] ?? new self();
+        if (null !== $data->title) {
+            $entity->title = $data->title;
+        }
+        if (null !== $data->adminOnly) {
+            $entity->adminOnly = $data->adminOnly;
+        }
+
+        return $entity;
+    }
+}

--- a/tests/Fixtures/TestBundle/Dto/SecuredInputDto.php
+++ b/tests/Fixtures/TestBundle/Dto/SecuredInputDto.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+class SecuredInputDto
+{
+    public ?string $title = null;
+
+    #[ApiProperty(security: "is_granted('ROLE_ADMIN')")]
+    public ?string $adminOnly = null;
+}

--- a/tests/Functional/SecurityPropertyInputDtoTest.php
+++ b/tests/Functional/SecurityPropertyInputDtoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DummyDtoSecuredInput;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+final class SecurityPropertyInputDtoTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [DummyDtoSecuredInput::class];
+    }
+
+    public function testNonAdminCannotWriteSecuredProperty(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new InMemoryUser('user', 'password', ['ROLE_USER']));
+
+        $response = $client->request('PATCH', '/dummy_dto_secured_inputs/1', [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'title' => 'updated title',
+                'adminOnly' => 'hacked value',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray();
+        $this->assertSame('updated title', $json['title']);
+        // The adminOnly field should be silently dropped (not written) for non-admin
+        $this->assertSame('existing admin value', $json['adminOnly']);
+    }
+
+    public function testAdminCanWriteSecuredProperty(): void
+    {
+        $client = self::createClient();
+        $client->loginUser(new InMemoryUser('admin', 'password', ['ROLE_ADMIN']));
+
+        $response = $client->request('PATCH', '/dummy_dto_secured_inputs/1', [
+            'headers' => ['Content-Type' => 'application/merge-patch+json'],
+            'json' => [
+                'title' => 'admin updated',
+                'adminOnly' => 'admin value',
+            ],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray();
+        $this->assertSame('admin updated', $json['title']);
+        $this->assertSame('admin value', $json['adminOnly']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | ∅
| License       | MIT
| Doc PR        | ∅

* Remove isResourceClass guards in canAccessAttribute() and post-denormalize block — only resource classes and input DTOs reach AbstractItemNormalizer via supportsDenormalization(), so the guards were preventing security evaluation on input DTOs while providing no protection for embedded objects.
* Add PropertyNotFoundException catch for input DTO properties that may not exist in the resource metadata chain.
