### PR TITLE
fix(doctrine): skip links with no join info when fromClass differs from entityClass

### DIFF
--- a/src/Doctrine/Orm/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Orm/State/LinksHandlerTrait.php
@@ -68,7 +68,11 @@ trait LinksHandlerTrait
             $hasCompositeIdentifiers = 1 < \count($identifierProperties);
 
             if (!$link->getFromProperty() && !$link->getToProperty()) {
-                $currentAlias = $fromClass === $entityClass ? $alias : $queryNameGenerator->generateJoinAlias($alias);
+                if ($fromClass !== $entityClass) {
+                    continue;
+                }
+
+                $currentAlias = $alias;
 
                 foreach ($identifierProperties as $identifierProperty) {
                     $placeholder = $queryNameGenerator->generateParameterName($identifierProperty);

--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -87,7 +87,13 @@ final class ReadLinkParameterProvider implements ParameterProviderInterface
             throw new NotFoundHttpException('Relation for link security not found.');
         }
 
-        $context['request']?->attributes->set($securityObjectName, $relation);
+        // Only set the request attribute if the security object name differs from the parameter key.
+        // When they are the same, SecurityParameterProvider already has the value via $parameter->getKey() => $value,
+        // and setting the request attribute would overwrite the route parameter (a scalar) with an entity object,
+        // breaking IRI generation.
+        if ($securityObjectName !== $parameter->getKey()) {
+            $context['request']?->attributes->set($securityObjectName, $relation);
+        }
 
         if ($parameter instanceof Link) {
             $uriVariables = $operation->getUriVariables();

--- a/tests/Fixtures/TestBundle/Entity/Issue7797/Pairing.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7797/Pairing.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7797;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Link;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @see https://github.com/api-platform/core/issues/7797
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            uriTemplate: '/issue7797_plans/{planId}/pairings',
+            uriVariables: [
+                'planId' => new Link(
+                    fromClass: Plan::class,
+                    security: 'true',
+                ),
+            ],
+        ),
+    ],
+)]
+#[ORM\Entity]
+class Pairing
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name = '';
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7797/Plan.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7797/Plan.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7797;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(operations: [new Get()])]
+#[ORM\Entity]
+class Plan
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name = '';
+}

--- a/tests/Functional/Parameters/LinkProviderParameterTest.php
+++ b/tests/Functional/Parameters/LinkProviderParameterTest.php
@@ -21,6 +21,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Company;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Employee;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7469Dummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7797\Pairing;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7797\Plan;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedOwnedDummy;
 use ApiPlatform\Tests\RecreateSchemaTrait;
@@ -38,7 +40,7 @@ final class LinkProviderParameterTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [WithParameter::class, Dummy::class, Employee::class, Company::class, LinkParameterProviderResource::class, Issue7469TestResource::class, Issue7469Dummy::class];
+        return [WithParameter::class, Dummy::class, Employee::class, Company::class, LinkParameterProviderResource::class, Issue7469TestResource::class, Issue7469Dummy::class, Pairing::class, Plan::class];
     }
 
     /**
@@ -46,7 +48,7 @@ final class LinkProviderParameterTest extends ApiTestCase
      */
     protected function setUp(): void
     {
-        $this->recreateSchema([Dummy::class, RelatedOwnedDummy::class, RelatedDummy::class, Employee::class, Company::class, Issue7469Dummy::class]);
+        $this->recreateSchema([Dummy::class, RelatedOwnedDummy::class, RelatedDummy::class, Employee::class, Company::class, Issue7469Dummy::class, Plan::class, Pairing::class]);
     }
 
     public function testReadDummyProviderFromQueryParameter(): void
@@ -203,6 +205,34 @@ final class LinkProviderParameterTest extends ApiTestCase
 
         $this->assertJsonContains([
             '@id' => '/link_parameter_provider_resources/1',
+        ]);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/7797
+     */
+    public function testSecurityLinkWithDifferentFromClassDoesNotBreakDoctrine(): void
+    {
+        $container = static::getContainer();
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $manager = $this->getManager();
+        $plan = new Plan();
+        $plan->name = 'Test Plan';
+        $manager->persist($plan);
+        $pairing = new Pairing();
+        $pairing->name = 'Test Pairing';
+        $manager->persist($pairing);
+        $manager->flush();
+
+        $response = self::createClient()->request('GET', '/issue7797_plans/'.$plan->id.'/pairings');
+        self::assertResponseStatusCodeSame(200);
+        self::assertJsonContains([
+            'hydra:member' => [
+                ['name' => 'Test Pairing'],
+            ],
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7797
| License       | MIT
| Doc PR        | ∅

* Skip links without fromProperty/toProperty when fromClass !== entityClass in LinksHandlerTrait to prevent undefined DQL alias
* Avoid overwriting route parameters with entity objects in ReadLinkParameterProvider when securityObjectName falls back to parameter key
