### PR TITLE
feat: support dynamic HTTP response status code via request attribute

### DIFF
--- a/src/State/Util/HttpResponseStatusTrait.php
+++ b/src/State/Util/HttpResponseStatusTrait.php
@@ -37,6 +37,10 @@ trait HttpResponseStatusTrait
      */
     private function getStatus(Request $request, HttpOperation $operation, array $context): int
     {
+        if ($request->attributes->has('_api_response_status')) {
+            return $request->attributes->getInt('_api_response_status');
+        }
+
         $status = $operation->getStatus();
         $method = $request->getMethod();
 

--- a/tests/State/RespondProcessorTest.php
+++ b/tests/State/RespondProcessorTest.php
@@ -162,6 +162,34 @@ class RespondProcessorTest extends TestCase
         $this->assertSame('application/ld+json', $response->headers->get('Accept-Post'));
     }
 
+    public function testDynamicResponseStatusFromRequestAttribute(): void
+    {
+        $operation = new Post(class: Employee::class);
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Employee::class)->willReturn(true);
+
+        $respondProcessor = new RespondProcessor(null, $resourceClassResolver->reveal());
+
+        $req = new Request([], [], ['_api_response_status' => 200]);
+        $req->setMethod('POST');
+        $response = $respondProcessor->process('content', $operation, context: [
+            'request' => $req,
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+
+        $req = new Request();
+        $req->setMethod('POST');
+        $response = $respondProcessor->process('content', $operation, context: [
+            'request' => $req,
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
+
     public function testDoesNotAddLinkedDataPlatformHeadersWithoutFactory(): void
     {
         $operation = new Get(uriTemplate: '/employees/{id}', class: Employee::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #7903 
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Allow processors to dynamically override the HTTP response status code by setting the `_api_response_status` request attribute.

**Use case:** A single POST endpoint that returns `200` when the operation is processed synchronously, and `202` when it is dispatched asynchronously.

```php                                                                                                                                                                                                                                      
  // In a processor                                                                                                                                                                                                                         
  $request = $context['request'] ?? null;                                                                                                                                                                                                     
  $request?->attributes->set('_api_response_status', 200);                                                                                                                                                                                  
```

The change is fully backward-compatible: when the attribute is not set, the existing behavior is unchanged.