### PR TITLE
fix(laravel): resolve casts defined via casts() method

### DIFF
--- a/src/Laravel/Eloquent/Metadata/ModelMetadata.php
+++ b/src/Laravel/Eloquent/Metadata/ModelMetadata.php
@@ -268,6 +268,13 @@ final class ModelMetadata
     /**
      * Gets the model casts, including any date casts.
      *
+     * In Laravel 11+, casts can be defined via the protected casts() method
+     * in addition to the $casts property. Since models may be instantiated
+     * without calling the constructor (newInstanceWithoutConstructor),
+     * initializeHasAttributes() is never called and the casts() method
+     * results are not merged into $casts. We call casts() via reflection
+     * to ensure both sources are included.
+     *
      * @return array<string, mixed>
      */
     private function getCastsWithDates(Model $model): array
@@ -280,7 +287,15 @@ final class ModelMetadata
             }
         }
 
-        return array_merge($dateCasts, $model->getCasts());
+        $casts = $model->getCasts();
+
+        try {
+            $castsMethod = new \ReflectionMethod($model, 'casts');
+            $casts = array_merge($casts, $castsMethod->invoke($model));
+        } catch (\ReflectionException) {
+        }
+
+        return array_merge($dateCasts, $casts);
     }
 
     /**

--- a/src/Laravel/Tests/Eloquent/Metadata/ModelMetadataTest.php
+++ b/src/Laravel/Tests/Eloquent/Metadata/ModelMetadataTest.php
@@ -20,6 +20,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 use Workbench\App\Models\Book;
+use Workbench\App\Models\BookWithMethodCasts;
 use Workbench\App\Models\Device;
 
 /**
@@ -80,6 +81,25 @@ final class ModelMetadataTest extends TestCase
 
         $metadata = new ModelMetadata();
         $this->assertCount(1, $metadata->getRelations($model));
+    }
+
+    /**
+     * Casts defined via the casts() method (Laravel 11+) should be detected
+     * just like those defined via the $casts property.
+     *
+     * @see https://github.com/api-platform/core/issues/7662
+     */
+    public function testCastsMethodIsDetected(): void
+    {
+        // Use newInstanceWithoutConstructor to replicate how API Platform creates models
+        $refl = new \ReflectionClass(BookWithMethodCasts::class);
+        $model = $refl->newInstanceWithoutConstructor();
+
+        $metadata = new ModelMetadata();
+        $attributes = $metadata->getAttributes($model);
+
+        $this->assertSame('boolean', $attributes['is_available']['cast']);
+        $this->assertSame('datetime', $attributes['publication_date']['cast']);
     }
 
     /**

--- a/src/Laravel/workbench/app/Models/BookWithMethodCasts.php
+++ b/src/Laravel/workbench/app/Models/BookWithMethodCasts.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Model that uses the casts() method instead of the $casts property.
+ *
+ * @see https://github.com/api-platform/core/issues/7662
+ */
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+    ],
+)]
+class BookWithMethodCasts extends Model
+{
+    use HasUlids;
+
+    protected $table = 'books';
+
+    protected $visible = ['name', 'isbn', 'publication_date', 'is_available'];
+    protected $fillable = ['name', 'isbn', 'publication_date', 'is_available'];
+
+    protected function casts(): array
+    {
+        return [
+            'is_available' => 'boolean',
+            'publication_date' => 'datetime',
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7662
| License       | MIT
| Doc PR        | ∅

Models created with newInstanceWithoutConstructor() skip initializeHasAttributes(), so casts() method results are never merged into $casts. Use reflection to call casts() in getCastsWithDates().