### PR TITLE
Feat/reset interface metadata resolvers

### DIFF
--- a/src/Metadata/Extractor/AbstractPropertyExtractor.php
+++ b/src/Metadata/Extractor/AbstractPropertyExtractor.php
@@ -15,13 +15,14 @@ namespace ApiPlatform\Metadata\Extractor;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Base file extractor.
  *
  * @author Vincent Chalamon <vincentchalamon@gmail.com>
  */
-abstract class AbstractPropertyExtractor implements PropertyExtractorInterface
+abstract class AbstractPropertyExtractor implements PropertyExtractorInterface, ResetInterface
 {
     protected ?array $properties = null;
     private array $collectedParameters = [];
@@ -54,6 +55,15 @@ abstract class AbstractPropertyExtractor implements PropertyExtractorInterface
      * Extracts metadata from a given path.
      */
     abstract protected function extractPath(string $path): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->properties = null;
+        $this->collectedParameters = [];
+    }
 
     /**
      * Recursively replaces placeholders with the service container parameters.

--- a/src/Metadata/Extractor/AbstractResourceExtractor.php
+++ b/src/Metadata/Extractor/AbstractResourceExtractor.php
@@ -15,13 +15,14 @@ namespace ApiPlatform\Metadata\Extractor;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Base file extractor.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
-abstract class AbstractResourceExtractor implements ResourceExtractorInterface
+abstract class AbstractResourceExtractor implements ResourceExtractorInterface, ResetInterface
 {
     protected ?array $resources = null;
     private array $collectedParameters = [];
@@ -54,6 +55,15 @@ abstract class AbstractResourceExtractor implements ResourceExtractorInterface
      * Extracts metadata from a given path.
      */
     abstract protected function extractPath(string $path): void;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->resources = null;
+        $this->collectedParameters = [];
+    }
 
     /**
      * Recursively replaces placeholders with the service container parameters.

--- a/src/Metadata/ResourceClassResolver.php
+++ b/src/Metadata/ResourceClassResolver.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Metadata;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Util\ClassInfoTrait;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * {@inheritdoc}
@@ -23,7 +24,7 @@ use ApiPlatform\Metadata\Util\ClassInfoTrait;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Samuel ROZE <samuel.roze@gmail.com>
  */
-final class ResourceClassResolver implements ResourceClassResolverInterface
+final class ResourceClassResolver implements ResourceClassResolverInterface, ResetInterface
 {
     use ClassInfoTrait;
     private array $localIsResourceClassCache = [];
@@ -104,5 +105,14 @@ final class ResourceClassResolver implements ResourceClassResolverInterface
         }
 
         return $this->localIsResourceClassCache[$type] = false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset(): void
+    {
+        $this->localIsResourceClassCache = [];
+        $this->localMostSpecificResourceClassCache = [];
     }
 }

--- a/src/Metadata/Tests/Extractor/YamlPropertyExtractorResetTest.php
+++ b/src/Metadata/Tests/Extractor/YamlPropertyExtractorResetTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Extractor;
+
+use ApiPlatform\Metadata\Extractor\YamlPropertyExtractor;
+use PHPUnit\Framework\TestCase;
+
+class YamlPropertyExtractorResetTest extends TestCase
+{
+    public function testReset(): void
+    {
+        $extractor = new YamlPropertyExtractor([]);
+
+        $refl = new \ReflectionClass($extractor);
+        $properties = $refl->getProperty('properties');
+        $properties->setAccessible(true);
+        $properties->setValue($extractor, ['foo' => 'bar']);
+
+        $this->assertNotEmpty($properties->getValue($extractor));
+
+        $extractor->reset();
+
+        $this->assertNull($properties->getValue($extractor));
+    }
+}

--- a/src/Metadata/Tests/Extractor/YamlResourceExtractorResetTest.php
+++ b/src/Metadata/Tests/Extractor/YamlResourceExtractorResetTest.php
@@ -13,31 +13,31 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Tests\Extractor;
 
-use ApiPlatform\Metadata\Extractor\AbstractPropertyExtractor;
-use ApiPlatform\Metadata\Extractor\YamlPropertyExtractor;
+use ApiPlatform\Metadata\Extractor\AbstractResourceExtractor;
+use ApiPlatform\Metadata\Extractor\YamlResourceExtractor;
 use PHPUnit\Framework\TestCase;
 
