### PR TITLE
feat(symfony): composer dependency JSON+LD/Hydra is now optional

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -711,6 +711,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             return;
         }
 
+        if (!InstalledVersions::isInstalled('api-platform/jsonld')) {
+            throw new \LogicException('JSON+LD support cannot be enabled as the JSON+LD component is not installed. Try running "composer require api-platform/jsonld".');
+        }
+
+        if (!InstalledVersions::isInstalled('api-platform/hydra')) {
+            throw new \LogicException('JSON+LD support cannot be enabled as the Hydra component is not installed. Try running "composer require api-platform/hydra".');
+        }
+
         if ($config['use_symfony_listeners']) {
             $loader->load('symfony/jsonld.php');
         } else {

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Put;
 use ApiPlatform\Symfony\Controller\MainController;
+use Composer\InstalledVersions;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Doctrine\ORM\EntityManagerInterface;
@@ -56,6 +57,8 @@ final class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('api_platform');
         $rootNode = $treeBuilder->getRootNode();
+
+        $jsonLdInstalled = InstalledVersions::isInstalled('api-platform/jsonld') && InstalledVersions::isInstalled('api-platform/hydra');
 
         $rootNode
             ->beforeNormalization()
@@ -191,15 +194,17 @@ final class Configuration implements ConfigurationInterface
 
         $this->addExceptionToStatusSection($rootNode);
 
-        $this->addFormatSection($rootNode, 'formats', [
-            'jsonld' => ['mime_types' => ['application/ld+json']],
+        $this->addFormatSection($rootNode, 'formats', $jsonLdInstalled ? [
+            'jsonld' => ['mime_types' => ['application/ld+json']]
+        ] : [
+            'json' => ['mime_types' => ['application/json']]
         ]);
         $this->addFormatSection($rootNode, 'patch_formats', [
             'json' => ['mime_types' => ['application/merge-patch+json']],
         ]);
 
-        $defaultDocFormats = [
-            'jsonld' => ['mime_types' => ['application/ld+json']],
+        $defaultDocFormats = $jsonLdInstalled ? ['jsonld' => ['mime_types' => ['application/ld+json']]] : [];
+        $defaultDocFormats += [
             'jsonopenapi' => ['mime_types' => ['application/vnd.openapi+json']],
             'html' => ['mime_types' => ['text/html']],
         ];
@@ -210,11 +215,19 @@ final class Configuration implements ConfigurationInterface
 
         $this->addFormatSection($rootNode, 'docs_formats', $defaultDocFormats);
 
-        $this->addFormatSection($rootNode, 'error_formats', [
-            'jsonld' => ['mime_types' => ['application/ld+json']],
+        $defaultDocFormats = $jsonLdInstalled ? ['jsonld' => ['mime_types' => ['application/ld+json']]] : [];
+        $defaultDocFormats += [
+            'jsonopenapi' => ['mime_types' => ['application/vnd.openapi+json']],
+            'html' => ['mime_types' => ['text/html']],
+        ];
+
+        $defaultErrorFormats = $jsonLdInstalled ? ['jsonld' => ['mime_types' => ['application/ld+json']]] : [];
+        $defaultErrorFormats += [
             'jsonproblem' => ['mime_types' => ['application/problem+json']],
             'json' => ['mime_types' => ['application/problem+json', 'application/json']],
-        ]);
+        ];
+        $this->addFormatSection($rootNode, 'error_formats', $defaultErrorFormats);
+
         $rootNode
             ->children()
                 ->arrayNode('jsonschema_formats')

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -32,8 +32,6 @@
         "api-platform/documentation": "^4.3",
         "api-platform/http-cache": "^4.3",
         "api-platform/json-schema": "^4.3",
-        "api-platform/jsonld": "^4.3",
-        "api-platform/hydra": "^4.3",
         "api-platform/metadata": "^4.3",
         "api-platform/serializer": "^4.3",
         "api-platform/state": "^4.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | main
| Tickets       | 
| License       | MIT
| Doc PR        | no changes on default, not needed

I'm switching to the modular version of api-platform/* packages, mainly to get rid of all Laravel dependencies, and I found that JSON-LD/Hydra is somewhat hard-coded to the Symfony package.

I think this requirement can be lowered or totally removed, since simple JSON format is always available for use.

To avoid BC, I've updated the Configuration class with an heuristics to detect the standard case. There are multiple way to detect that (e.g. class_exists), please let me know it this doesn't not stand with your quality standards.