### PR TITLE
feat(state): cache hydra documentation and entrypoint responses

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -555,7 +555,21 @@ class ApiPlatformProvider extends ServiceProvider
         // Documentation/entrypoint processor wraps the base ProcessorInterface with the cache decorator.
         // MainController and the rest keep the bare ProcessorInterface so regular resource responses are not cached as docs.
         $this->app->bind('api_platform.state_processor.documentation', static function (Application $app) {
-            return new CacheableDocumentationProcessor($app->make(ProcessorInterface::class));
+            $cfg = $app['config']->get('api-platform.documentation.cache_headers', []);
+            $base = $app->make(ProcessorInterface::class);
+
+            if (false === ($cfg['enabled'] ?? true)) {
+                return $base;
+            }
+
+            return new CacheableDocumentationProcessor(
+                $base,
+                $cfg['max_age'] ?? 0,
+                $cfg['shared_max_age'] ?? null,
+                $cfg['public'] ?? true,
+                $cfg['must_revalidate'] ?? true,
+                $cfg['etag'] ?? true,
+            );
         });
 
         $this->app->singleton(ObjectNormalizer::class, static function (Application $app) {

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -158,6 +158,7 @@ use ApiPlatform\State\ErrorProvider;
 use ApiPlatform\State\Pagination\Pagination;
 use ApiPlatform\State\Pagination\PaginationOptions;
 use ApiPlatform\State\Processor\AddLinkHeaderProcessor;
+use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
 use ApiPlatform\State\Processor\ObjectMapperInputProcessor;
 use ApiPlatform\State\Processor\ObjectMapperOutputProcessor;
 use ApiPlatform\State\Processor\RespondProcessor;
@@ -551,6 +552,12 @@ class ApiPlatformProvider extends ServiceProvider
             });
         }
 
+        // Documentation/entrypoint processor wraps the base ProcessorInterface with the cache decorator.
+        // MainController and the rest keep the bare ProcessorInterface so regular resource responses are not cached as docs.
+        $this->app->bind('api_platform.state_processor.documentation', static function (Application $app) {
+            return new CacheableDocumentationProcessor($app->make(ProcessorInterface::class));
+        });
+
         $this->app->singleton(ObjectNormalizer::class, static function (Application $app) {
             $config = $app['config'];
             $defaultContext = $config->get('api-platform.serializer', []);
@@ -779,7 +786,7 @@ class ApiPlatformProvider extends ServiceProvider
                 version: $config->get('api-platform.version') ?? '',
                 openApiFactory: $app->make(OpenApiFactoryInterface::class),
                 provider: $app->make(ProviderInterface::class),
-                processor: $app->make(ProcessorInterface::class),
+                processor: $app->make('api_platform.state_processor.documentation'),
                 negotiator: $app->make(Negotiator::class),
                 documentationFormats: $config->get('api-platform.docs_formats'),
                 swaggerUiEnabled: $config->get('api-platform.swagger_ui.enabled', false),
@@ -792,7 +799,7 @@ class ApiPlatformProvider extends ServiceProvider
             /** @var ConfigRepository */
             $config = $app['config'];
 
-            return new EntrypointController($app->make(ResourceNameCollectionFactoryInterface::class), $app->make(ProviderInterface::class), $app->make(ProcessorInterface::class), $config->get('api-platform.docs_formats'));
+            return new EntrypointController($app->make(ResourceNameCollectionFactoryInterface::class), $app->make(ProviderInterface::class), $app->make('api_platform.state_processor.documentation'), $config->get('api-platform.docs_formats'));
         });
 
         $this->app->singleton(Pagination::class, static function (Application $app) {

--- a/src/Laravel/Tests/CacheableDocumentationTest.php
+++ b/src/Laravel/Tests/CacheableDocumentationTest.php
@@ -65,4 +65,57 @@ class CacheableDocumentationTest extends TestCase
         $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
         $this->assertStringNotContainsString('max-age=0', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
     }
+
+    public function testCustomMaxAgeAndSharedMaxAgeAreApplied(): void
+    {
+        $this->app['config']->set('api-platform.documentation.cache_headers.max_age', 3600);
+        $this->app['config']->set('api-platform.documentation.cache_headers.shared_max_age', 600);
+        $this->app->forgetInstance('api_platform.state_processor.documentation');
+
+        $response = $this->get('/api/docs.jsonld');
+        $response->assertStatus(200);
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringContainsString('max-age=3600', $cacheControl);
+        $this->assertStringContainsString('s-maxage=600', $cacheControl);
+    }
+
+    public function testMustRevalidateCanBeDisabled(): void
+    {
+        $this->app['config']->set('api-platform.documentation.cache_headers.must_revalidate', false);
+        $this->app->forgetInstance('api_platform.state_processor.documentation');
+
+        $response = $this->get('/api/docs.jsonld');
+        $response->assertStatus(200);
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl);
+    }
+
+    public function testEtagCanBeDisabled(): void
+    {
+        $this->app['config']->set('api-platform.documentation.cache_headers.etag', false);
+        $this->app->forgetInstance('api_platform.state_processor.documentation');
+
+        $response = $this->get('/api/docs.jsonld');
+        $response->assertStatus(200);
+
+        // documentation decorator stays wired (must-revalidate proves it) but its md5 ETag must not be set
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+        $etag = trim($response->headers->get('etag') ?? '', '"');
+        $this->assertFalse(1 === preg_match('/^[a-f0-9]{32}$/', $etag), 'documentation decorator must not produce its md5 ETag when etag is disabled');
+    }
+
+    public function testFeatureCanBeDisabled(): void
+    {
+        $this->app['config']->set('api-platform.documentation.cache_headers.enabled', false);
+        $this->app->forgetInstance('api_platform.state_processor.documentation');
+
+        $response = $this->get('/api/docs.jsonld');
+        $response->assertStatus(200);
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'when disabled, the cache decorator must not be wired');
+    }
 }

