### PR TITLE
ci: openapi errors

### DIFF
--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -147,7 +147,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                     'items' => [
                         'allOf' => [
                             ['$ref' => $prefix.$key],
-                            ['type' => 'object', 'properties' => ['source' => ['type' => 'object'], 'status' => ['type' => 'string']]],
+                            ['type' => 'object', 'properties' => ['source' => ['type' => 'object'], 'status' => ['type' => ['string', 'integer', 'null']]]],
                         ],
                     ],
                 ],

--- a/src/State/ApiResource/Error.php
+++ b/src/State/ApiResource/Error.php
@@ -127,7 +127,7 @@ class Error extends \Exception implements ProblemExceptionInterface, HttpExcepti
             identifier: true,
             writable: false,
             initializable: false,
-            schema: ['type' => ['number', 'null'], 'examples' => [404], 'default' => 400]
+            schema: ['type' => ['integer', 'null'], 'examples' => [404], 'default' => 400]
         )] private ?int $status,
         ?array $originalTrace = null,
         private ?string $instance = null,

--- a/tests/Fixtures/TestBundle/Entity/Issue5793/BagOfTests.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue5793/BagOfTests.php
@@ -37,7 +37,7 @@ class BagOfTests
     #[Groups(['read', 'write'])]
     // ignore "type" schema property to ensure "schema" is properly overridden
     // see JsonSchemaGenerateCommandTest::testArraySchemaWithReference
-    #[ApiProperty(schema: ['maxLength' => 255])]
+    #[ApiProperty(schema: ['type' => 'string', 'maxLength' => 255])]
     private ?string $description = null;
 
     #[ORM\OneToMany(mappedBy: 'bagOfTests', targetEntity: TestEntity::class)]

--- a/tests/Functional/JsonSchema/JsonLdJsonSchemaTest.php
+++ b/tests/Functional/JsonSchema/JsonLdJsonSchemaTest.php
@@ -65,6 +65,7 @@ final class JsonLdJsonSchemaTest extends ApiTestCase
                             'readOnly' => true,
                         ]),
                         'description' => new \ArrayObject([
+                            'type' => 'string',
                             'maxLength' => 255,
                         ]),
                         'tests' => new \ArrayObject([

--- a/tests/Functional/JsonSchema/JsonSchemaTest.php
+++ b/tests/Functional/JsonSchema/JsonSchemaTest.php
@@ -158,6 +158,7 @@ class JsonSchemaTest extends ApiTestCase
         ]));
 
         $this->assertEquals($schema['definitions']['BagOfTests-write']['properties']['description'], new \ArrayObject([
+            'type' => 'string',
             'maxLength' => 255,
         ]));
 

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -161,7 +161,7 @@ class OpenApiTest extends ApiTestCase
                         ],
                         'status' => [
                             'type' => [
-                                'number',
+                                'integer',
                                 'null',
                             ],
                             'examples' => [
@@ -202,7 +202,11 @@ class OpenApiTest extends ApiTestCase
                         'type' => 'object',
                     ],
                     'status' => [
-                        'type' => 'string',
+                        'type' => [
+                            'string',
+                            'integer',
+                            'null',
+                        ],
                     ],
                 ]],
             ]], $res['components']['schemas']['Error.jsonapi']['properties']['errors']['items']);


### PR DESCRIPTION
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Fix the following errors: 
```
build/out/openapi/openapi_v3.yaml:156186:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156202:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests-read'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156218:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests-write'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156234:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests-write.jsonMergePatch'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156250:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests.graphql-read'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156266:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests.html-read'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156345:15  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests.jsonld-read'].allOf[1].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156361:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests.multipart-read'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:156377:11  ✗           `maxLength` constraint is only applicable to string types, not `[]` 
$.components.schemas['BagOfTests.xml-read'].properties['description'].maxLength
rule: oas-schema-check  category: Schemas

build/out/openapi/openapi_v3.yaml:175381:13  ✗           `allOf` property `status` declared as [string, number, null]: properties defined across an `allOf` composition must have a non-empty common valid type
$.components.schemas['Error.jsonapi'].properties['errors'].items.allOf
rule: allof-conflicts  category: Schemas

 category              ✗ errors      ▲ warnings    ● info                                                  
 ────────────────────  ────────────  ────────────  ────────────────────────────────────────────────────────
 Schemas               10            0             0                                                       
 ────────────────────  ────────────  ────────────  ────────────────────────────────────────────────────────
 total                 10            0             0                                                       

 rule                                      violations    quality impact                                    
 ────────────────────────────────────────  ────────────  ──────────────────────────────────────────────────
 oas-schema-check                          9             ██████████████████████████████████████████████████
 allof-conflicts                           1             █████                                             
 ────────────────────────────────────────  ────────────  ──────────────────────────────────────────────────
 total                                     10          

 --> use the <dashboard> command to be able to navigate results interactively <--

 | Quality Score: 10/100 [🥵]

 | ✗ Failed with 10 errors, 0 warnings and 0 informs.
```
