### PR TITLE
fix: fix phpstan errors

### DIFF
--- a/src/Mcp/Server/Handler.php
+++ b/src/Mcp/Server/Handler.php
@@ -74,7 +74,7 @@ final class Handler implements RequestHandlerInterface
         } else {
             \assert($request instanceof CallToolRequest);
             $operationNameOrUri = $request->name;
-            $arguments = $request->arguments ?? [];
+            $arguments = $request->arguments;
             $this->logger->debug('Executing tool', ['name' => $operationNameOrUri, 'arguments' => $arguments]);
         }
 

--- a/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
+++ b/src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php
@@ -145,7 +145,7 @@ final class PurgeHttpCacheListener
 
         /** @var array|AssociationMapping $associationMapping according to the version of doctrine orm */
         foreach ($associationMappings as $property => $associationMapping) {
-            if ($associationMapping instanceof AssociationMapping && ($associationMapping->targetEntity ?? null) && !$this->resourceClassResolver->isResourceClass($associationMapping->targetEntity)) {
+            if ($associationMapping instanceof AssociationMapping && $associationMapping->targetEntity && !$this->resourceClassResolver->isResourceClass($associationMapping->targetEntity)) {
                 return;
             }
             if (!$this->propertyAccessor->isReadable($entity, $property)) {


### PR DESCRIPTION
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Fix the followig errors: 
```
PHPStan - PHP Static Analysis Tool 2.1.50
Note: Using configuration file /home/runner/work/core/core/phpstan.neon.dist.
Error: Property Mcp\Schema\Request\CallToolRequest::$arguments (array<string, mixed>) on left side of ?? is not nullable.
Error: Property Doctrine\ORM\Mapping\AssociationMapping::$targetEntity (class-string) on left side of ?? is not nullable.
 ------ ----------------------------------------------------------------------- 
  Line   src/Mcp/Server/Handler.php                                             
 ------ ----------------------------------------------------------------------- 
  77     Property Mcp\Schema\Request\CallToolRequest::$arguments (array<string  
         , mixed>) on left side of ?? is not nullable.                          
         🪪  nullCoalesce.property                                              
 ------ ----------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------- 
  Line   src/Symfony/Doctrine/EventListener/PurgeHttpCacheListener.php    
 ------ ----------------------------------------------------------------- 
  148    Property Doctrine\ORM\Mapping\AssociationMapping::$targetEntity  
         (class-string) on left side of ?? is not nullable.               
         🪪  nullCoalesce.property                                        
 ------ -----------------------------------------------------------------
```
