### PR TITLE
refactor(jsonld): simplify @context building

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -59,6 +59,7 @@ parameters:
 				- tests/Fixtures/TestBundle/Document/
 				- tests/Fixtures/TestBundle/Entity/
 				- src/OpenApi/Factory/OpenApiFactory.php
+				- src/JsonLd/Serializer/ObjectNormalizer.php
 		-
 			message: '#is never assigned .* so it can be removed from the property type.#'
 			paths:

--- a/src/JsonLd/ContextBuilder.php
+++ b/src/JsonLd/ContextBuilder.php
@@ -82,19 +82,8 @@ final class ContextBuilder implements AnonymousContextBuilderInterface, Operatio
     {
         /** @var HttpOperation $operation */
         $operation = $this->resourceMetadataFactory->create($resourceClass)->getOperation(null, false, true);
-        if (null === $shortName = $operation->getShortName()) {
-            return [];
-        }
 
-        $context = $operation->getNormalizationContext();
-        if ($context['iri_only'] ?? false) {
-            $context = $this->getBaseContext($referenceType);
-            $context[$this->getHydraPrefix($context).'member']['@type'] = '@id';
-
-            return $context;
-        }
-
-        return $this->getResourceContextWithShortname($resourceClass, $referenceType, $shortName, $operation);
+        return $this->getResourceContextFromOperation($operation, $resourceClass, $referenceType);
     }
 
     /**
@@ -103,11 +92,8 @@ final class ContextBuilder implements AnonymousContextBuilderInterface, Operatio
     public function getResourceContextUri(string $resourceClass, ?int $referenceType = null): string
     {
         $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass)[0];
-        if (null === $referenceType) {
-            $referenceType = $resourceMetadata->getUrlGenerationStrategy();
-        }
 
-        return $this->urlGenerator->generate('api_jsonld_context', ['shortName' => $resourceMetadata->getShortName()], $referenceType ?? UrlGeneratorInterface::ABS_PATH);
+        return $this->generateContextUri($resourceMetadata->getShortName(), $referenceType ?? $resourceMetadata->getUrlGenerationStrategy());
     }
 
     /**
@@ -155,12 +141,6 @@ final class ContextBuilder implements AnonymousContextBuilderInterface, Operatio
             unset($jsonLdContext['@context']);
         }
 
-        // here the object can be different from the resource given by the $context['api_resource'] value
-        // TODO: this is probably not used anymore and is slow we get that @type way earlier, remove this
-        if (isset($context['api_resource'])) {
-            $jsonLdContext['@type'] = $this->resourceMetadataFactory->create($this->getObjectClass($context['api_resource']))[0]->getShortName();
-        }
-
         return $jsonLdContext;
     }
 
@@ -169,11 +149,7 @@ final class ContextBuilder implements AnonymousContextBuilderInterface, Operatio
      */
     public function getResourceContextUriFromOperation(HttpOperation $operation, ?int $referenceType = null): string
     {
-        if (null === $referenceType) {
-            $referenceType = $operation->getUrlGenerationStrategy();
-        }
-
-        return $this->urlGenerator->generate('api_jsonld_context', ['shortName' => $operation->getShortName()], $referenceType ?? UrlGeneratorInterface::ABS_PATH);
+        return $this->generateContextUri($operation->getShortName(), $referenceType ?? $operation->getUrlGenerationStrategy());
     }
 
     /**
@@ -194,6 +170,11 @@ final class ContextBuilder implements AnonymousContextBuilderInterface, Operatio
         }
 
         return $this->getResourceContextWithShortname($resourceClass, $referenceType, $shortName, $operation);
+    }
+
+    private function generateContextUri(?string $shortName, ?int $referenceType): string
+    {
+        return $this->urlGenerator->generate('api_jsonld_context', ['shortName' => $shortName], $referenceType ?? UrlGeneratorInterface::ABS_PATH);
     }
 
     private function getResourceContextWithShortname(string $resourceClass, int $referenceType, string $shortName, ?HttpOperation $operation = null): array

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -152,6 +152,18 @@ final class ItemNormalizer extends AbstractItemNormalizer
             return $normalizedData;
         }
 
+        if (!isset($metadata['@type']) && null !== ($type = $this->resolveType($resourceClass, $isResourceClass, $context))) {
+            $metadata['@type'] = $type;
+        }
+
+        return $metadata + $normalizedData;
+    }
+
+    /**
+     * @return string|array<int, string>|null
+     */
+    private function resolveType(string $resourceClass, bool $isResourceClass, array $context): string|array|null
+    {
         $operation = $context['operation'] ?? null;
 
         if ($this->operationMetadataFactory && isset($context['item_uri_template']) && !$operation) {
@@ -162,30 +174,31 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $operation = $this->resourceMetadataCollectionFactory->create($resourceClass)->getOperation();
         }
 
-        if (!isset($metadata['@type']) && $operation) {
-            $types = $operation instanceof HttpOperation ? $operation->getTypes() : null;
-            if (null === $types) {
-                // TODO: 5.x break on this as this looks wrong, CollectionReferencingItem returns an IRI that point through
-                // ItemReferencedInCollection but it returns a CollectionReferencingItem therefore we should use the current
-                // object's class Type and not rely on operation ?
-                if (isset($context['item_uri_template'])) {
-                    // When the operation comes from item_uri_template, use its shortName directly
-                    // as $resourceClass refers to the collection resource, not the item resource
-                    $types = [$operation->getShortName()];
-                } else {
-                    // Use resource-level shortName to avoid operation-specific overrides
-                    $typeClass = $isResourceClass ? $resourceClass : ($operation->getClass() ?? $resourceClass);
-                    try {
-                        $types = [$this->resourceMetadataCollectionFactory->create($typeClass)[0]->getShortName()];
-                    } catch (\Exception) {
-                        $types = [$operation->getShortName()];
-                    }
-                }
-            }
-            $metadata['@type'] = 1 === \count($types) ? $types[0] : $types;
+        if (!$operation) {
+            return null;
         }
 
-        return $metadata + $normalizedData;
+        $types = $operation instanceof HttpOperation ? $operation->getTypes() : null;
+        if (null === $types) {
+            // TODO: 5.x break on this as this looks wrong, CollectionReferencingItem returns an IRI that point through
+            // ItemReferencedInCollection but it returns a CollectionReferencingItem therefore we should use the current
+            // object's class Type and not rely on operation ?
+            if (isset($context['item_uri_template'])) {
+                // When the operation comes from item_uri_template, use its shortName directly
+                // as $resourceClass refers to the collection resource, not the item resource
+                $types = [$operation->getShortName()];
+            } else {
+                // Use resource-level shortName to avoid operation-specific overrides
+                $typeClass = $isResourceClass ? $resourceClass : ($operation->getClass() ?? $resourceClass);
+                try {
+                    $types = [$this->resourceMetadataCollectionFactory->create($typeClass)[0]->getShortName()];
+                } catch (\Exception) {
+                    $types = [$operation->getShortName()];
+                }
+            }
+        }
+
+        return 1 === \count($types) ? $types[0] : $types;
     }
 
     /**

--- a/src/JsonLd/Serializer/JsonLdContextTrait.php
+++ b/src/JsonLd/Serializer/JsonLdContextTrait.php
@@ -59,9 +59,7 @@ trait JsonLdContextTrait
 
     private function createJsonLdContext(AnonymousContextBuilderInterface $contextBuilder, object $object, array &$context): array
     {
-        $anonymousContext = ($context['output'] ?? []) + [
-            'api_resource' => $context['api_resource'] ?? null,
-        ];
+        $anonymousContext = $context['output'] ?? [];
 
         if (isset($context['item_uri_template'])) {
             $anonymousContext['item_uri_template'] = $context['item_uri_template'];

--- a/src/JsonLd/Serializer/ObjectNormalizer.php
+++ b/src/JsonLd/Serializer/ObjectNormalizer.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\JsonLd\Serializer;
 
 use ApiPlatform\JsonLd\AnonymousContextBuilderInterface;
-use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\IriConverterInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -53,11 +52,6 @@ final class ObjectNormalizer implements NormalizerInterface
      */
     public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
     {
-        if (isset($context['api_resource'])) {
-            $originalResource = $context['api_resource'];
-            unset($context['api_resource']);
-        }
-
         /*
          * Converts the normalized data array of a resource into an IRI, if the
          * normalized data array is empty.
@@ -73,15 +67,6 @@ final class ObjectNormalizer implements NormalizerInterface
         $normalizedData = $this->decorated->normalize($data, $format, $context);
         if (!\is_array($normalizedData) || !$normalizedData) {
             return $normalizedData;
-        }
-
-        if (isset($originalResource)) {
-            try {
-                $context['output']['iri'] = $this->iriConverter->getIriFromResource($originalResource);
-            } catch (InvalidArgumentException) {
-                // The original resource has no identifiers
-            }
-            $context['api_resource'] = $originalResource;
         }
 
         $metadata = $this->createJsonLdContext($this->anonymousContextBuilder, $data, $context);

--- a/tests/JsonLd/ContextBuilderTest.php
+++ b/tests/JsonLd/ContextBuilderTest.php
@@ -226,57 +226,6 @@ class ContextBuilderTest extends TestCase
         $this->assertEquals($expected, $contextBuilder->getAnonymousResourceContext($output, ['iri' => '/dummies', 'name' => 'Dummy']));
     }
 
-    public function testAnonymousResourceContextWithApiResource(): void
-    {
-        $output = new OutputDto();
-        $this->propertyNameCollectionFactoryProphecy->create(OutputDto::class)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
-        $this->propertyMetadataFactoryProphecy->create(OutputDto::class, 'dummyPropertyA', Argument::type('array'))->willReturn((new ApiProperty())->withNativeType(Type::string())->withDescription('Dummy property A')->withReadable(true)->withWritable(true)->withReadableLink(true)->withWritableLink(true));
-        $this->urlGeneratorProphecy->generate('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_URL)->willReturn('');
-
-        $this->resourceMetadataCollectionFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadataCollection('Dummy', [
-            (new ApiResource())
-                ->withShortName('Dummy')
-                ->withOperations(new Operations(['get' => (new Get())->withShortName('Dummy')])),
-        ]));
-
-        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
-
-        $expected = [
-            '@context' => [
-                '@vocab' => '#',
-                'hydra' => 'http://www.w3.org/ns/hydra/core#',
-                'dummyPropertyA' => 'OutputDto/dummyPropertyA',
-            ],
-            '@id' => '/dummies',
-            '@type' => 'Dummy',
-        ];
-
-        $this->assertEquals($expected, $contextBuilder->getAnonymousResourceContext($output, ['iri' => '/dummies', 'name' => 'Dummy', 'api_resource' => new Dummy()]));
-    }
-
-    public function testAnonymousResourceContextWithApiResourceHavingContext(): void
-    {
-        $output = new OutputDto();
-        $this->propertyNameCollectionFactoryProphecy->create(OutputDto::class)->willReturn(new PropertyNameCollection(['dummyPropertyA']));
-        $this->propertyMetadataFactoryProphecy->create(OutputDto::class, 'dummyPropertyA', Argument::type('array'))->willReturn((new ApiProperty())->withNativeType(Type::string())->withDescription('Dummy property A')->withReadable(true)->withWritable(true)->withReadableLink(true)->withWritableLink(true));
-        $this->urlGeneratorProphecy->generate('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_URL)->willReturn('');
-
-        $this->resourceMetadataCollectionFactoryProphecy->create(Dummy::class)->willReturn(new ResourceMetadataCollection('Dummy', [
-            (new ApiResource())
-                ->withShortName('Dummy')
-                ->withOperations(new Operations(['get' => (new Get())->withShortName('Dummy')])),
-        ]));
-
-        $contextBuilder = new ContextBuilder($this->resourceNameCollectionFactoryProphecy->reveal(), $this->resourceMetadataCollectionFactoryProphecy->reveal(), $this->propertyNameCollectionFactoryProphecy->reveal(), $this->propertyMetadataFactoryProphecy->reveal(), $this->urlGeneratorProphecy->reveal());
-
-        $expected = [
-            '@id' => '/dummies',
-            '@type' => 'Dummy',
-        ];
-
-        $this->assertEquals($expected, $contextBuilder->getAnonymousResourceContext($output, ['iri' => '/dummies', 'name' => 'Dummy', 'api_resource' => new Dummy(), 'has_context' => true]));
-    }
-
     public function testResourceContextWithoutHydraPrefix(): void
     {
         $this->resourceMetadataCollectionFactoryProphecy->create($this->entityClass)->willReturn(new ResourceMetadataCollection('DummyEntity', [

--- a/tests/JsonLd/Serializer/ObjectNormalizerTest.php
+++ b/tests/JsonLd/Serializer/ObjectNormalizerTest.php
@@ -86,50 +86,19 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals([], $normalizer->normalize($dummy));
     }
 
-    public function testNormalizeWithOutput(): void
+    public function testNormalizeWithJsonLdContextSet(): void
     {
         $dummy = new Dummy();
         $dummy->setName('hello');
 
         $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummy/1234');
 
         $serializerProphecy = $this->prophesize(SerializerInterface::class);
         $serializerProphecy->willImplement(NormalizerInterface::class);
         $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn(['name' => 'hello']);
 
         $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
-        $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['api_resource' => $dummy, 'iri' => '/dummy/1234'])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy', '@context' => []]);
-
-        $normalizer = new ObjectNormalizer(
-            $serializerProphecy->reveal(),
-            $iriConverterProphecy->reveal(),
-            $contextBuilderProphecy->reveal()
-        );
-
-        $expected = [
-            '@context' => [],
-            '@id' => '/dummy/1234',
-            '@type' => 'Dummy',
-            'name' => 'hello',
-        ];
-        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['api_resource' => $dummy]));
-    }
-
-    public function testNormalizeWithContext(): void
-    {
-        $dummy = new Dummy();
-        $dummy->setName('hello');
-
-        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
-        $iriConverterProphecy->getIriFromResource($dummy)->willReturn('/dummy/1234');
-
-        $serializerProphecy = $this->prophesize(SerializerInterface::class);
-        $serializerProphecy->willImplement(NormalizerInterface::class);
-        $serializerProphecy->normalize($dummy, null, Argument::type('array'))->willReturn(['name' => 'hello']);
-
-        $contextBuilderProphecy = $this->prophesize(AnonymousContextBuilderInterface::class);
-        $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['api_resource' => $dummy, 'has_context' => true, 'iri' => '/dummy/1234'])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy']);
+        $contextBuilderProphecy->getAnonymousResourceContext($dummy, ['has_context' => true])->shouldBeCalled()->willReturn(['@id' => '/dummy/1234', '@type' => 'Dummy']);
 
         $normalizer = new ObjectNormalizer(
             $serializerProphecy->reveal(),
@@ -142,6 +111,6 @@ class ObjectNormalizerTest extends TestCase
             '@type' => 'Dummy',
             'name' => 'hello',
         ];
-        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['api_resource' => $dummy, 'jsonld_has_context' => true]));
+        $this->assertEquals($expected, $normalizer->normalize($dummy, null, ['jsonld_has_context' => true]));
     }
 }


### PR DESCRIPTION
* remove dead api_resource @type override and its save/restore plumbing
* dedupe getResourceContext / *FromOperation pairs via a shared private helper, no public surface change
* extract @type resolution from ItemNormalizer::normalize into a private method