### PR TITLE
fix(symfony): security regression when ResourceAccessChecker is decorated (#7896)

### DIFF
--- a/src/Symfony/Security/State/AccessCheckerProvider.php
+++ b/src/Symfony/Security/State/AccessCheckerProvider.php
@@ -85,7 +85,14 @@ final class AccessCheckerProvider implements ProviderInterface
             ];
         }
 
-        if ('pre_read' === $this->event && $this->resourceAccessChecker instanceof ObjectVariableCheckerInterface && $this->resourceAccessChecker->usesObjectVariable($isGranted, $resourceAccessCheckerContext)) {
+        // Skip pre_read optimization when object is used via granted (or usage is not predicatable)
+        if (
+            'pre_read' === $this->event
+            && (
+                !$this->resourceAccessChecker instanceof ObjectVariableCheckerInterface
+                || $this->resourceAccessChecker->usesObjectVariable($isGranted, $resourceAccessCheckerContext)
+            )
+        ) {
             return $this->decorated->provide($operation, $uriVariables, $context);
         }
 

--- a/tests/Symfony/Security/State/AccessCheckerProviderTest.php
+++ b/tests/Symfony/Security/State/AccessCheckerProviderTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\ResourceAccessCheckerInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Symfony\Security\Exception\AccessDeniedException;
+use ApiPlatform\Symfony\Security\ObjectVariableCheckerInterface;
 use ApiPlatform\Symfony\Security\State\AccessCheckerProvider;
 use ApiPlatform\Tests\Fixtures\DummyEntity;
 use PHPUnit\Framework\TestCase;
@@ -61,6 +62,44 @@ class AccessCheckerProviderTest extends TestCase
         $accessChecker->provide($operation, [], []);
     }
 
+    public function testPreReadSkipsSecurityWhenResourceAccessCheckerIsDecorated(): void
+    {
+        $obj = new \stdClass();
+        $operation = new Get(class: DummyEntity::class, security: 'is_granted("ROLE_ADMIN")');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->willReturn($obj);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->expects($this->never())->method('isGranted');
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker, 'pre_read');
+        $this->assertSame($obj, $accessChecker->provide($operation, [], []));
+    }
+
+    public function testPreReadChecksSecurityWhenObjectVariableIsNotUsed(): void
+    {
+        $obj = new \stdClass();
+        $operation = new Get(class: DummyEntity::class, security: 'is_granted("ROLE_ADMIN")');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->willReturn($obj);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerWithObjectVariableInterface::class);
+        $resourceAccessChecker->method('usesObjectVariable')->willReturn(false);
+        $resourceAccessChecker->expects($this->once())->method('isGranted')->with(DummyEntity::class, 'is_granted("ROLE_ADMIN")', ['object' => null, 'previous_object' => null, 'request' => null])->willReturn(true);
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker, 'pre_read');
+        $this->assertSame($obj, $accessChecker->provide($operation, [], []));
+    }
+
+    public function testPreReadSkipsSecurityWhenObjectVariableIsUsed(): void
+    {
+        $obj = new \stdClass();
+        $operation = new Get(class: DummyEntity::class, security: 'is_granted("ROLE_ADMIN") and object.owner == user');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->willReturn($obj);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerWithObjectVariableInterface::class);
+        $resourceAccessChecker->method('usesObjectVariable')->willReturn(true);
+        $resourceAccessChecker->expects($this->never())->method('isGranted');
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker, 'pre_read');
+        $this->assertSame($obj, $accessChecker->provide($operation, [], []));
+    }
+
     public function testCheckAccessDenied(): void
     {
         $this->expectException(AccessDeniedException::class);
@@ -90,4 +129,8 @@ class AccessCheckerProviderTest extends TestCase
         $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker);
         $accessChecker->provide($operation, [], []);
     }
+}
+
+interface ResourceAccessCheckerWithObjectVariableInterface extends ResourceAccessCheckerInterface, ObjectVariableCheckerInterface
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7896
| License       | MIT
| Doc PR        | 

Commit 359a128cd56934aeb3aefc13040fcd1206907157 introduced a regression when ResourceAccessChecker is decorated, and `security`/`securityPostDenormalize` are using `object` in `is_granted` expression.

The issue arise since `AccessCheckerProvider` violates the Liskov substitution principle by assuming that if the (previously unknown) interface `ObjectVariableCheckerInterface` is not defined, then the `pre_read` optimization can be used without an object instance.

NOTE: this is a security evaluation regression that actually will blocks more then required, so not a security issue on the project itself.

## The solution (in addition to this PR)

To preserve the implementation I had to implement `ObjectVariableCheckerInterface` in my codebased (which is not optimal, maybe should be documented or refactored). This is a workaround also for versions 4.3.0 => 4.3.3.

```php
<?php

namespace Acme\ApiPlatform;

use ApiPlatform\Metadata\ResourceAccessCheckerInterface;
use ApiPlatform\Symfony\Security\ObjectVariableCheckerInterface;

/** @note the references to `ObjectVariableCheckerInterface` and `usesObjectVariable` */
readonly class ResourceAccessCheckerDecorator implements ResourceAccessCheckerInterface, ObjectVariableCheckerInterface
{
    public function __construct(
        private ResourceAccessCheckerInterface&ObjectVariableCheckerInterface $resourceAccessChecker
    )
    {}

    public function isGranted(string $resourceClass, string $expression, array $extraVariables = []): bool
    {
        $extraVariables['my'] = $things;

        return $this->resourceAccessChecker->isGranted($resourceClass, $expression, $extraVariables);
    }

    public function usesObjectVariable(string $expression, array $variables = []): bool
    {
        $variables['my'] = null;
        return $this->resourceAccessChecker->usesObjectVariable($expression, $variables);
    }
}

```






