### PR TITLE
fix(laravel): fall back to resource class when object is null in ResourceAccessChecker

### DIFF
--- a/src/Laravel/Security/ResourceAccessChecker.php
+++ b/src/Laravel/Security/ResourceAccessChecker.php
@@ -21,11 +21,11 @@ class ResourceAccessChecker implements ResourceAccessCheckerInterface
 {
     public function isGranted(string $resourceClass, string $expression, array $extraVariables = []): bool
     {
+        $object = $extraVariables['object'] ?? null;
+
         return Gate::allows(
             $expression,
-            $extraVariables['object'] instanceof Paginator ?
-                $resourceClass :
-                $extraVariables['object']
+            ($object instanceof Paginator || null === $object) ? $resourceClass : $object
         );
     }
 }

--- a/src/Laravel/Tests/Policy/Issue7945Test.php
+++ b/src/Laravel/Tests/Policy/Issue7945Test.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Policy;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Gate;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\ApiResource\Issue7945;
+use Workbench\App\Policies\Issue7945Policy;
+
+class Issue7945Test extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        Gate::guessPolicyNamesUsing(static fn (string $modelClass) => Issue7945::class === $modelClass ? Issue7945Policy::class : null);
+    }
+
+    public function testPolicyGrantsAccessWhenBodyIsNull(): void
+    {
+        $response = $this->postJson('/api/issue7945/import', [], ['accept' => 'application/ld+json']);
+        $response->assertStatus(202);
+    }
+}

--- a/src/Laravel/Tests/Unit/Security/ResourceAccessCheckerTest.php
+++ b/src/Laravel/Tests/Unit/Security/ResourceAccessCheckerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Unit\Security;
+
+use ApiPlatform\Laravel\Eloquent\Paginator;
+use ApiPlatform\Laravel\Security\ResourceAccessChecker;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Gate;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\Book;
+
+class ResourceAccessCheckerTest extends TestCase
+{
+    use WithWorkbench;
+
+    public function testNullObjectFallsBackToResourceClass(): void
+    {
+        Gate::shouldReceive('allows')
+            ->once()
+            ->with('import', Book::class)
+            ->andReturn(true);
+
+        $checker = new ResourceAccessChecker();
+        $this->assertTrue($checker->isGranted(Book::class, 'import', ['object' => null]));
+    }
+
+    public function testPaginatorObjectFallsBackToResourceClass(): void
+    {
+        Gate::shouldReceive('allows')
+            ->once()
+            ->with('viewAny', Book::class)
+            ->andReturn(true);
+
+        $paginator = new Paginator(new LengthAwarePaginator([], 0, 1));
+        $checker = new ResourceAccessChecker();
+        $this->assertTrue($checker->isGranted(Book::class, 'viewAny', ['object' => $paginator]));
+    }
+
+    public function testActualObjectIsForwarded(): void
+    {
+        $book = new Book();
+
+        Gate::shouldReceive('allows')
+            ->once()
+            ->with('view', $book)
+            ->andReturn(true);
+
+        $checker = new ResourceAccessChecker();
+        $this->assertTrue($checker->isGranted(Book::class, 'view', ['object' => $book]));
+    }
+}

--- a/src/Laravel/workbench/app/ApiResource/Issue7945.php
+++ b/src/Laravel/workbench/app/ApiResource/Issue7945.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/issue7945/import',
+            policy: 'import',
+            output: false,
+            deserialize: false,
+            status: 202,
+            processor: [self::class, 'process'],
+        ),
+    ]
+)]
+class Issue7945
+{
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): mixed
+    {
+        return null;
+    }
+}

--- a/src/Laravel/workbench/app/Policies/Issue7945Policy.php
+++ b/src/Laravel/workbench/app/Policies/Issue7945Policy.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Policies;
+
+use Illuminate\Foundation\Auth\User;
+
+class Issue7945Policy
+{
+    public function import(?User $user): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7945
| License       | MIT
| Doc PR        | ∅

## Summary

`ResourceAccessChecker::isGranted()` passes the body returned by the decorated provider to `Gate::allows()` as the second argument. When the operation has `deserialize: false` (or `output: false`) and no provider returning an instance, that body is `null` — and Laravel's Gate cannot resolve a policy class from `null`, so it silently returns `false`. The request fails with 403 even when the policy method explicitly returns `true`.

The existing code already handles the symmetric case for `Paginator` (collection endpoints, no instance available) by falling back to `$resourceClass`. This PR applies the same fallback to `null`.

## Behavior

- Before: `Gate::allows('import', null)` → silent deny (false negative).
- After: `Gate::allows('import', Item::class)` → routes through normal policy resolution; the configured policy method is invoked as the developer intended.

## Test plan

- [x] New unit test `Tests/Unit/Security/ResourceAccessCheckerTest.php` covers null, Paginator, and concrete-object paths. Verified the null case fails without the fix (Gate is called with `NULL`) and passes with it.
- [x] Existing `Tests/Policy/*` and `Tests/AuthTest.php` still pass (17 tests, 22 assertions).