--- a/src/Laravel/Tests/CacheableDocumentationTest.php
+++ b/src/Laravel/Tests/CacheableDocumentationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class CacheableDocumentationTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use WithWorkbench;
+
+    public function testDocumentationResponseHasCacheHeaders(): void
+    {
+        $response = $this->get('/api/docs.jsonld');
+        $response->assertStatus(200);
+
+        $etag = $response->headers->get('etag');
+        $this->assertNotEmpty($etag, 'documentation response is missing an ETag');
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringContainsString('max-age=0', $cacheControl);
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+    }
+
+    public function testEntrypointResponseHasCacheHeaders(): void
+    {
+        $response = $this->get('/api/index.jsonld');
+        $response->assertStatus(200);
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringContainsString('max-age=0', $cacheControl);
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+    }
+
+    public function testDocumentationReturnsNotModifiedWhenIfNoneMatchMatches(): void
+    {
+        $first = $this->get('/api/docs.jsonld');
+        $etag = $first->headers->get('etag');
+        $this->assertNotEmpty($etag, 'expected an ETag on the first documentation response');
+
+        $second = $this->get('/api/docs.jsonld', ['If-None-Match' => $etag]);
+        $second->assertStatus(304);
+    }
+
+    public function testRegularResourceDoesNotHaveDocumentationCacheHeaders(): void
+    {
+        $response = $this->get('/api/staff', headers: ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+
+        $cacheControl = $response->headers->get('cache-control') ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
+        $this->assertStringNotContainsString('max-age=0', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
+    }
+}

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -182,6 +182,19 @@ return [
     //     ],
     // ],
 
+    // HTTP cache headers added to documentation and entrypoint responses (e.g. /api/docs, /api).
+    // Unrelated to the resource-level "http_cache" block above which targets API resource responses.
+    'documentation' => [
+        'cache_headers' => [
+            'enabled' => true,
+            'max_age' => 0,
+            'shared_max_age' => null,
+            'public' => true,
+            'must_revalidate' => true,
+            'etag' => true,
+        ],
+    ],
+
     'error_handler' => [
         'extend_laravel_handler' => true,
     ],

--- a/src/State/Processor/CacheableDocumentationProcessor.php
+++ b/src/State/Processor/CacheableDocumentationProcessor.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Processor;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\State\StopwatchAwareInterface;
+use ApiPlatform\State\StopwatchAwareTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Adds an ETag and revalidating Cache-Control headers on the API documentation
+ * and entrypoint responses so clients can avoid re-downloading the (often large)
+ * payload when nothing changed.
+ *
+ * @template T1
+ * @template T2
+ *
+ * @implements ProcessorInterface<T1, T2>
+ */
+final class CacheableDocumentationProcessor implements ProcessorInterface, StopwatchAwareInterface
+{
+    use StopwatchAwareTrait;
+
+    /**
+     * @param ProcessorInterface<T1, T2> $decorated
+     */
+    public function __construct(private readonly ProcessorInterface $decorated)
+    {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        $response = $this->decorated->process($data, $operation, $uriVariables, $context);
+
+        if (!$response instanceof Response || 200 !== $response->getStatusCode()) {
+            return $response;
+        }
+
+        $content = $response->getContent();
+        if (false === $content || '' === $content) {
+            return $response;
+        }
+
+        $this->stopwatch?->start('api_platform.processor.cacheable_documentation');
+
+        $response->setEtag(md5($content));
+        $response->setPublic();
+        $response->setMaxAge(0);
+        $response->headers->addCacheControlDirective('must-revalidate');
+
+        if (($request = $context['request'] ?? null) instanceof Request) {
+            $response->isNotModified($request);
+        }
+
+        $this->stopwatch?->stop('api_platform.processor.cacheable_documentation');
+
+        return $response;
+    }
+}

--- a/src/State/Processor/CacheableDocumentationProcessor.php
+++ b/src/State/Processor/CacheableDocumentationProcessor.php
@@ -37,8 +37,14 @@ final class CacheableDocumentationProcessor implements ProcessorInterface, Stopw
     /**
      * @param ProcessorInterface<T1, T2> $decorated
      */
-    public function __construct(private readonly ProcessorInterface $decorated)
-    {
+    public function __construct(
+        private readonly ProcessorInterface $decorated,
+        private readonly int $maxAge = 0,
+        private readonly ?int $sharedMaxAge = null,
+        private readonly bool $public = true,
+        private readonly bool $mustRevalidate = true,
+        private readonly bool $etag = true,
+    ) {
     }
 
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
@@ -56,12 +62,27 @@ final class CacheableDocumentationProcessor implements ProcessorInterface, Stopw
 
         $this->stopwatch?->start('api_platform.processor.cacheable_documentation');
 
-        $response->setEtag(md5($content));
-        $response->setPublic();
-        $response->setMaxAge(0);
-        $response->headers->addCacheControlDirective('must-revalidate');
+        if ($this->etag) {
+            $response->setEtag(md5($content));
+        }
 
-        if (($request = $context['request'] ?? null) instanceof Request) {
+        if ($this->public) {
+            $response->setPublic();
+        } else {
+            $response->setPrivate();
+        }
+
+        $response->setMaxAge($this->maxAge);
+
+        if (null !== $this->sharedMaxAge) {
+            $response->setSharedMaxAge($this->sharedMaxAge);
+        }
+
+        if ($this->mustRevalidate) {
+            $response->headers->addCacheControlDirective('must-revalidate');
+        }
+
+        if ($this->etag && ($request = $context['request'] ?? null) instanceof Request) {
             $response->isNotModified($request);
         }
 

--- a/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
+++ b/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Tests\Processor;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
+use ApiPlatform\State\ProcessorInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CacheableDocumentationProcessorTest extends TestCase
+{
+    public function testItSetsEtagAndCacheHeadersOnResponse(): void
+    {
+        $body = '{"hello":"world"}';
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response($body)));
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('"'.md5($body).'"', $response->getEtag());
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('must-revalidate'));
+        $this->assertSame(0, (int) $response->headers->getCacheControlDirective('max-age'));
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testItReturnsNotModifiedWhenIfNoneMatchHeaderMatches(): void
+    {
+        $body = '{"hello":"world"}';
+        $etag = '"'.md5($body).'"';
+        $request = new Request();
+        $request->headers->set('If-None-Match', $etag);
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response($body)));
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => $request]);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(304, $response->getStatusCode());
+        $this->assertEmpty($response->getContent());
+        $this->assertSame($etag, $response->getEtag());
+    }
+
+    public function testItPassesThroughWhenDecoratedDoesNotReturnResponse(): void
+    {
+        $data = new \stdClass();
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning($data));
+
+        $this->assertSame($data, $processor->process($data, new Get(), [], ['request' => new Request()]));
+    }
+
+    public function testItDoesNothingForNonOkResponses(): void
+    {
+        $response = new Response('error', 500);
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning($response));
+
+        $result = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertSame($response, $result);
+        $this->assertNull($result->getEtag());
+    }
+
+    public function testItDoesNothingWhenResponseHasNoBody(): void
+    {
+        $response = new Response('');
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning($response));
+
+        $result = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertSame($response, $result);
+        $this->assertNull($result->getEtag());
+    }
+
+    public function testItStillSetsHeadersWhenRequestIsAbsent(): void
+    {
+        $body = 'payload';
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response($body)));
+
+        $response = $processor->process(new \stdClass(), new Get(), [], []);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame('"'.md5($body).'"', $response->getEtag());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    private function decoratedReturning(mixed $value): ProcessorInterface
+    {
+        $decorated = $this->createStub(ProcessorInterface::class);
+        $decorated->method('process')->willReturn($value);
+
+        return $decorated;
+    }
+}

