### PR TITLE
fix(symfony): api_platform_iris route loader for graphql-only setups

### DIFF
--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Routing;
 
 use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\NotExposed;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\OpenApi\Attributes\Webhook;
@@ -34,6 +35,8 @@ use Symfony\Component\Routing\RouteCollection;
 final class ApiLoader extends Loader
 {
     public const DEFAULT_ACTION_PATTERN = 'api_platform.action.';
+    public const TYPE = 'api_platform';
+    public const TYPE_IRIS = 'api_platform_iris';
 
     private readonly PhpFileLoader $fileLoader;
 
@@ -48,15 +51,24 @@ final class ApiLoader extends Loader
      */
     public function load(mixed $data, ?string $type = null): RouteCollection
     {
+        $notExposedOnly = self::TYPE_IRIS === $type;
+
         $routeCollection = new RouteCollection();
         foreach ($this->resourceClassDirectories as $directory) {
             $routeCollection->addResource(new DirectoryResource($directory, '/\.php$/'));
         }
 
-        $this->loadExternalFiles($routeCollection);
+        if (!$notExposedOnly) {
+            $this->loadExternalFiles($routeCollection);
+        }
+
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {
             foreach ($this->resourceMetadataFactory->create($resourceClass) as $resourceMetadata) {
                 foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
+                    if ($notExposedOnly && !$operation instanceof NotExposed) {
+                        continue;
+                    }
+
                     if ($operation->getOpenapi() instanceof Webhook) {
                         continue;
                     }
@@ -119,7 +131,7 @@ final class ApiLoader extends Loader
      */
     public function supports(mixed $resource, ?string $type = null): bool
     {
-        return 'api_platform' === $type;
+        return self::TYPE === $type || self::TYPE_IRIS === $type;
     }
 
     /**

--- a/tests/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Symfony/Routing/ApiLoaderTest.php
@@ -19,6 +19,7 @@ use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\NotExposed;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
@@ -257,6 +258,25 @@ class ApiLoaderTest extends TestCase
         );
     }
 
+    public function testApiLoaderIrisTypeOnlyEmitsNotExposedRoutes(): void
+    {
+        $resourceCollection = new ResourceMetadataCollection(Dummy::class, [
+            (new ApiResource())->withShortName('dummy')->withOperations(new Operations([
+                'api_dummies_get_item' => (new Get())->withUriTemplate('/dummies/{id}{._format}')->withController('api_platform.action.get_item'),
+                'api_dummies_get_collection' => (new GetCollection())->withUriTemplate('/dummies{._format}'),
+                'api_dummies_not_exposed_item' => (new NotExposed())->withUriTemplate('/dummies/{id}{._format}'),
+            ])),
+        ]);
+
+        $routeCollection = $this->getApiLoaderWithResourceMetadataCollection($resourceCollection)->load(null, ApiLoader::TYPE_IRIS);
+
+        $this->assertNull($routeCollection->get('api_dummies_get_item'));
+        $this->assertNull($routeCollection->get('api_dummies_get_collection'));
+        $this->assertNotNull($routeCollection->get('api_dummies_not_exposed_item'));
+        $this->assertNull($routeCollection->get('api_jsonld_context'));
+        $this->assertNull($routeCollection->get('api_entrypoint'));
+    }
+
     public function testApiLoaderWithUndefinedControllerService(): void
     {
         $this->expectExceptionObject(new \RuntimeException('Operation "api_dummies_my_undefined_controller_method_item" is defining an unknown service as controller "Foo\\Bar\\MyUndefinedController". Make sure it is properly registered in the dependency injection container.'));
@@ -284,6 +304,7 @@ class ApiLoaderTest extends TestCase
             'api_platform.action.get_item',
             'api_platform.action.put_item',
             'api_platform.action.delete_item',
+            'api_platform.action.not_exposed',
             'Foo\\Bar\\MyController',
         ];
         $containerProphecy = $this->prophesize(ContainerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | #7915
| License       | MIT
| Doc PR        | ∅

Adds a new `api_platform_iris` Symfony route loader type that registers only the auto-generated `NotExposed` operations — no exposed REST controllers, no docs/entrypoint routes. This lets users run a GraphQL-only API while keeping IRIs (Relay global IDs, subscription keys, nested IRI inputs) working through the standard `api_platform.symfony.iri_converter`.

## Usage

```yaml
# config/routes/api_platform.yaml
api_platform_iris:
    resource: .
    type: api_platform_iris

api_platform_graphql:
    resource: '@ApiPlatformBundle/Resources/config/routing/graphql/graphql.php'
```

REST setups keep `type: api_platform` exactly as before.

## Why this approach

The `NotExposedOperationResourceMetadataCollectionFactory` already auto-generates a `NotExposed` operation for any resource without an item GET (for example resources declared with `operations: []` and `graphqlOperations: [...]`). The new loader simply walks the same metadata and emits Symfony routes for those `NotExposed` operations only. This means IRI generation and matching go through the regular `api_platform.symfony.iri_converter` — no decorator, no shadow URI-template engine.