### PR TITLE
fix(laravel): expose ReDoc/Scalar in docs footer

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -749,10 +749,13 @@ class ApiPlatformProvider extends ServiceProvider
             /** @var ConfigRepository */
             $config = $app['config'];
 
+            $graphQlEnabled = (bool) $config->get('api-platform.graphql.enabled', false);
+
             return new SwaggerUiProcessor(
                 urlGenerator: $app->make(UrlGeneratorInterface::class),
                 normalizer: $app->make(NormalizerInterface::class),
                 openApiOptions: $app->make(Options::class),
+                formats: $config->get('api-platform.docs_formats', []),
                 oauthClientId: $config->get('api-platform.swagger_ui.oauth.clientId'),
                 oauthClientSecret: $config->get('api-platform.swagger_ui.oauth.clientSecret'),
                 oauthPkce: $config->get('api-platform.swagger_ui.oauth.pkce', false),
@@ -760,6 +763,8 @@ class ApiPlatformProvider extends ServiceProvider
                 scalarEnabled: $config->get('api-platform.scalar.enabled', false),
                 scalarExtraConfiguration: $config->get('api-platform.scalar.extra_configuration', []),
                 redocEnabled: $config->get('api-platform.redoc.enabled', false),
+                graphQlEnabled: $graphQlEnabled,
+                graphiQlEnabled: $graphQlEnabled && (bool) $config->get('api-platform.graphiql.enabled', true),
             );
         });
 

--- a/src/Laravel/State/SwaggerUiProcessor.php
+++ b/src/Laravel/State/SwaggerUiProcessor.php
@@ -48,6 +48,8 @@ final class SwaggerUiProcessor implements ProcessorInterface
         private readonly bool $scalarEnabled = false,
         private readonly array $scalarExtraConfiguration = [],
         private readonly bool $redocEnabled = false,
+        private readonly bool $graphQlEnabled = false,
+        private readonly bool $graphiQlEnabled = false,
     ) {
     }
 
@@ -62,8 +64,8 @@ final class SwaggerUiProcessor implements ProcessorInterface
             'formats' => $this->formats,
             'title' => $openApi->getInfo()->getTitle(),
             'description' => $openApi->getInfo()->getDescription(),
