### PR TITLE
chore: allow doctrine/collections ^v3

### DIFF
--- a/src/Doctrine/Common/composer.json
+++ b/src/Doctrine/Common/composer.json
@@ -26,7 +26,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^4.2.6",
         "api-platform/state": "^4.2.4",
-        "doctrine/collections": "^2.1",
+        "doctrine/collections": "^2.1 || ^3.0",
         "doctrine/common": "^3.2.2",
         "doctrine/persistence": "^3.2 || ^4.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7941
| License       | MIT
| Doc PR        | N/A

Allow `doctrine/collections` v3 in `api-platform/doctrine-common` by widening the Composer constraint from `^2.1` to `^2.1 || ^3.0`.

This change is backward compatible and unblocks projects upgrading to newer Doctrine components, including Doctrine ORM versions that support `doctrine/collections` v3.

---

Re-opened against `api-platform/core` (the monorepo) on behalf of @vch-a5sys — original PR was opened against the read-only sub-tree split `api-platform/doctrine-common#1`. Authorship preserved via cherry-pick.