--- a/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
+++ b/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
@@ -16,7 +16,6 @@ namespace ApiPlatform\State\Tests\Processor;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
 use ApiPlatform\State\ProcessorInterface;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
+++ b/src/State/Tests/Processor/CacheableDocumentationProcessorTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\State\Tests\Processor;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
 use ApiPlatform\State\ProcessorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -93,6 +94,56 @@ class CacheableDocumentationProcessorTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('"'.md5($body).'"', $response->getEtag());
         $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testItHonorsCustomMaxAge(): void
+    {
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response('body')), maxAge: 3600);
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertSame(3600, (int) $response->headers->getCacheControlDirective('max-age'));
+    }
+
+    public function testItHonorsSharedMaxAge(): void
+    {
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response('body')), sharedMaxAge: 600);
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertSame(600, (int) $response->headers->getCacheControlDirective('s-maxage'));
+    }
+
+    public function testItSetsPrivateWhenPublicIsFalse(): void
+    {
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response('body')), public: false);
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+    }
+
+    public function testItOmitsMustRevalidateWhenDisabled(): void
+    {
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response('body')), mustRevalidate: false);
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => new Request()]);
+
+        $this->assertFalse($response->headers->hasCacheControlDirective('must-revalidate'));
+    }
+
+    public function testItOmitsEtagWhenDisabled(): void
+    {
+        $body = 'body';
+        $request = new Request();
+        $request->headers->set('If-None-Match', '"'.md5($body).'"');
+        $processor = new CacheableDocumentationProcessor($this->decoratedReturning(new Response($body)), etag: false);
+
+        $response = $processor->process(new \stdClass(), new Get(), [], ['request' => $request]);
+
+        $this->assertNull($response->getEtag());
+        $this->assertSame(200, $response->getStatusCode(), 'When etag is disabled, isNotModified short-circuit must not run');
     }
 
     private function decoratedReturning(mixed $value): ProcessorInterface

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -338,6 +338,14 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         if (!$container->hasParameter('serializer.default_context')) {
             $container->setParameter('serializer.default_context', $container->getParameter('api_platform.serializer.default_context'));
         }
