### PR TITLE
fix(doctrine): IriFilter ignores custom ApiProperty identifier on ODM

### DIFF
--- a/src/Doctrine/Odm/Filter/IriFilter.php
+++ b/src/Doctrine/Odm/Filter/IriFilter.php
@@ -78,10 +78,24 @@ final class IriFilter implements FilterInterface, OpenApiParameterFilterInterfac
             $or = $aggregationBuilder->matchExpr();
 
             foreach ($value as $v) {
+                if (!\is_object($v)) {
+                    continue;
+                }
+
                 $or->addOr($aggregationBuilder->matchExpr()->field($matchField)->{$method}($v));
             }
 
             $match->{$operator}($or);
+
+            return;
+        }
+
+        // The IRI did not resolve to a resource: emit an always-false clause so the query
+        // returns no result rather than attempting to match against a raw IRI string.
+        if (!\is_object($value)) {
+            $match->{$operator}(
+                $aggregationBuilder->matchExpr()->field($matchField)->in([])
+            );
 
             return;
         }

--- a/src/Doctrine/Odm/State/ItemProvider.php
+++ b/src/Doctrine/Odm/State/ItemProvider.php
@@ -57,7 +57,13 @@ final class ItemProvider implements ProviderInterface
 
         $fetchData = $context['fetch_data'] ?? true;
         if (!$fetchData) {
-            return $manager->getReference($documentClass, reset($uriVariables));
+            $identifier = $manager->getClassMetadata($documentClass)->identifier;
+            if ($identifier && 1 === \count($uriVariables) && \array_key_exists($identifier, $uriVariables)) {
+                return $manager->getReference($documentClass, $uriVariables[$identifier]);
+            }
+            // When URI variables don't correspond to the document identifier (e.g. custom
+            // ApiProperty identifier on a non-#[Id] field), fall through to a real lookup
+            // so that the returned document carries the actual database identifier.
         }
 
         $repository = $manager->getRepository($documentClass);

--- a/tests/Fixtures/TestBundle/Document/Issue7913/Agent.php
+++ b/tests/Fixtures/TestBundle/Document/Issue7913/Agent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue7913;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document(collection: 'issue_7913_agent')]
+#[ApiResource(
+    shortName: 'Issue7913Agent',
+    operations: [new Get(uriTemplate: '/issue7913_agents/{agentId}', uriVariables: ['agentId'])],
+)]
+class Agent
+{
+    #[ODM\Id(type: 'string', strategy: 'INCREMENT')]
+    #[ApiProperty(identifier: false)]
+    private ?string $id = null;
+
+    #[ODM\Field(type: 'string')]
+    #[ApiProperty(identifier: true)]
+    private ?string $agentId = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getAgentId(): ?string
+    {
+        return $this->agentId;
+    }
+
+    public function setAgentId(string $agentId): self
+    {
+        $this->agentId = $agentId;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/TestBundle/Document/Issue7913/Mail.php
+++ b/tests/Fixtures/TestBundle/Document/Issue7913/Mail.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue7913;
+
+use ApiPlatform\Doctrine\Odm\Filter\IriFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document(collection: 'issue_7913_mail')]
+#[ApiResource(
+    shortName: 'Issue7913Mail',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/issue7913_mails',
+            normalizationContext: ['hydra_prefix' => false],
+            parameters: [
+                'author' => new QueryParameter(filter: new IriFilter()),
+            ],
+        ),
+    ],
+)]
+class Mail
+{
+    #[ODM\Id(type: 'string', strategy: 'INCREMENT')]
+    private ?string $id = null;
+
+    #[ODM\ReferenceOne(targetDocument: Agent::class, storeAs: 'id')]
+    private ?Agent $author = null;
+
+    #[ODM\Field(type: 'string')]
+    private ?string $subject = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getAuthor(): ?Agent
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?Agent $author): self
+    {
+        $this->author = $author;
+
+        return $this;
+    }
+
+    public function getSubject(): ?string
+    {
+        return $this->subject;
+    }
+
+    public function setSubject(?string $subject): self
+    {
+        $this->subject = $subject;
+
+        return $this;
+    }
+}

--- a/tests/Functional/Parameters/Issue7913IriFilterCustomIdentifierTest.php
+++ b/tests/Functional/Parameters/Issue7913IriFilterCustomIdentifierTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue7913\Agent as DocumentAgent;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Issue7913\Mail as DocumentMail;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Tests for issue #7913: IriFilter must work when the referenced
+ * resource declares a custom ApiProperty identifier (different from #[Id]).
+ *
+ * @see https://github.com/api-platform/core/issues/7913
+ *
+ * @group issue-7913
+ */
+final class Issue7913IriFilterCustomIdentifierTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [DocumentAgent::class, DocumentMail::class];
+    }
+
+    protected function setUp(): void
+    {
+        if (!$this->isMongoDB()) {
+            $this->markTestSkipped('Issue #7913 only affects ODM IriFilter.');
+        }
+
+        $this->recreateSchema([DocumentAgent::class, DocumentMail::class]);
+        $this->loadFixtures();
+    }
+
+    public function testIriFilterMatchesByCustomIdentifier(): void
+    {
+        $client = self::createClient();
+
+        $response = $client->request('GET', '/issue7913_mails?author=/issue7913_agents/AGENT_001');
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $this->assertCount(1, $data['member']);
+        $this->assertSame('First mail', $data['member'][0]['subject']);
+    }
+
+    public function testIriFilterReturnsEmptyForUnknownCustomIdentifier(): void
+    {
+        $client = self::createClient();
+
+        $response = $client->request('GET', '/issue7913_mails?author=/issue7913_agents/UNKNOWN');
+        $this->assertResponseIsSuccessful();
+
+        $data = $response->toArray();
+        $this->assertCount(0, $data['member']);
+    }
+
+    private function loadFixtures(): void
+    {
+        $manager = $this->getManager();
+
+        $agent1 = new DocumentAgent();
+        $agent1->setAgentId('AGENT_001');
+
+        $agent2 = new DocumentAgent();
+        $agent2->setAgentId('AGENT_002');
+
+        $manager->persist($agent1);
+        $manager->persist($agent2);
+        $manager->flush();
+
+        $mail1 = new DocumentMail();
+        $mail1->setSubject('First mail');
+        $mail1->setAuthor($agent1);
+
+        $mail2 = new DocumentMail();
+        $mail2->setSubject('Second mail');
+        $mail2->setAuthor($agent2);
+
+        $manager->persist($mail1);
+        $manager->persist($mail2);
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7913
| License       | MIT
| Doc PR        | ∅

ODM ItemProvider was unconditionally calling getReference() with the first URI variable when fetch_data=false, producing a proxy with the wrong _id when the resource declared a custom ApiProperty identifier on a non-#[Id] field. IriFilter now also emits a never-match clause for unresolved IRIs instead of crashing on a raw IRI string.