-class YamlPropertyExtractorResetTest extends TestCase
+class YamlResourceExtractorResetTest extends TestCase
 {
     public function testReset(): void
     {
-        $extractor = new YamlPropertyExtractor([]);
+        $extractor = new YamlResourceExtractor([]);
 
         $refl = new \ReflectionClass($extractor);
-        $properties = $refl->getProperty('properties');
-        $properties->setAccessible(true);
-        $properties->setValue($extractor, ['foo' => 'bar']);
+        $resources = $refl->getProperty('resources');
+        $resources->setAccessible(true);
+        $resources->setValue($extractor, ['foo' => 'bar']);
         
-        $collectedParameters = new \ReflectionProperty(AbstractPropertyExtractor::class, 'collectedParameters');
+        $collectedParameters = new \ReflectionProperty(AbstractResourceExtractor::class, 'collectedParameters');
         $collectedParameters->setAccessible(true);
         $collectedParameters->setValue($extractor, ['param' => 'value']);
 
-        $this->assertNotEmpty($properties->getValue($extractor));
+        $this->assertNotEmpty($resources->getValue($extractor));
         $this->assertNotEmpty($collectedParameters->getValue($extractor));
 
         $extractor->reset();
 
-        $this->assertNull($properties->getValue($extractor));
+        $this->assertNull($resources->getValue($extractor));
         $this->assertEmpty($collectedParameters->getValue($extractor));
     }
 }

--- a/src/Metadata/Tests/ResourceClassResolverTest.php
+++ b/src/Metadata/Tests/ResourceClassResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests;
+
+use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceNameCollection;
+use ApiPlatform\Metadata\ResourceClassResolver;
+use PHPUnit\Framework\TestCase;
+
+class ResourceClassResolverTest extends TestCase
+{
+    public function testReset(): void
+    {
+        $resourceNameCollectionFactoryProphecy = $this->createMock(ResourceNameCollectionFactoryInterface::class);
+        $resourceNameCollectionFactoryProphecy->method('create')->willReturn(new ResourceNameCollection([ \stdClass::class ]));
+
+        $resolver = new ResourceClassResolver($resourceNameCollectionFactoryProphecy);
+
+        $this->assertTrue($resolver->isResourceClass(\stdClass::class));
+
+        $resolver->reset();
+
+        $refl = new \ReflectionClass($resolver);
+        $localIsResourceClassCache = $refl->getProperty('localIsResourceClassCache');
+        $localIsResourceClassCache->setAccessible(true);
+        $localMostSpecificResourceClassCache = $refl->getProperty('localMostSpecificResourceClassCache');
+        $localMostSpecificResourceClassCache->setAccessible(true);
+
+        $this->assertEmpty($localIsResourceClassCache->getValue($resolver));
+        $this->assertEmpty($localMostSpecificResourceClassCache->getValue($resolver));
+    }
+}


### PR DESCRIPTION
### Description

This PR is the second part of the worker mode compatibility audit (see #7918). It implements the `Symfony\Contracts\Service\ResetInterface` for metadata resolvers and extractors that maintain internal state.

### The Issue

Several singleton services in the Metadata component use private arrays as local caches (e.g., `$localIsResourceClassCache`, `$properties`). In persistent memory runtimes like **FrankenPHP** or **Swoole**, these arrays:
1. **Grow indefinitely**: Every unique class or property processed adds a new entry.
2. **Leak memory**: Without a reset mechanism, the RAM usage of the worker increases linearly over time.
3. **Risk staleness**: In some edge cases, internal state might persist where it shouldn't between different request contexts.

### The Solution

By implementing `ResetInterface`, we allow the Symfony kernel to automatically call the `reset()` method after each request (when running in worker mode). 

- **ResourceClassResolver**: Clears `$localMostSpecificResourceClassCache` and `$localIsResourceClassCache`.
- **YamlPropertyExtractor**: Clears the `$properties` cache.

This ensures a "clean slate" for every request, preventing slow memory leaks and ensuring long-term stability for high-traffic APIs.

### Context

This fix is part of a global audit performed with [**Igor-PHP**](https://github.com/igor-php/igor-php).