+        $documentationCacheHeaders = $config['documentation']['cache_headers'];
+        $container->setParameter('api_platform.documentation.cache_headers.enabled', $documentationCacheHeaders['enabled']);
+        $container->setParameter('api_platform.documentation.cache_headers.max_age', $documentationCacheHeaders['max_age']);
+        $container->setParameter('api_platform.documentation.cache_headers.shared_max_age', $documentationCacheHeaders['shared_max_age']);
+        $container->setParameter('api_platform.documentation.cache_headers.public', $documentationCacheHeaders['public']);
+        $container->setParameter('api_platform.documentation.cache_headers.must_revalidate', $documentationCacheHeaders['must_revalidate']);
+        $container->setParameter('api_platform.documentation.cache_headers.etag', $documentationCacheHeaders['etag']);
+
         if ($config['use_symfony_listeners']) {
             $loader->load('symfony/events.php');
         } else {
@@ -346,6 +354,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $loader->load('state/processor.php');
         }
         $loader->load('state/parameter_provider.php');
+
+        if (!$documentationCacheHeaders['enabled'] && $container->hasDefinition('api_platform.state_processor.documentation.cache')) {
+            $container->removeDefinition('api_platform.state_processor.documentation.cache');
+        }
 
         $container->setParameter('api_platform.enable_entrypoint', $config['enable_entrypoint']);
         $container->setParameter('api_platform.enable_docs', $config['enable_docs']);

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -182,6 +182,7 @@ final class Configuration implements ConfigurationInterface
         $this->addGraphQlSection($rootNode);
         $this->addSwaggerSection($rootNode);
         $this->addHttpCacheSection($rootNode);
