### PR TITLE
fix(state): scope ReadLinkParameterProvider to current Link's class

### DIFF
--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -105,11 +105,13 @@ final class ReadLinkParameterProvider implements ParameterProviderInterface
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     private function getUriVariables(mixed $value, Parameter $parameter, Operation $operation): array
     {
-        $extraProperties = $parameter->getExtraProperties();
+        if (\is_array($value)) {
+            return $value;
+        }
 
         if ($operation instanceof HttpOperation) {
             $links = $operation->getUriVariables();
@@ -119,24 +121,30 @@ final class ReadLinkParameterProvider implements ParameterProviderInterface
             $links = [];
         }
 
-        if (!\is_array($value)) {
-            $uriVariables = [];
+        $extraProperties = $parameter->getExtraProperties();
+        $linkClass = $parameter instanceof Link
+            ? ($parameter->getFromClass() ?? $parameter->getToClass())
+            : null;
 
-            foreach ($links as $key => $link) {
-                if (!\is_string($key)) {
-                    $key = $link->getParameterName() ?? $extraProperties['uri_variable'] ?? $link->getFromProperty();
-                }
-
-                if (!$key || !\is_string($key)) {
-                    continue;
-                }
-
-                $uriVariables[$key] = $value;
+        $fallbackKey = null;
+        foreach ($links as $key => $link) {
+            if (!\is_string($key)) {
+                $key = $link->getParameterName() ?? $extraProperties['uri_variable'] ?? $link->getFromProperty();
             }
 
-            return $uriVariables;
+            if (!$key || !\is_string($key)) {
+                continue;
+            }
+
+            $linkFromClass = $link instanceof Link ? ($link->getFromClass() ?? $link->getToClass()) : null;
+
+            if (null !== $linkClass && $linkFromClass === $linkClass) {
+                return [$key => $value];
+            }
+
+            $fallbackKey ??= $key;
         }
 
-        return $value;
+        return null === $fallbackKey ? [] : [$fallbackKey => $value];
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7939BarResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7939BarResource.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/issue7939_foos/{fooId}/bars/{id}',
+            uriVariables: [
+                'fooId' => new Link(fromClass: Issue7939FooResource::class, toProperty: 'foo'),
+                'id' => new Link(fromClass: self::class),
+            ],
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+final class Issue7939BarResource
+{
+    private const PARENTS = ['B' => 'F2'];
+
+    public string $id = '';
+    public ?Issue7939FooResource $foo = null;
+
+    public static function parentOf(string $barId): ?string
+    {
+        return self::PARENTS[$barId] ?? null;
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [])
+    {
+        $id = (string) ($uriVariables['id'] ?? '');
+        $parent = self::parentOf($id);
+
+        if (null === $parent) {
+            return null;
+        }
+
+        $bar = new self();
+        $bar->id = $id;
+        $foo = new Issue7939FooResource();
+        $foo->id = $parent;
+        $bar->foo = $foo;
+
+        return $bar;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7939BazResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7939BazResource.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Parameter;
+use ApiPlatform\State\ParameterProvider\ReadLinkParameterProvider;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/issue7939_foos/{fooId}/bars/{barId}/baz',
+            uriVariables: [
+                'fooId' => new Link(fromClass: Issue7939FooResource::class),
+                'barId' => new Link(
+                    fromClass: Issue7939BarResource::class,
+                    identifiers: ['id'],
+                    provider: ReadLinkParameterProvider::class,
+                ),
+            ],
+            provider: [self::class, 'provide'],
+        ),
+        new Get(
+            uriTemplate: '/issue7939_foos/{fooId}/bars/{barId}/baz_strict',
+            uriVariables: [
+                'fooId' => new Link(
+                    fromClass: Issue7939FooResource::class,
+                    provider: [self::class, 'validateParent'],
+                ),
+                'barId' => new Link(
+                    fromClass: Issue7939BarResource::class,
+                    identifiers: ['id'],
+                    provider: ReadLinkParameterProvider::class,
+                ),
+            ],
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+final class Issue7939BazResource
+{
+    public string $id = '1';
+    public string $barId = '';
+    public string $fooId = '';
+
+    public static function provide(Operation $operation, array $uriVariables = [])
+    {
+        $r = new self();
+        $r->fooId = (string) ($uriVariables['fooId'] ?? '');
+        $r->barId = (string) ($uriVariables['barId'] ?? '');
+
+        return $r;
+    }
+
+    public static function validateParent(Parameter $parameter, array $values = [], array $context = []): ?Operation
+    {
+        $barId = (string) ($values['barId'] ?? '');
+        $fooId = (string) ($values['fooId'] ?? '');
+
+        if (Issue7939BarResource::parentOf($barId) !== $fooId) {
+            throw new NotFoundHttpException('Bar does not belong to the requested Foo.');
+        }
+
+        return $context['operation'] ?? null;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7939FooResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7939FooResource.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(
+    operations: [
+        new Get(
+            uriTemplate: '/issue7939_foos/{id}',
+            provider: [self::class, 'provide'],
+        ),
+    ],
+)]
+final class Issue7939FooResource
+{
+    public string $id = '';
+
+    public static function provide(Operation $operation, array $uriVariables = [])
+    {
+        $r = new self();
+        $r->id = (string) ($uriVariables['id'] ?? '');
+
+        return $r;
+    }
+}

--- a/tests/Functional/Parameters/LinkProviderParameterTest.php
+++ b/tests/Functional/Parameters/LinkProviderParameterTest.php
@@ -15,6 +15,9 @@ namespace ApiPlatform\Tests\Functional\Parameters;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7469TestResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7939BarResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7939BazResource;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7939FooResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\LinkParameterProviderResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WithParameter;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Company;
@@ -40,7 +43,7 @@ final class LinkProviderParameterTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [WithParameter::class, Dummy::class, Employee::class, Company::class, LinkParameterProviderResource::class, Issue7469TestResource::class, Issue7469Dummy::class, Pairing::class, Plan::class];
+        return [WithParameter::class, Dummy::class, Employee::class, Company::class, LinkParameterProviderResource::class, Issue7469TestResource::class, Issue7469Dummy::class, Pairing::class, Plan::class, Issue7939FooResource::class, Issue7939BarResource::class, Issue7939BazResource::class];
     }
 
     /**
@@ -234,6 +237,47 @@ final class LinkProviderParameterTest extends ApiTestCase
                 ['name' => 'Test Pairing'],
             ],
         ]);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/7939
+     */
+    public function testReadLinkParameterProviderResolvesNestedUriVariables(): void
+    {
+        $container = static::getContainer();
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $response = self::createClient()->request('GET', '/issue7939_foos/F/bars/B/baz');
+        self::assertResponseStatusCodeSame(200);
+        self::assertJsonContains([
+            'fooId' => 'F',
+            'barId' => 'B',
+        ]);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/7939
+     */
+    public function testParentLinkProviderEnforcesParentScope(): void
+    {
+        $container = static::getContainer();
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $client = self::createClient();
+
+        $client->request('GET', '/issue7939_foos/F2/bars/B/baz_strict');
+        self::assertResponseStatusCodeSame(200);
+        self::assertJsonContains([
+            'fooId' => 'F2',
+            'barId' => 'B',
+        ]);
+
+        $client->request('GET', '/issue7939_foos/F1/bars/B/baz_strict');
+        self::assertResponseStatusCodeSame(404);
     }
 
     public function testIssue7469IriGenerationFailsForLinkedResource(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7939
| License       | MIT
| Doc PR        | ∅

getUriVariables() previously assigned the same scalar to every URI variable of the linked operation, breaking nested resources whose primary Get has multiple URI variables. Resolution now sets only the URI variable matching the current Link's fromClass.