### PR TITLE
fix(openapi): uri variable default description

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -281,10 +281,22 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     continue;
                 }
 
+                $description = $uriVariable->getDescription();
+                if (null === $description) {
+                    $fromClass = $uriVariable->getFromClass();
+                    if (null !== $fromClass && $fromClass !== $resourceClass) {
+                        $uriResourceName = (new \ReflectionClass($fromClass))->getShortName();
+                    } else {
+                        $uriResourceName = $resourceShortName;
+                    }
+
+                    $description = "$uriResourceName identifier";
+                }
+
                 $parameter = new Parameter(
                     $parameterName,
                     'path',
-                    $uriVariable->getDescription() ?? "$resourceShortName identifier",
+                    $description,
                     $uriVariable->getRequired() ?? true,
                     false,
                     null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main for features / current stable version branch for bug fixes <!-- see below -->
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Given the route 
```
new GetCollection(
            uriTemplate: '/workspaces/{workspaceUuid}/invitations',
            uriVariables: [
                'workspaceUuid' => new Link(toProperty: 'workspace', fromClass: Workspace::class),
            ],
```
The default generated description of the uriVariable description is `Invitation identifier` while it should be `Workspace identifier`.