### PR TITLE
fix(hydra): handle string and null serialization groups in DocumentationNormalizer

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -173,8 +173,8 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getPropertyMetadataFactoryContext(ApiResource $resourceMetadata): array
     {
-        $normalizationGroups = $resourceMetadata->getNormalizationContext()[AbstractNormalizer::GROUPS] ?? null;
-        $denormalizationGroups = $resourceMetadata->getDenormalizationContext()[AbstractNormalizer::GROUPS] ?? null;
+        $normalizationGroups = (array)(($resourceMetadata->getNormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
+        $denormalizationGroups = (array)(($resourceMetadata->getDenormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
         $propertyContext = [
             'normalization_groups' => $normalizationGroups,
             'denormalization_groups' => $denormalizationGroups,

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -173,8 +173,16 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getPropertyMetadataFactoryContext(ApiResource $resourceMetadata): array
     {
-        $normalizationGroups = (array) (($resourceMetadata->getNormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
-        $denormalizationGroups = (array) (($resourceMetadata->getDenormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
+        $normalizationGroups = ($resourceMetadata->getNormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null;
+        $denormalizationGroups = ($resourceMetadata->getDenormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null;
+
+        if (\is_string($normalizationGroups)) {
+            $normalizationGroups = [$normalizationGroups];
+        }
+        if (\is_string($denormalizationGroups)) {
+            $denormalizationGroups = [$denormalizationGroups];
+        }
+
         $propertyContext = [
             'normalization_groups' => $normalizationGroups,
             'denormalization_groups' => $denormalizationGroups,

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -173,8 +173,8 @@ final class DocumentationNormalizer implements NormalizerInterface
      */
     private function getPropertyMetadataFactoryContext(ApiResource $resourceMetadata): array
     {
-        $normalizationGroups = (array)(($resourceMetadata->getNormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
-        $denormalizationGroups = (array)(($resourceMetadata->getDenormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
+        $normalizationGroups = (array) (($resourceMetadata->getNormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
+        $denormalizationGroups = (array) (($resourceMetadata->getDenormalizationContext() ?? [])[AbstractNormalizer::GROUPS] ?? null);
         $propertyContext = [
             'normalization_groups' => $normalizationGroups,
             'denormalization_groups' => $denormalizationGroups,

--- a/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
+++ b/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
@@ -1170,4 +1170,52 @@ class DocumentationNormalizerTest extends TestCase
 
         $this->assertEquals($expected, $documentationNormalizer->normalize($documentation, null, [ContextBuilder::HYDRA_CONTEXT_HAS_PREFIX => false]));
     }
+
+    public function testNormalizeWithStringGroups(): void
+    {
+        $title = 'Test Api';
+        $desc = 'test';
+        $version = '0.0.0';
+        $documentation = new Documentation(new ResourceNameCollection(['dummy' => 'dummy']), $title, $desc, $version);
+
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactoryProphecy->create('dummy', Argument::type('array'))->shouldBeCalled()->willReturn(new PropertyNameCollection(['name']));
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactoryProphecy->create('dummy', 'name', Argument::type('array'))->shouldBeCalled()->willReturn(
+            (new ApiProperty())->withNativeType(Type::string())->withDescription('name')->withReadable(true)->withWritable(true)->withReadableLink(true)->withWritableLink(true)
+        );
+
+        $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactoryProphecy->create('dummy')->shouldBeCalled()->willReturn(new ResourceMetadataCollection('dummy', [
+            (new ApiResource())
+                ->withShortName('dummy')
+                ->withOperations(new Operations([
+                    'get' => (new Get())->withShortName('dummy'),
+                ]))
+                ->withNormalizationContext(['groups' => 'read'])
+                ->withDenormalizationContext(['groups' => 'write']),
+        ]));
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->isResourceClass(Argument::type('string'))->willReturn(false);
+
+        $urlGenerator = $this->prophesize(UrlGeneratorInterface::class);
+        $urlGenerator->generate('api_entrypoint')->willReturn('/');
+        $urlGenerator->generate('api_doc', ['_format' => 'jsonld'])->willReturn('/doc');
+        $urlGenerator->generate('api_doc', ['_format' => 'jsonld'], 0)->willReturn('/doc');
+
+        $documentationNormalizer = new DocumentationNormalizer(
+            $resourceMetadataFactoryProphecy->reveal(),
+            $propertyNameCollectionFactoryProphecy->reveal(),
+            $propertyMetadataFactoryProphecy->reveal(),
+            $resourceClassResolverProphecy->reveal(),
+            $urlGenerator->reveal()
+        );
+
+        $doc = $documentationNormalizer->normalize($documentation);
+
+        $this->assertSame('#dummy', $doc['hydra:supportedClass'][0]['@id']);
+        $this->assertNotEmpty($doc['hydra:supportedClass'][0]['hydra:supportedProperty']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | 
| License       | MIT
| Doc PR        | 

`DocumentationNormalizer::getPropertyMetadataFactoryContext` crashes when serialization groups are defined as a string rather than an array, or when no normalization/denormalization context is set.

Symfony's serializer supports string groups. [`AbstractNormalizer::getGroups()`](https://github.com/symfony/serializer/blob/8.1/Normalizer/AbstractNormalizer.php#L278-L283) casts scalars to arrays, and the [Symfony docs](https://symfony.com/doc/current/serializer.html#selecting-specific-properties) demonstrate the following is possible `'groups' => 'public_view'`.

**Reproducer:**

```php
#[ApiResource(
    normalizationContext: ['groups' => 'read'],
    denormalizationContext: ['groups' => 'write'],
)]
class DragonTreasure { ... }
```

Requesting the Hydra documentation endpoint produces:
- `Warning: foreach() argument must be of type array|object, string given` (string groups passed to `foreach`)
- `Warning: Trying to access array offset on null` (when context is `null`)

**Fix:**
- Wrap `getNormalizationContext()` / `getDenormalizationContext()` with `?? []` to handle `null` contexts
- Cast string group values to arrays before iterating, matching Symfony's `AbstractNormalizer::getGroups()` behaviour