### PR TITLE
feat(hydra): use hydra:memberAssertion instead of owl:equivalentClass

### DIFF
--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -108,14 +108,10 @@ final class DocumentationNormalizer implements NormalizerInterface
                 '@type' => $hydraPrefix.'Link',
                 'domain' => '#Entrypoint',
                 'owl:maxCardinality' => 1,
-                'range' => [
-                    ['@id' => 'hydra:Collection'],
-                    [
-                        'owl:equivalentClass' => [
-                            'owl:onProperty' => ['@id' => 'hydra:member'],
-                            'owl:allValuesFrom' => ['@id' => $prefixedShortName],
-                        ],
-                    ],
+                'range' => 'hydra:Collection',
+                $hydraPrefix.'memberAssertion' => [
+                    $hydraPrefix.'property' => ['@id' => 'rdf:type'],
+                    $hydraPrefix.'object' => ['@id' => $prefixedShortName],
                 ],
                 $hydraPrefix.'supportedOperation' => $hydraCollectionOperations,
             ],

--- a/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
+++ b/src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php
@@ -333,16 +333,12 @@ class DocumentationNormalizerTest extends TestCase
                                 '@id' => '#Entrypoint/dummy',
                                 '@type' => 'hydra:Link',
                                 'domain' => '#Entrypoint',
-                                'range' => [
-                                    ['@id' => 'hydra:Collection'],
-                                    [
-                                        'owl:equivalentClass' => [
-                                            'owl:onProperty' => ['@id' => 'hydra:member'],
-                                            'owl:allValuesFrom' => ['@id' => '#dummy'],
-                                        ],
-                                    ],
-                                ],
                                 'owl:maxCardinality' => 1,
+                                'range' => 'hydra:Collection',
+                                'hydra:memberAssertion' => [
+                                    'hydra:property' => ['@id' => 'rdf:type'],
+                                    'hydra:object' => ['@id' => '#dummy'],
+                                ],
                                 'hydra:supportedOperation' => [
                                     [
                                         '@type' => ['hydra:Operation', 'schema:FindAction'],
@@ -898,16 +894,12 @@ class DocumentationNormalizerTest extends TestCase
                                 '@id' => '#Entrypoint/dummy',
                                 '@type' => 'Link',
                                 'domain' => '#Entrypoint',
-                                'range' => [
-                                    ['@id' => 'hydra:Collection'],
-                                    [
-                                        'owl:equivalentClass' => [
-                                            'owl:onProperty' => ['@id' => 'hydra:member'],
-                                            'owl:allValuesFrom' => ['@id' => '#dummy'],
-                                        ],
-                                    ],
-                                ],
                                 'owl:maxCardinality' => 1,
+                                'range' => 'hydra:Collection',
+                                'memberAssertion' => [
+                                    'property' => ['@id' => 'rdf:type'],
+                                    'object' => ['@id' => '#dummy'],
+                                ],
                                 'supportedOperation' => [
                                     [
                                         '@type' => ['Operation', 'schema:FindAction'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fixes #2827
| License       | MIT

## Summary

Per the [Hydra Core spec](https://www.hydra-cg.com/spec/latest/core/) (introduced in [HydraCG/Specifications#195](https://github.com/HydraCG/Specifications/pull/195) and later renamed `manages` → `memberAssertion`), entrypoint collection properties now declare what kind of resources they manage via a `hydra:memberAssertion` block rather than the legacy `owl:equivalentClass`/`owl:allValuesFrom` restriction.

The Hydra JSON-LD vocabulary already exposes `memberAssertion`, `subject`, `property`, and `object` (see `src/JsonLd/HydraContext.php`); `hydra:manages` is now flagged as `archaic` with a comment pointing to `hydra:memberAssertion`. This PR aligns the documentation output with the modern term and removes the awkward OWL block dunglas pointed to in the issue.

### Before

```json
"range": [
  {"@id": "hydra:Collection"},
  {
    "owl:equivalentClass": {
      "owl:onProperty": {"@id": "hydra:member"},
      "owl:allValuesFrom": {"@id": "#Book"}
    }
  }
]
```

### After

```json
"range": "hydra:Collection",
"hydra:memberAssertion": {
  "hydra:property": {"@id": "rdf:type"},
  "hydra:object": {"@id": "#Book"}
}
```

## Changes

- `src/Hydra/Serializer/DocumentationNormalizer.php` — replace the `owl:equivalentClass` block with `hydra:memberAssertion` in `populateEntrypointProperties()`.
- `src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php` — update both prefixed and prefix-less fixtures (`testNormalize`, `testNormalizeWithoutPrefix`).

## Follow-up

[`api-platform/api-doc-parser`](https://github.com/api-platform/api-doc-parser) currently parses the `owl:equivalentClass` block to discover member types — it will need a follow-up patch to read `hydra:memberAssertion` instead. Filing this as draft pending that patch.

## Test plan

- [x] `vendor/bin/phpunit src/Hydra/Tests/Serializer/DocumentationNormalizerTest.php` — 7/7 pass
- [x] `vendor/bin/phpunit src/Hydra/Tests` — 50/50 pass
- [x] `vendor/bin/phpunit tests/JsonLd` — 21/21 pass