### PR TITLE
feat(openapi): implement ResetInterface in OpenApiFactory

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -62,11 +62,12 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Generates an Open API v3 specification.
  */
-final class OpenApiFactory implements OpenApiFactoryInterface
+final class OpenApiFactory implements OpenApiFactoryInterface, ResetInterface
 {
     use NormalizeOperationNameTrait;
     use StateOptionsTrait;
@@ -1064,5 +1065,11 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         }
 
         return $this->localErrorResourceCache[$error] = $errorResource;
+    }
+
+    public function reset(): void
+    {
+        $this->routeCollection = null;
+        $this->localErrorResourceCache = [];
     }
 }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -1438,4 +1438,38 @@ class OpenApiFactoryTest extends TestCase
 
         $openApi = $factory->__invoke();
     }
+
+    public function testReset(): void
+    {
+        $resourceNameCollectionFactory = $this->createMock(ResourceNameCollectionFactoryInterface::class);
+        $resourceCollectionMetadataFactory = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory = $this->createMock(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactory = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $schemaFactory = $this->createMock(\ApiPlatform\JsonSchema\SchemaFactoryInterface::class);
+
+        $factory = new OpenApiFactory(
+            $resourceNameCollectionFactory,
+            $resourceCollectionMetadataFactory,
+            $propertyNameCollectionFactory,
+            $propertyMetadataFactory,
+            $schemaFactory
+        );
+
+        $refl = new \ReflectionClass($factory);
+        $routeCollection = $refl->getProperty('routeCollection');
+        $routeCollection->setAccessible(true);
+        $routeCollection->setValue($factory, new \Symfony\Component\Routing\RouteCollection());
+
+        $localErrorResourceCache = $refl->getProperty('localErrorResourceCache');
+        $localErrorResourceCache->setAccessible(true);
+        $localErrorResourceCache->setValue($factory, ['foo' => 'bar']);
+
+        $this->assertNotNull($routeCollection->getValue($factory));
+        $this->assertNotEmpty($localErrorResourceCache->getValue($factory));
+
+        $factory->reset();
+
+        $this->assertNull($routeCollection->getValue($factory));
+        $this->assertEmpty($localErrorResourceCache->getValue($factory));
+    }
 }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -1458,7 +1458,9 @@ class OpenApiFactoryTest extends TestCase
         $refl = new \ReflectionClass($factory);
         $routeCollection = $refl->getProperty('routeCollection');
         $routeCollection->setAccessible(true);
-        $routeCollection->setValue($factory, new \Symfony\Component\Routing\RouteCollection());
+        if (class_exists(\Symfony\Component\Routing\RouteCollection::class)) {
+            $routeCollection->setValue($factory, $this->createMock(\Symfony\Component\Routing\RouteCollection::class));
+        }
 
         $localErrorResourceCache = $refl->getProperty('localErrorResourceCache');
         $localErrorResourceCache->setAccessible(true);


### PR DESCRIPTION
### Description

This PR is the fourth part of the worker mode compatibility audit (see #7918). It implements `ResetInterface` in `OpenApiFactory` to handle internal state persistence.

### The Issue

`OpenApiFactory` is a singleton service that maintains two types of internal state:
1. **Route Collection Cache**: Once the router is accessed, the `RouteCollection` is stored in a private property.
2. **Local Error Resource Cache**: A private array (`$localErrorResourceCache`) that stores resolved error resources to avoid redundant processing.

In persistent memory environments like **FrankenPHP**:
- **Stale Data**: If routes are modified or dynamically updated, the factory might keep using the old cached `RouteCollection` until the worker restarts.
- **Memory Growth**: The error resource cache grows with every unique error encountered, leading to an unbounded increase in RAM usage over time.

### The Solution

By implementing `Symfony\Contracts\Service\ResetInterface`, we ensure that:
- `$routeCollection` is reset to `null`.
- `$localErrorResourceCache` is cleared (reset to `[]`).

This happens automatically after each request in worker mode, ensuring that the next request starts with fresh metadata and a clean memory footprint.