### PR TITLE
fix(state): prioritize input class over output in ObjectMapperProvider

### DIFF
--- a/src/State/Provider/ObjectMapperProvider.php
+++ b/src/State/Provider/ObjectMapperProvider.php
@@ -41,7 +41,7 @@ final class ObjectMapperProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $data = $this->decorated->provide($operation, $uriVariables, $context);
-        $class = $operation->getOutput()['class'] ?? $operation->getClass();
+        $class = $operation->getInput()['class'] ?? $operation->getOutput()['class'] ?? $operation->getClass();
 
         if (!$this->objectMapper || !$operation->canMap()) {
             return $data;

--- a/tests/State/Provider/ObjectMapperProviderTest.php
+++ b/tests/State/Provider/ObjectMapperProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\State\Provider;
 
 use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
 use ApiPlatform\State\Pagination\ArrayPaginator;
 use ApiPlatform\State\Pagination\MappedObjectPaginator;
 use ApiPlatform\State\Provider\ObjectMapperProvider;
@@ -168,6 +169,42 @@ class ObjectMapperProviderTest extends TestCase
         $this->assertSame($targetResource2, $items[1]);
     }
 
+    public function testProvideMapsToInputClassWhenInputIsSet(): void
+    {
+        $sourceEntity = new SourceEntity();
+        $inputResource = new InputResource();
+        $operation = new Patch(class: TargetResource::class, input: ['class' => InputResource::class], output: ['class' => OutputResource::class], map: true);
+        $objectMapper = $this->createMock(ObjectMapperInterface::class);
+        $objectMapper->expects($this->once())
+            ->method('map')
+            ->with($sourceEntity, InputResource::class)
+            ->willReturn($inputResource);
+        $decorated = $this->createStub(ProviderInterface::class);
+        $decorated->method('provide')->willReturn($sourceEntity);
+        $provider = new ObjectMapperProvider($objectMapper, $decorated);
+
+        $result = $provider->provide($operation);
+        $this->assertSame($inputResource, $result);
+    }
+
+    public function testProvideMapsToOutputClassWhenNoInput(): void
+    {
+        $sourceEntity = new SourceEntity();
+        $outputResource = new OutputResource();
+        $operation = new Get(class: TargetResource::class, output: ['class' => OutputResource::class], map: true);
+        $objectMapper = $this->createMock(ObjectMapperInterface::class);
+        $objectMapper->expects($this->once())
+            ->method('map')
+            ->with($sourceEntity, OutputResource::class)
+            ->willReturn($outputResource);
+        $decorated = $this->createStub(ProviderInterface::class);
+        $decorated->method('provide')->willReturn($sourceEntity);
+        $provider = new ObjectMapperProvider($objectMapper, $decorated);
+
+        $result = $provider->provide($operation);
+        $this->assertSame($outputResource, $result);
+    }
+
     public function testProvideMapsEmptyArray(): void
     {
         $operation = new Get(class: TargetResource::class, map: true);
@@ -206,4 +243,14 @@ class SourceEntity
 class TargetResource
 {
     public string $name = 'target';
+}
+
+class InputResource
+{
+    public string $name = 'input';
+}
+
+class OutputResource
+{
+    public string $name = 'output';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #7745
| License       | MIT
| Doc PR        | ∅

ObjectMapperProvider always mapped to the output class, breaking PATCH operations with separate input/output DTOs. The deserialized data was mapped to the output instead of the input, preventing proper merge.