+        $this->addDocumentationSection($rootNode);
         $this->addMercureSection($rootNode);
         $this->addMessengerSection($rootNode);
         $this->addElasticsearchSection($rootNode);
@@ -449,6 +450,31 @@ final class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                 ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addDocumentationSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('documentation')
+                    ->info('Documentation/entrypoint response options. Unrelated to the operation-level "defaults.cache_headers" / "http_cache" knobs which apply to API resource responses.')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('cache_headers')
+                            ->info('HTTP cache headers added to documentation and entrypoint responses.')
+                            ->canBeDisabled()
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->integerNode('max_age')->defaultValue(0)->info('Cache-Control max-age, in seconds.')->end()
+                                ->integerNode('shared_max_age')->defaultNull()->info('Cache-Control s-maxage, in seconds. Useful for CDN edges.')->end()
+                                ->booleanNode('public')->defaultTrue()->info('Whether the response is public (shared caches may store it).')->end()
+                                ->booleanNode('must_revalidate')->defaultTrue()->info('Whether to add the must-revalidate Cache-Control directive.')->end()
+                                ->booleanNode('etag')->defaultTrue()->info('Whether to add a content-hash ETag header (and short-circuit to 304 on If-None-Match).')->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/Resources/config/symfony/controller.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/controller.php
@@ -35,7 +35,14 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('api_platform.state_processor.documentation.cache', CacheableDocumentationProcessor::class)
         ->decorate('api_platform.state_processor.documentation', null, 300)
-        ->args([service('api_platform.state_processor.documentation.cache.inner')]);
+        ->args([
+            service('api_platform.state_processor.documentation.cache.inner'),
+            '%api_platform.documentation.cache_headers.max_age%',
+            '%api_platform.documentation.cache_headers.shared_max_age%',
+            '%api_platform.documentation.cache_headers.public%',
+            '%api_platform.documentation.cache_headers.must_revalidate%',
+            '%api_platform.documentation.cache_headers.etag%',
+        ]);
 
     $services->set('api_platform.action.entrypoint', EntrypointAction::class)
         ->public()

--- a/src/Symfony/Bundle/Resources/config/symfony/controller.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/controller.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
 use ApiPlatform\Symfony\Action\DocumentationAction;
 use ApiPlatform\Symfony\Action\EntrypointAction;
 use ApiPlatform\Symfony\Controller\MainController;
@@ -30,12 +31,18 @@ return static function (ContainerConfigurator $container) {
             service('logger')->ignoreOnInvalid(),
         ]);
 
+    $services->alias('api_platform.state_processor.documentation', 'api_platform.state_processor.main');
+
+    $services->set('api_platform.state_processor.documentation.cache', CacheableDocumentationProcessor::class)
+        ->decorate('api_platform.state_processor.documentation', null, 300)
+        ->args([service('api_platform.state_processor.documentation.cache.inner')]);
+
     $services->set('api_platform.action.entrypoint', EntrypointAction::class)
         ->public()
         ->args([
             service('api_platform.metadata.resource.name_collection_factory'),
             service('api_platform.state_provider.main'),
-            service('api_platform.state_processor.main'),
+            service('api_platform.state_processor.documentation'),
             '%api_platform.docs_formats%',
         ]);
 
