### PR TITLE
fix(metadata): read operation tags from OpenAPI context in XML

### DIFF
--- a/src/Metadata/Extractor/XmlResourceExtractor.php
+++ b/src/Metadata/Extractor/XmlResourceExtractor.php
@@ -202,7 +202,7 @@ final class XmlResourceExtractor extends AbstractResourceExtractor
             $data[$attributeName] = $this->phpize($attributes, $attributeName, 'deprecated' === $attributeName ? 'bool' : 'string');
         }
 
-        $data['tags'] = $this->buildArrayValue($resource, 'tag');
+        $data['tags'] = $this->buildArrayValue($openapi, 'tag');
 
         if (isset($openapi->responses->response)) {
             foreach ($openapi->responses->response as $response) {


### PR DESCRIPTION
| Q       | A |
|---------|---|
| Branch | 4.2 |
| Tickets | N/A |
| License | MIT |
| Doc PR  | N/A |

 Fix reading tags defined in the OpenAPI context of an operation when using XML.
Duplicates previously opened pr targeting 4.3 https://github.com/api-platform/core/pull/7857.