### PR TITLE
fix(serializer): disable normalizer cache to prevent wrong normalizer in worker mode

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -130,7 +130,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
     public function getSupportedTypes(?string $format): array
     {
         return [
-            'object' => true,
+            'object' => false,
         ];
     }
 

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -90,7 +90,7 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
         $this->assertFalse($normalizer->supportsNormalization([]));
-        $this->assertSame(['object' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => false], $normalizer->getSupportedTypes('any'));
     }
 
     public function testNormalize(): void

--- a/src/Serializer/Tests/ItemNormalizerTest.php
+++ b/src/Serializer/Tests/ItemNormalizerTest.php
@@ -71,7 +71,7 @@ class ItemNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertTrue($normalizer->supportsDenormalization($dummy, Dummy::class));
         $this->assertFalse($normalizer->supportsDenormalization($std, \stdClass::class));
-        $this->assertSame(['object' => true], $normalizer->getSupportedTypes('any'));
+        $this->assertSame(['object' => false], $normalizer->getSupportedTypes('any'));
     }
 
     public function testNormalize(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #7868
| License       | MIT
| Doc PR        | ∅

* Change getSupportedTypes() from ['object' => true] to ['object' => false] so supportsNormalization() is called fresh each time with current context
* In FrankenPHP worker mode, the stale cache caused ItemNormalizer to incorrectly handle output DTOs appearing as nested objects in other resources
