### PR TITLE
fix(state): preserve Type message when expectedTypes is set

### DIFF
--- a/src/State/Provider/DeserializeProvider.php
+++ b/src/State/Provider/DeserializeProvider.php
@@ -115,6 +115,8 @@ final class DeserializeProvider implements ProviderInterface, StopwatchAwareInte
                 $parameters = [];
                 if ($exception->canUseMessageForUser()) {
                     $parameters['hint'] = $exception->getMessage();
+                }
+                if (!$expectedTypes && $exception->canUseMessageForUser()) {
                     $violationMessage = $exception->getMessage();
                     $violations->add(new ConstraintViolation($violationMessage, $violationMessage, $parameters, null, $exception->getPath(), null, null, (string) Type::INVALID_TYPE_ERROR));
                 } else {

--- a/src/State/Tests/Provider/DeserializeProviderTest.php
+++ b/src/State/Tests/Provider/DeserializeProviderTest.php
@@ -208,7 +208,7 @@ class DeserializeProviderTest extends TestCase
     }
 
     #[IgnoreDeprecations]
-    public function testDeserializeUsesExceptionMessageWhenCanUseMessageForUser(): void
+    public function testDeserializeKeepsTypeMessageWhenExpectedTypesAreSet(): void
     {
         $operation = new Post(deserialize: true, class: \stdClass::class);
         $decorated = $this->createStub(ProviderInterface::class);
@@ -239,10 +239,10 @@ class DeserializeProviderTest extends TestCase
         } catch (ValidationException $e) {
             $violations = $e->getConstraintViolationList();
             $this->assertCount(1, $violations);
-            $this->assertSame('The data must belong to a backed enumeration of type Suit.', $violations[0]->getMessage());
-            $this->assertSame('The data must belong to a backed enumeration of type Suit.', $violations[0]->getMessageTemplate());
+            $this->assertSame('This value should be of type string.', $violations[0]->getMessage());
             $this->assertSame('status', $violations[0]->getPropertyPath());
             $this->assertSame((string) Type::INVALID_TYPE_ERROR, $violations[0]->getCode());
+            $this->assertSame('The data must belong to a backed enumeration of type Suit.', $violations[0]->getParameters()['hint'] ?? null);
         }
     }
 

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -85,7 +85,7 @@ final class ValidationTest extends ApiTestCase
 
         $violationBaz = $findViolation('baz');
         $this->assertNotNull($violationBaz, 'Violation for "baz" not found.');
-        $this->assertSame('Failed to create object because the class misses the "baz" property.', $violationBaz['message']);
+        $this->assertSame('This value should be of type string.', $violationBaz['message']);
         $this->assertArrayHasKey('hint', $violationBaz);
         $this->assertSame('Failed to create object because the class misses the "baz" property.', $violationBaz['hint']);
 
@@ -117,14 +117,14 @@ final class ValidationTest extends ApiTestCase
         $violationUuid = $findViolation('uuid');
         $this->assertNotNull($violationUuid);
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->assertSame('Invalid UUID string: y', $violationUuid['message']);
+            $this->assertSame('This value should be of type uuid.', $violationUuid['message']);
         } else {
             $this->assertSame('This value should be of type UuidInterface|null.', $violationUuid['message']);
         }
 
         $violationRelatedDummy = $findViolation('relatedDummy');
         $this->assertNotNull($violationRelatedDummy);
-        $this->assertSame('The type of the "relatedDummy" attribute must be "array" (nested document) or "string" (IRI), "integer" given.', $violationRelatedDummy['message']);
+        $this->assertSame('This value should be of type array|string.', $violationRelatedDummy['message']);
 
         $violationRelatedDummies = $findViolation('relatedDummies');
         $this->assertNotNull($violationRelatedDummies);

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -125,6 +125,8 @@ final class ValidationTest extends ApiTestCase
         $violationRelatedDummy = $findViolation('relatedDummy');
         $this->assertNotNull($violationRelatedDummy);
         $this->assertSame('This value should be of type array|string.', $violationRelatedDummy['message']);
+        $this->assertArrayHasKey('hint', $violationRelatedDummy);
+        $this->assertSame('The type of the "relatedDummy" attribute must be "array" (nested document) or "string" (IRI), "integer" given.', $violationRelatedDummy['hint']);
 
         $violationRelatedDummies = $findViolation('relatedDummies');
         $this->assertNotNull($violationRelatedDummies);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | refs #7894
| License       | MIT
| Doc PR        | N/A

Only fall back to the exception message when expectedTypes is empty (Symfony 8.1 BackedEnumNormalizer). Restores BC for the validator "This value should be of type ..." translation; the user-friendly message is still available via the `hint` parameter.