### PR TITLE
test(state): add failing test for nested DTO mapping with source-only Map attribute

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/Issue7801/Issue7801CategoryDto.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7801/Issue7801CategoryDto.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7801;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801\Issue7801Category;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    operations: [
+        new Get(),
+    ],
+    shortName: 'Issue7801Category',
+    stateOptions: new Options(entityClass: Issue7801Category::class)
+)]
+#[Map(source: Issue7801Category::class)]
+class Issue7801CategoryDto
+{
+    public ?int $id = null;
+
+    public string $name;
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7801/Issue7801ProductDto.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7801/Issue7801ProductDto.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7801;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801\Issue7801Product;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    operations: [
+        new Get(),
+        new GetCollection(),
+    ],
+    shortName: 'Issue7801Product',
+    stateOptions: new Options(entityClass: Issue7801Product::class)
+)]
+#[Map(source: Issue7801Product::class)]
+class Issue7801ProductDto
+{
+    public ?int $id = null;
+
+    public string $name;
+
+    public ?Issue7801CategoryDto $category = null;
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7801/Issue7801Category.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7801/Issue7801Category.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Issue7801Category
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    public string $name;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Issue7801/Issue7801Product.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue7801/Issue7801Product.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Issue7801Product
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    public string $name;
+
+    #[ORM\ManyToOne(targetEntity: Issue7801Category::class)]
+    public ?Issue7801Category $category = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(?int $id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/tests/Functional/Doctrine/StateOptionTest.php
+++ b/tests/Functional/Doctrine/StateOptionTest.php
@@ -17,9 +17,13 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6039\UserApi;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7689\Issue7689CategoryDto;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7689\Issue7689ProductDto;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7801\Issue7801CategoryDto;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7801\Issue7801ProductDto;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6039\Issue6039EntityUser;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7689\Issue7689Category;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7689\Issue7689Product;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801\Issue7801Category;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue7801\Issue7801Product;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
@@ -36,7 +40,7 @@ final class StateOptionTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [UserApi::class, Issue7689ProductDto::class, Issue7689CategoryDto::class];
+        return [UserApi::class, Issue7689ProductDto::class, Issue7689CategoryDto::class, Issue7801ProductDto::class, Issue7801CategoryDto::class];
     }
 
     public function testDtoWithEntityClassOptionCollection(): void
@@ -90,5 +94,37 @@ final class StateOptionTest extends ApiTestCase
         $product = $manager->getRepository(Issue7689Product::class)->findOneBy(['name' => 'product']);
         $this->assertNotNull($product->category);
         $this->assertEquals(1, $product->category->getId());
+    }
+
+    public function testGetWithNestedDtoMapping(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('MongoDB not tested.');
+        }
+
+        if (!class_exists(ReverseClassObjectMapperMetadataFactory::class)) {
+            $this->markTestSkipped('This test requires symfony/object-mapper >= 8.1');
+        }
+
+        $this->recreateSchema([Issue7801Product::class, Issue7801Category::class]);
+        $manager = static::getContainer()->get('doctrine')->getManager();
+
+        $category = new Issue7801Category();
+        $category->name = 'electronics';
+        $manager->persist($category);
+
+        $product = new Issue7801Product();
+        $product->name = 'laptop';
+        $product->category = $category;
+        $manager->persist($product);
+        $manager->flush();
+
+        $response = static::createClient()->request('GET', '/issue7801_products/'.$product->getId(), ['headers' => ['Accept' => 'application/ld+json']]);
+        $this->assertResponseStatusCodeSame(200);
+
+        $json = $response->toArray();
+        $this->assertSame('laptop', $json['name']);
+        $this->assertArrayHasKey('category', $json);
+        $this->assertSame('electronics', $json['category']['name']);
     }
 }


### PR DESCRIPTION
Reproduces the issue where nested entity→DTO mapping fails on GET when DTOs use #[Map(source:...)] without #[Map(target:...)] on entities. Requires symfony/object-mapper >= 8.1 (skipped otherwise).
