### PR TITLE
fix(laravel): skip relation metadata for abstract Eloquent models

### DIFF
--- a/src/Laravel/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoader.php
+++ b/src/Laravel/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoader.php
@@ -42,6 +42,10 @@ final class RelationMetadataLoader implements LoaderInterface
         }
 
         $refl = $classMetadata->getReflectionClass();
+        if ($refl->isAbstract()) {
+            return false;
+        }
+
         /** @var Model */
         $model = $refl->newInstanceWithoutConstructor();
         $attributesMetadata = $classMetadata->getAttributesMetadata();

--- a/src/Laravel/Tests/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoaderTest.php
+++ b/src/Laravel/Tests/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoaderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Eloquent\Serializer\Mapping\Loader;
+
+use ApiPlatform\Laravel\Eloquent\Metadata\ModelMetadata;
+use ApiPlatform\Laravel\Eloquent\Serializer\Mapping\Loader\RelationMetadataLoader;
+use Orchestra\Testbench\TestCase;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Workbench\App\Models\AbstractModel;
+
+class RelationMetadataLoaderTest extends TestCase
+{
+    /**
+     * @see https://github.com/api-platform/core/issues/7911
+     */
+    public function testLoadClassMetadataReturnsFalseForAbstractModelWithoutInstantiating(): void
+    {
+        $loader = new RelationMetadataLoader(new ModelMetadata());
+
+        $result = $loader->loadClassMetadata(new ClassMetadata(AbstractModel::class));
+
+        $this->assertFalse($result);
+    }
+}

--- a/src/Laravel/workbench/app/Models/AbstractModel.php
+++ b/src/Laravel/workbench/app/Models/AbstractModel.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+abstract class AbstractModel extends Model
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7911
| License       | MIT
| Doc PR        | n/a

`RelationMetadataLoader` crashes with `Cannot instantiate abstract class` when an API resource model extends an abstract base model.

The Symfony serializer's `ClassMetadataFactory` walks the full class hierarchy when building metadata. For a chain like `ItemTranslation extends AbstractModel extends Model`, the loader is also invoked for `AbstractModel`. Since `AbstractModel` is still a subclass of `Model`, the existing `is_a(..., Model::class, true)` guard passes, and `$refl->newInstanceWithoutConstructor()` then throws because the class is abstract.

This PR adds an early `return false` when the reflected class is abstract — there is nothing meaningful to load on an abstract model anyway, and the recursion continues normally for the concrete subclass.

### Changes

- `src/Laravel/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoader.php`: guard with `ReflectionClass::isAbstract()` before instantiation.
- New regression test: `src/Laravel/Tests/Eloquent/Serializer/Mapping/Loader/RelationMetadataLoaderTest.php`.
- New workbench fixture: `src/Laravel/workbench/app/Models/AbstractModel.php` (generic abstract Eloquent model, reusable by future tests).

### Backwards compatibility

No BC break: previously, calling the loader with an abstract model class always threw `Error: Cannot instantiate abstract class`. There is no existing code path that relied on this behavior.