### PR TITLE
fix(jsonapi): use parent-resolved class in denormalizeRelation

### DIFF
--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -266,7 +266,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      * @throws RuntimeException
      * @throws UnexpectedValueException
      */
-    protected function denormalizeRelation(string $attributeName, ApiProperty $propertyMetadata, string $targetClass, mixed $value, ?string $format, array $context): ?object
+    protected function denormalizeRelation(string $attributeName, ApiProperty $propertyMetadata, string $className, mixed $value, ?string $format, array $context): ?object
     {
         if (!\is_array($value) || !isset($value['id'], $value['type'])) {
             throw new UnexpectedValueException('Only resource linkage supported currently, see: http://jsonapi.org/format/#document-resource-object-linkage.');
@@ -279,8 +279,8 @@ final class ItemNormalizer extends AbstractItemNormalizer
             }
 
             /** @var HttpOperation $getOperation */
-            $getOperation = $this->resourceMetadataCollectionFactory->create($targetClass)->getOperation(httpOperation: true);
-            $iri = $this->reconstructIri($targetClass, (string) $value['id'], $getOperation);
+            $getOperation = $this->resourceMetadataCollectionFactory->create($className)->getOperation(httpOperation: true);
+            $iri = $this->reconstructIri($className, (string) $value['id'], $getOperation);
 
             return $this->iriConverter->getResourceFromIri($iri, $context);
         } catch (ItemNotFoundException $e) {
@@ -290,7 +290,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context['not_normalizable_value_exceptions'][] = NotNormalizableValueException::createForUnexpectedDataType(
                 $e->getMessage(),
                 $value,
-                [$targetClass],
+                [$className],
                 $context['deserialization_path'] ?? null,
                 true,
                 $e->getCode(),

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -266,7 +266,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
      * @throws RuntimeException
      * @throws UnexpectedValueException
      */
-    protected function denormalizeRelation(string $attributeName, ApiProperty $propertyMetadata, string $className, mixed $value, ?string $format, array $context): ?object
+    protected function denormalizeRelation(string $attributeName, ApiProperty $propertyMetadata, string $targetClass, mixed $value, ?string $format, array $context): ?object
     {
         if (!\is_array($value) || !isset($value['id'], $value['type'])) {
             throw new UnexpectedValueException('Only resource linkage supported currently, see: http://jsonapi.org/format/#document-resource-object-linkage.');
@@ -276,19 +276,6 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context += ['fetch_data' => true];
             if ($this->useIriAsId) {
                 return $this->iriConverter->getResourceFromIri($value['id'], $context);
-            }
-
-            $targetClass = null;
-            $nativeType = $propertyMetadata->getNativeType();
-
-            if ($nativeType) {
-                $nativeType->isSatisfiedBy(function (Type $type) use (&$targetClass): bool {
-                    return $type instanceof ObjectType && $this->resourceClassResolver->isResourceClass($targetClass = $type->getClassName());
-                });
-            }
-
-            if (null === $targetClass) {
-                throw new ItemNotFoundException(\sprintf('Cannot determine target class for property "%s".', $attributeName));
             }
 
             /** @var HttpOperation $getOperation */
@@ -303,7 +290,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $context['not_normalizable_value_exceptions'][] = NotNormalizableValueException::createForUnexpectedDataType(
                 $e->getMessage(),
                 $value,
-                [$className],
+                [$targetClass],
                 $context['deserialization_path'] ?? null,
                 true,
                 $e->getCode(),

--- a/src/JsonApi/Tests/Serializer/ItemNormalizerTest.php
+++ b/src/JsonApi/Tests/Serializer/ItemNormalizerTest.php
@@ -314,6 +314,67 @@ class ItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $normalizer->denormalize($data, Dummy::class, ItemNormalizer::FORMAT));
     }
 
+    // https://github.com/api-platform/core/pull/7938
+    public function testDenormalizeRelationUsesClassNameArgument(): void
+    {
+        $relatedDummy = new RelatedDummy();
+        $relatedDummy->setId(1);
+
+        $propertyMetadata = (new ApiProperty())
+            ->withNativeType(Type::collection(Type::object(ArrayCollection::class), Type::object(RelatedDummy::class), Type::int()))
+            ->withReadable(false)->withWritable(true)
+            ->withReadableLink(false)->withWritableLink(false);
+
+        $iriConverter = $this->createStub(IriConverterInterface::class);
+        $iriConverter->method('getIriFromResource')->willReturn('/related_dummies/1');
+        $iriConverter->method('getResourceFromIri')->willReturn($relatedDummy);
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturnMap([
+            [RelatedDummy::class, true],
+            [ArrayCollection::class, false],
+        ]);
+
+        $resourceMetadataCollectionFactory = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataCollectionFactory->expects($this->once())
+            ->method('create')
+            ->with(RelatedDummy::class)
+            ->willReturn(new ResourceMetadataCollection(RelatedDummy::class, [
+                (new ApiResource())->withOperations(new Operations([
+                    new Get(name: 'get', uriTemplate: '/related_dummies/{id}', uriVariables: ['id' => new Link(fromClass: RelatedDummy::class, identifiers: ['id'])]),
+                ])),
+            ]));
+
+        $normalizer = new ItemNormalizer(
+            $this->createStub(PropertyNameCollectionFactoryInterface::class),
+            $this->createStub(PropertyMetadataFactoryInterface::class),
+            $iriConverter,
+            $resourceClassResolver,
+            null,
+            new ReservedAttributeNameConverter(),
+            null,
+            [],
+            $resourceMetadataCollectionFactory,
+            null,
+            null,
+            null,
+            null,
+            false,
+        );
+
+        $result = (new \ReflectionMethod(ItemNormalizer::class, 'denormalizeRelation'))->invoke(
+            $normalizer,
+            'relatedDummies',
+            $propertyMetadata,
+            RelatedDummy::class,
+            ['type' => 'related-dummy', 'id' => '1'],
+            null,
+            []
+        );
+
+        $this->assertSame($relatedDummy, $result);
+    }
+
     public function testDenormalizeUpdateOperationNotAllowed(): void
     {
         $this->expectException(NotNormalizableValueException::class);


### PR DESCRIPTION
This fix aims at avoiding the

Uncaught PHP Exception ApiPlatform\Metadata\Exception\OperationNotFoundException: "Operation "" not found for resource "Collection"." at ResourceMetadataCollection.php line 114 

when using JSONAPI with

```
api_platform:
   jsonapi:
        use_iri_as_id: false
```

Happens in version 4.3.


The reason is that the implemented algorithm does not resolve to the class inside of the container. The third parameter seems already to provide the actual target class.