@@ -48,7 +55,7 @@ return static function (ContainerConfigurator $container) {
             '%api_platform.version%',
             service('api_platform.openapi.factory')->nullOnInvalid(),
             service('api_platform.state_provider.main'),
-            service('api_platform.state_processor.main'),
+            service('api_platform.state_processor.documentation'),
             service('api_platform.negotiator')->nullOnInvalid(),
             '%api_platform.docs_formats%',
             '%api_platform.enable_swagger_ui%',

--- a/src/Symfony/Bundle/Resources/config/symfony/events.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use ApiPlatform\State\Processor\AddLinkHeaderProcessor;
+use ApiPlatform\State\Processor\CacheableDocumentationProcessor;
 use ApiPlatform\State\Processor\RespondProcessor;
 use ApiPlatform\State\Processor\SerializeProcessor;
 use ApiPlatform\State\Processor\WriteProcessor;
@@ -144,6 +145,10 @@ return static function (ContainerConfigurator $container) {
         ->arg('$negotiator', service('api_platform.negotiator'));
 
     $services->alias('api_platform.state_processor.documentation', 'api_platform.state_processor.respond');
+
+    $services->set('api_platform.state_processor.documentation.cache', CacheableDocumentationProcessor::class)
+        ->decorate('api_platform.state_processor.documentation', null, 300)
+        ->args([service('api_platform.state_processor.documentation.cache.inner')]);
 
     $services->set('api_platform.state_processor.documentation.serialize', SerializeProcessor::class)
         ->decorate('api_platform.state_processor.documentation', null, 200)

--- a/src/Symfony/Bundle/Resources/config/symfony/events.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.php
@@ -148,7 +148,14 @@ return static function (ContainerConfigurator $container) {
 
     $services->set('api_platform.state_processor.documentation.cache', CacheableDocumentationProcessor::class)
         ->decorate('api_platform.state_processor.documentation', null, 300)
-        ->args([service('api_platform.state_processor.documentation.cache.inner')]);
+        ->args([
+            service('api_platform.state_processor.documentation.cache.inner'),
+            '%api_platform.documentation.cache_headers.max_age%',
+            '%api_platform.documentation.cache_headers.shared_max_age%',
+            '%api_platform.documentation.cache_headers.public%',
+            '%api_platform.documentation.cache_headers.must_revalidate%',
+            '%api_platform.documentation.cache_headers.etag%',
+        ]);
 
     $services->set('api_platform.state_processor.documentation.serialize', SerializeProcessor::class)
         ->decorate('api_platform.state_processor.documentation', null, 200)

--- a/tests/Fixtures/TestBundle/ApiResource/CacheableDocumentationDummy.php
+++ b/tests/Fixtures/TestBundle/ApiResource/CacheableDocumentationDummy.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+
+#[ApiResource(
+    shortName: 'CacheableDocumentationDummy',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/cacheable_documentation_dummies',
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+class CacheableDocumentationDummy
+{
+    public function __construct(#[ApiProperty(identifier: true)] public int $id)
+    {
+    }
+
+    public static function provide(): iterable
+    {
+        return [new self(1), new self(2)];
+    }
+}

--- a/tests/Functional/State/CacheableDocumentationTest.php
+++ b/tests/Functional/State/CacheableDocumentationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\State;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\CacheableDocumentationDummy;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CacheableDocumentationAppKernel extends \AppKernel
+{
+    public static bool $useSymfonyListeners = false;
+
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller');
+    }
+
+    public function getLogDir(): string
+    {
+        return parent::getLogDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller');
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        parent::configureContainer($c, $loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            $container->loadFromExtension('api_platform', [
+                'use_symfony_listeners' => CacheableDocumentationAppKernel::$useSymfonyListeners,
+            ]);
+        });
+    }
+}
+
+final class CacheableDocumentationTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [CacheableDocumentationDummy::class];
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return CacheableDocumentationAppKernel::class;
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function modeProvider(): iterable
+    {
+        yield 'controller mode' => [false];
+        yield 'listener mode' => [true];
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testDocumentationResponseHasCacheHeaders(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+
+        $response = self::createClient()->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $headers = $response->getHeaders();
+        $this->assertNotEmpty($headers['etag'][0] ?? null, 'documentation response is missing an ETag');
+        $cacheControl = $headers['cache-control'][0] ?? '';
+        $this->assertStringContainsString('public', $cacheControl);
+        $this->assertStringContainsString('max-age=0', $cacheControl);
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testEntrypointResponseHasCacheHeaders(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+
+        $response = self::createClient()->request('GET', '/index.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $headers = $response->getHeaders();
+        $this->assertNotEmpty($headers['etag'][0] ?? null, 'entrypoint response is missing an ETag');
+        $cacheControl = $headers['cache-control'][0] ?? '';
+        $this->assertStringContainsString('max-age=0', $cacheControl);
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testDocumentationReturnsNotModifiedWhenIfNoneMatchMatches(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+
+        $client = self::createClient();
+        $first = $client->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+        $etag = $first->getHeaders()['etag'][0] ?? null;
+        $this->assertNotEmpty($etag, 'expected an ETag on the first documentation response');
+
+        $client->request('GET', '/docs.jsonld', [
+            'headers' => [
+                'Accept' => 'application/ld+json',
+                'If-None-Match' => $etag,
+            ],
+        ]);
+        $this->assertResponseStatusCodeSame(304);
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testRegularResourceDoesNotHaveDocumentationCacheHeaders(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+
+        $response = self::createClient()->request('GET', '/cacheable_documentation_dummies');
+
+        $this->assertResponseStatusCodeSame(200);
+        $headers = $response->getHeaders();
+        $cacheControl = $headers['cache-control'][0] ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
+        $this->assertStringNotContainsString('max-age=0', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
+    }
+}

--- a/tests/Functional/State/CacheableDocumentationTest.php
+++ b/tests/Functional/State/CacheableDocumentationTest.php
@@ -24,14 +24,19 @@ class CacheableDocumentationAppKernel extends \AppKernel
 {
     public static bool $useSymfonyListeners = false;
 
+    /**
+     * @var array<string, mixed>
+     */
+    public static array $cacheHeaders = [];
+
     public function getCacheDir(): string
     {
-        return parent::getCacheDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller');
+        return parent::getCacheDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller').'_'.self::cacheHeadersSignature();
     }
 
     public function getLogDir(): string
     {
-        return parent::getLogDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller');
+        return parent::getLogDir().'/cache_doc_'.($this::$useSymfonyListeners ? 'listeners' : 'controller').'_'.self::cacheHeadersSignature();
     }
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
@@ -39,10 +44,21 @@ class CacheableDocumentationAppKernel extends \AppKernel
         parent::configureContainer($c, $loader);
 
         $loader->load(static function (ContainerBuilder $container): void {
-            $container->loadFromExtension('api_platform', [
+            $extensionConfig = [
                 'use_symfony_listeners' => CacheableDocumentationAppKernel::$useSymfonyListeners,
-            ]);
+            ];
+
+            if ([] !== CacheableDocumentationAppKernel::$cacheHeaders) {
+                $extensionConfig['documentation'] = ['cache_headers' => CacheableDocumentationAppKernel::$cacheHeaders];
+            }
+
+            $container->loadFromExtension('api_platform', $extensionConfig);
         });
+    }
+
+    private static function cacheHeadersSignature(): string
+    {
+        return [] === self::$cacheHeaders ? 'default' : substr(md5(serialize(self::$cacheHeaders)), 0, 8);
     }
 }
 
@@ -72,6 +88,14 @@ final class CacheableDocumentationTest extends ApiTestCase
     {
         yield 'controller mode' => [false];
         yield 'listener mode' => [true];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // reset config overrides so each test starts from defaults
+        CacheableDocumentationAppKernel::$cacheHeaders = [];
     }
 
     #[DataProvider('modeProvider')]
@@ -142,5 +166,69 @@ final class CacheableDocumentationTest extends ApiTestCase
         $cacheControl = $headers['cache-control'][0] ?? '';
         $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
         $this->assertStringNotContainsString('max-age=0', $cacheControl, 'regular resource must not be wrapped by the documentation cache decorator');
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testCustomMaxAgeAndSharedMaxAgeAreApplied(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+        CacheableDocumentationAppKernel::$cacheHeaders = ['max_age' => 3600, 'shared_max_age' => 600];
+
+        $response = self::createClient()->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $cacheControl = $response->getHeaders()['cache-control'][0] ?? '';
+        $this->assertStringContainsString('max-age=3600', $cacheControl);
+        $this->assertStringContainsString('s-maxage=600', $cacheControl);
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testMustRevalidateCanBeDisabled(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+        CacheableDocumentationAppKernel::$cacheHeaders = ['must_revalidate' => false];
+
+        $response = self::createClient()->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $cacheControl = $response->getHeaders()['cache-control'][0] ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl);
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testEtagCanBeDisabled(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+        CacheableDocumentationAppKernel::$cacheHeaders = ['etag' => false];
+
+        $response = self::createClient()->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        // documentation decorator is still wired (must-revalidate proves it) but it must not have set its md5 ETag
+        $cacheControl = $response->getHeaders()['cache-control'][0] ?? '';
+        $this->assertStringContainsString('must-revalidate', $cacheControl);
+        $etag = trim($response->getHeaders()['etag'][0] ?? '', '"');
+        $this->assertFalse(1 === preg_match('/^[a-f0-9]{32}$/', $etag), 'documentation decorator must not produce its md5 ETag when etag is disabled');
+    }
+
+    #[DataProvider('modeProvider')]
+    public function testFeatureCanBeDisabled(bool $useSymfonyListeners): void
+    {
+        CacheableDocumentationAppKernel::$useSymfonyListeners = $useSymfonyListeners;
+        CacheableDocumentationAppKernel::$cacheHeaders = ['enabled' => false];
+
+        $response = self::createClient()->request('GET', '/docs.jsonld', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $cacheControl = $response->getHeaders()['cache-control'][0] ?? '';
+        $this->assertStringNotContainsString('must-revalidate', $cacheControl, 'when disabled, the cache decorator must not be wired');
     }
 }

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -198,6 +198,16 @@ class ConfigurationTest extends TestCase
                 ],
                 'public' => null,
             ],
+            'documentation' => [
+                'cache_headers' => [
+                    'enabled' => true,
+                    'max_age' => 0,
+                    'shared_max_age' => null,
+                    'public' => true,
+                    'must_revalidate' => true,
+                    'etag' => true,
+                ],
+            ],
             'doctrine' => [
                 'enabled' => \in_array('orm', $doctrineIntegrationsToLoad, true),
             ],


### PR DESCRIPTION
## Summary

Adds HTTP caching headers (ETag + revalidation `Cache-Control`) to the API documentation (`/docs.{_format}`) and entrypoint (`/{index}.{_format}`) routes so clients can skip re-downloading the body when nothing has changed.

Fixes #4074.

## Why

These two endpoints are hit on every page load by API Platform Admin and any other client that parses the Hydra documentation. The response is often hundreds of KB (one user reports 280 KB / 1.3 s in #4074) and the content rarely changes between requests. Today there is no cache validator at all, so every fetch re-transfers the full payload.

## What changes

- Adds `ApiPlatform\State\Processor\CacheableDocumentationProcessor`, a state processor that decorates `api_platform.state_processor.documentation` (the processor used exclusively by `EntrypointAction` and `DocumentationAction`).
- The processor:
  - Sets a strong ETag (`md5` of the response body).
  - Sets `Cache-Control: public, max-age=0, must-revalidate` so clients always revalidate but can serve from local cache while doing so.
  - Calls `Response::isNotModified()` which short-circuits to a `304 Not Modified` (with empty body) when the client sends a matching `If-None-Match`.
- Wired in `src/Symfony/Bundle/Resources/config/symfony/events.php` as a decorator at priority `300` (outermost, so it sees the final serialized `Response`). The pattern mirrors the existing `AddLinkHeaderProcessor`.
- The processor is a no-op for non-`Response` returns, non-200 responses, or empty bodies — and because it only decorates the `documentation` processor, it cannot affect any non-documentation route.

This follows the maintainer's suggestion in [#4074](https://github.com/api-platform/core/issues/4074#issuecomment-780651855) (\"we must set etags and basic HTTP cache header on these endpoints\").

## Why a state processor (not a kernel listener)

API Platform 4.x routes documentation through the same state-processor pipeline as resources (`documentation.serialize` at 200, `documentation.write` at 100). A processor decorator is the idiomatic extension point — it scopes naturally to the two documentation actions (no route-name sniffing on `kernel.response`), composes with the stopwatch, and matches the precedent set by `AddLinkHeaderProcessor`.

## Tests

New `ApiPlatform\State\Tests\Processor\CacheableDocumentationProcessorTest` covers:
- ETag + Cache-Control headers (`public`, `must-revalidate`, `max-age=0`) are set on a 200 response.
- `If-None-Match` matching the computed ETag yields a `304` response with an empty body.
- Pass-through when the decorated processor returns something that isn't a `Response`.
- No-op for non-200 responses.
- No-op when the response body is empty.
- Headers still applied when no `request` is present in the context.

## Test plan

- [x] `./vendor/bin/phpunit --filter CacheableDocumentationProcessorTest` (6/6, 18 assertions)
- [x] Full `src/State` suite (60/60, 216 assertions)
- [x] `php -l` on all changed files