### PR TITLE
fix: use JSON:API compliant conversion

### DIFF
--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -67,7 +67,7 @@ final class JsonApiProvider implements ProviderInterface
         if (
             \is_array($pageParameter)
         ) {
-            $filters = array_merge($pageParameter, $filters);
+            $filters = array_merge($this->transformPagination($pageParameter), $filters);
         }
 
         [$included, $properties] = $this->transformFieldsetsParameters($queryParameters, $operation->getShortName() ?? '');
@@ -113,5 +113,14 @@ final class JsonApiProvider implements ProviderInterface
         }
 
         return [$included, $properties];
+    }
+
+    private function transformPagination(array $pageParameter): array
+    {
+        return array_filter([
+            'page' => $pageParameter['number'] ?? null,
+            'itemsPerPage' => $pageParameter['size'] ?? null,
+            'pagination' => $pageParameter['pagination'] ?? null,
+        ], fn($v) => $v !== null);
     }
 }


### PR DESCRIPTION
Following recommendations from here

https://jsonapi.org/format/#fetching-pagination

while being close to the ways used internally in api-platform.

===

This addresses some of the issues discussed in [this issue](https://github.com/api-platform/core/issues/7888).

Going forward, there are two possible approaches:

- Support the default pagination parameters of API Platform (page, itemsPerPage, pagination) alongside filters and the JSON:API page[...] structure
- Or adopt the JSON:API pagination format exclusively

Depending on the chosen approach, the links section needs to be handled accordingly:

- If JSON:API-style pagination is used, the links key should be updated to reflect it
- If API Platform parameters are also supported at the top level, the existing links handling can remain unchanged

This ultimately comes down to a design decision based on the desired level of compatibility and consistency.