-            'originalRoute' => $request->attributes->get('_api_original_route', $request->attributes->get('_route')),
-            'originalRouteParams' => $request->attributes->get('_api_original_route_params', $request->attributes->get('_route_params', [])),
+            'originalRoute' => $request->attributes->get('_api_original_route') ?? $request->route()?->getName(),
+            'originalRouteParams' => $request->attributes->get('_api_original_route_params') ?? $request->route()?->parameters() ?? [],
         ];
 
         $swaggerData = [
@@ -99,7 +101,15 @@ final class SwaggerUiProcessor implements ProcessorInterface
 
         $swaggerData['scalarExtraConfiguration'] = $this->scalarExtraConfiguration;
 
-        return new Response(view('api-platform::swagger-ui', $swaggerContext + ['swagger_data' => $swaggerData, 'ui' => $this->getUi()]), 200);
+        return new Response(view('api-platform::swagger-ui', $swaggerContext + [
+            'swagger_data' => $swaggerData,
+            'ui' => $this->getUi(),
+            'swaggerUiEnabled' => $this->swaggerEnabled,
+            'redocEnabled' => $this->redocEnabled,
+            'scalarEnabled' => $this->scalarEnabled,
+            'graphQlEnabled' => $this->graphQlEnabled,
+            'graphiQlEnabled' => $this->graphiQlEnabled,
+        ]), 200);
     }
 
     /**

--- a/src/Laravel/Tests/DocsSingleUiTest.php
+++ b/src/Laravel/Tests/DocsSingleUiTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Config\Repository;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class DocsSingleUiTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use WithWorkbench;
+
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config): void {
+            $config->set('api-platform.swagger_ui.enabled', true);
+            $config->set('api-platform.redoc.enabled', false);
+            $config->set('api-platform.scalar.enabled', false);
+        });
+    }
+
+    public function testHtmlDocsHasNoOtherUiLinksWhenOnlyOneUiEnabled(): void
+    {
+        $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
+        $res->assertOk();
+        $content = $res->getContent();
+
+        $this->assertStringContainsString('init-swagger-ui.js', $content);
+        $this->assertStringContainsString('id="formats"', $content);
+        $this->assertStringNotContainsString('>Swagger UI</a>', $content);
+        $this->assertStringNotContainsString('>ReDoc</a>', $content);
+        $this->assertStringNotContainsString('>Scalar</a>', $content);
+    }
+}

--- a/src/Laravel/Tests/DocsSingleUiTest.php
+++ b/src/Laravel/Tests/DocsSingleUiTest.php
@@ -36,7 +36,7 @@ class DocsSingleUiTest extends TestCase
     {
         $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
         $res->assertOk();
-        $content = $res->getContent();
+        $content = (string) $res->getContent();
 
         $this->assertStringContainsString('init-swagger-ui.js', $content);
         $this->assertStringContainsString('id="formats"', $content);

--- a/src/Laravel/Tests/DocsTest.php
+++ b/src/Laravel/Tests/DocsTest.php
@@ -49,4 +49,40 @@ class DocsTest extends TestCase
         $this->assertArrayHasKey('@context', $res->json());
         $this->assertSame('application/ld+json; charset=utf-8', $res->headers->get('content-type'));
     }
+
+    public function testHtmlDocsRendersSwaggerUiByDefault(): void
+    {
+        $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
+        $res->assertOk();
+        $content = $res->getContent();
+
+        $this->assertStringContainsString('init-swagger-ui.js', $content);
+        $this->assertStringContainsString('id="formats"', $content);
+        $this->assertStringContainsString('>ReDoc</a>', $content);
+        $this->assertStringContainsString('>Scalar</a>', $content);
+        $this->assertStringNotContainsString('>Swagger UI</a>', $content);
+    }
+
+    public function testHtmlDocsRendersRedocWhenRequested(): void
+    {
+        $res = $this->get('/api/docs?ui=redoc', headers: ['accept' => 'text/html']);
+        $res->assertOk();
+        $content = $res->getContent();
+
+        $this->assertStringContainsString('init-redoc-ui.js', $content);
+        $this->assertStringContainsString('id="formats"', $content);
+        $this->assertStringContainsString('>Swagger UI</a>', $content);
+        $this->assertStringContainsString('>Scalar</a>', $content);
+        $this->assertStringNotContainsString('>ReDoc</a>', $content);
+    }
+
+    public function testHtmlDocsRendersScalarWithoutFooterWhenRequested(): void
+    {
+        $res = $this->get('/api/docs?ui=scalar', headers: ['accept' => 'text/html']);
+        $res->assertOk();
+        $content = $res->getContent();
+
+        $this->assertStringContainsString('init-scalar-ui.js', $content);
+        $this->assertStringNotContainsString('id="formats"', $content);
+    }
 }

--- a/src/Laravel/Tests/DocsTest.php
+++ b/src/Laravel/Tests/DocsTest.php
@@ -54,7 +54,7 @@ class DocsTest extends TestCase
     {
         $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
         $res->assertOk();
-        $content = $res->getContent();
+        $content = (string) $res->getContent();
 
         $this->assertStringContainsString('init-swagger-ui.js', $content);
         $this->assertStringContainsString('id="formats"', $content);
@@ -67,7 +67,7 @@ class DocsTest extends TestCase
     {
         $res = $this->get('/api/docs?ui=redoc', headers: ['accept' => 'text/html']);
         $res->assertOk();
-        $content = $res->getContent();
+        $content = (string) $res->getContent();
 
         $this->assertStringContainsString('init-redoc-ui.js', $content);
         $this->assertStringContainsString('id="formats"', $content);
@@ -80,7 +80,7 @@ class DocsTest extends TestCase
     {
         $res = $this->get('/api/docs?ui=scalar', headers: ['accept' => 'text/html']);
         $res->assertOk();
-        $content = $res->getContent();
+        $content = (string) $res->getContent();
 
         $this->assertStringContainsString('init-scalar-ui.js', $content);
         $this->assertStringNotContainsString('id="formats"', $content);

--- a/src/Laravel/resources/views/swagger-ui.blade.php
+++ b/src/Laravel/resources/views/swagger-ui.blade.php
@@ -213,6 +213,26 @@
         @endif
 
         <div id="swagger-ui" class="api-platform"></div>
+
+        @if ($ui !== 'scalar')
+        <div class="swagger-ui" id="formats">
+            <div class="information-container wrapper">
+                <div class="info">
+                    Available formats:
+                    @foreach (array_keys($formats) as $format)
+                        <a href="{{ route($originalRoute, array_merge($originalRouteParams, ['_format' => '.'.$format])) }}">{{ $format }}</a>
+                    @endforeach
+                    <br>
+                    Other API docs:
+                    @if ($swaggerUiEnabled && $ui !== 'swagger')<a href="{{ route($originalRoute, $originalRouteParams) }}">Swagger UI</a>@endif
+                    @if ($redocEnabled && $ui !== 'redoc')<a href="{{ route($originalRoute, array_merge($originalRouteParams, ['ui' => 'redoc'])) }}">ReDoc</a>@endif
+                    @if ($scalarEnabled && $ui !== 'scalar')<a href="{{ route($originalRoute, array_merge($originalRouteParams, ['ui' => 'scalar'])) }}">Scalar</a>@endif
+                    @if (!$graphQlEnabled || $graphiQlEnabled)<a @if ($graphiQlEnabled)href="{{ route('api_graphiql') }}"@endif class="graphiql-link">GraphiQL</a>@endif
+                </div>
+            </div>
+        </div>
+        @endif
+
         @if ($ui === 'scalar')
             <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
             <script src="/vendor/api-platform/init-scalar-ui.js"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7682
| License       | MIT
| Doc PR        | N/A

Mirrors the Symfony footer (`SwaggerUi/index.html.twig#L84-L98`) in the Laravel `swagger-ui.blade.php`: available formats plus an "Other API docs" switcher to ReDoc/Scalar/GraphiQL when each is enabled. Hidden under Scalar, which provides its own UI.

Also fixes `originalRoute` / `originalRouteParams` in `SwaggerUiProcessor` (the previous lookup relied on the Symfony-only `_route` attribute and was always null on Laravel) and passes the missing `formats` argument when wiring the processor.