### PR TITLE
fix(symfony): Symfony 8.1 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1078,6 +1078,7 @@ jobs:
       - name: Run Behat tests
         run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction
 
+  # remove once behat can be installed with symfony 8.1
   phpunit-symfony-edge:
     name: PHPUnit (PHP ${{ matrix.php }}) (Symfony 8.1)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1078,6 +1078,54 @@ jobs:
       - name: Run Behat tests
         run: vendor/bin/behat --out=std --format=progress --profile=default --no-interaction
 
+  phpunit-symfony-edge:
+    name: PHPUnit (PHP ${{ matrix.php }}) (Symfony 8.1)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    strategy:
+      matrix:
+        php:
+          - '8.5'
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl, composer
+          extensions: intl, bcmath, curl, openssl, mbstring
+          coverage: none
+          ini-values: memory_limit=-1
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Allow unstable project dependencies
+        run: composer config minimum-stability dev
+      - name: Drop Behat dev dependencies (incompatible with Symfony 8.1)
+        run: composer remove --no-update --no-interaction --dev behat/behat behat/mink soyuka/contexts friends-of-behat/symfony-extension friends-of-behat/mink-browserkit-driver friends-of-behat/mink-extension
+      - name: Force Symfony 8.1 dev for framework-bundle and json-streamer
+        run: composer require --dev --no-update --no-interaction "symfony/framework-bundle:8.1.x-dev" "symfony/json-streamer:8.1.x-dev"
+      - name: Cache dependencies
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-symfony-edge-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-symfony-edge-
+      - name: Remove cache
+        run: rm -Rf tests/Fixtures/app/var/cache/*
+      - name: Update project dependencies
+        run: |
+          composer global require soyuka/pmu
+          composer global config allow-plugins.soyuka/pmu true --no-interaction
+          composer global link .
+      - name: Clear test app cache
+        run: tests/Fixtures/app/console cache:clear --ansi
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit
+
   windows-behat:
     name: Windows Behat (PHP ${{ matrix.php }}) (SQLite)
     runs-on: windows-latest

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -84,6 +84,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
 use Symfony\Component\ObjectMapper\ObjectMapper;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\NumberNormalizer;
 use Symfony\Component\Uid\AbstractUid;
@@ -201,15 +202,18 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerLinkSecurityConfiguration($loader, $config);
         $this->registerJsonStreamerConfiguration($container, $loader, $formats, $config);
 
-        // TranslationExtractCommand was introduced in framework-bundle/7.3 with the object mapper service
-        if (class_exists(ObjectMapper::class) && class_exists(TranslationExtractCommand::class)) {
+        // TranslationExtractCommand was introduced in framework-bundle/7.3 with the object mapper service.
+        // willBeAvailable mirrors FrameworkBundle's own gate: when symfony/object-mapper is in dev-only,
+        // FrameworkBundle skips object_mapper.php and the "object_mapper" service we alias to does not exist.
+        if (class_exists(ObjectMapper::class) && class_exists(TranslationExtractCommand::class) && ContainerBuilder::willBeAvailable('symfony/object-mapper', ObjectMapperInterface::class, ['symfony/framework-bundle'])) {
             $loader->load('state/object_mapper.php');
             $loader->load($config['use_symfony_listeners'] ? 'symfony/object_mapper.php' : 'state/object_mapper_processor.php');
         }
 
         $container->setParameter('api_platform.mcp.format', $config['mcp']['format'] ?? null);
 
-        if (($config['mcp']['enabled'] ?? false) && class_exists(McpBundle::class)) {
+        // McpToolProvider requires Symfony's object_mapper service; mirror FrameworkBundle's gate so we don't try to wire it when object-mapper is dev-only.
+        if (($config['mcp']['enabled'] ?? false) && class_exists(McpBundle::class) && ContainerBuilder::willBeAvailable('symfony/object-mapper', ObjectMapperInterface::class, ['symfony/framework-bundle'])) {
             $loader->load('mcp/mcp.php');
             $loader->load($config['use_symfony_listeners'] ? 'mcp/events.php' : 'mcp/state.php');
         }

--- a/src/Symfony/Bundle/Resources/config/json_streamer/common.php
+++ b/src/Symfony/Bundle/Resources/config/json_streamer/common.php
@@ -17,6 +17,7 @@ use ApiPlatform\JsonLd\JsonStreamer\ValueTransformer\ContextValueTransformer;
 use ApiPlatform\JsonLd\JsonStreamer\ValueTransformer\IriValueTransformer;
 use ApiPlatform\JsonLd\JsonStreamer\ValueTransformer\TypeValueTransformer;
 use ApiPlatform\JsonLd\JsonStreamer\WritePropertyMetadataLoader;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Component\JsonStreamer\CacheWarmer\LazyGhostCacheWarmer;
 use Symfony\Component\JsonStreamer\JsonStreamReader;
 use Symfony\Component\JsonStreamer\JsonStreamWriter;
@@ -77,9 +78,9 @@ return static function (ContainerConfigurator $container) {
         ->args([service('api_platform.router')])
         ->tag('json_streamer.value_transformer');
 
-    if (class_exists(DateTimeValueObjectTransformer::class)) {
+    // FrameworkBundle 8.1+ registers DateTimeValueObjectTransformer itself; skip to avoid duplicate registration and TransformerPass validation breakage (issue #7954).
+    if (class_exists(DateTimeValueObjectTransformer::class) && !class_exists(DeprecateJsonStreamerValueTransformerTagPass::class)) {
         $services->set('api_platform.jsonld.json_streamer.value_transformer.date_time', DateTimeValueObjectTransformer::class)
-            ->tag('json_streamer.value_transformer', ['key' => \DateTimeInterface::class])
             ->tag('json_streamer.value_object_transformer');
     }
 };

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -81,7 +81,7 @@ class AppKernel extends Kernel
             new MakerBundle(),
         ];
 
-        if (null === ($_ENV['APP_PHPUNIT'] ?? null)) {
+        if (null === ($_ENV['APP_PHPUNIT'] ?? null) && class_exists(FriendsOfBehatSymfonyExtensionBundle::class)) {
             $bundles[] = new FriendsOfBehatSymfonyExtensionBundle();
         }
 

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -126,7 +126,10 @@ class AppKernel extends Kernel
 
         $loader->load(__DIR__."/config/config_{$this->getEnvironment()}.yml");
 
-        $c->getDefinition(DoctrineContext::class)->setArgument('$passwordHasher', class_exists(NativePasswordHasher::class) ? 'security.user_password_encoder' : 'security.user_password_hasher');
+        if (interface_exists(Behat\Behat\Context\Context::class) && class_exists(DoctrineContext::class)) {
+            $loader->load(__DIR__.('mongodb' === $this->getEnvironment() ? '/config/config_behat_mongodb.yml' : '/config/config_behat_orm.yml'));
+            $c->getDefinition(DoctrineContext::class)->setArgument('$passwordHasher', class_exists(NativePasswordHasher::class) ? 'security.user_password_encoder' : 'security.user_password_hasher');
+        }
 
         $messengerConfig = [
             'default_bus' => 'messenger.bus.default',

--- a/tests/Fixtures/app/config/config_elasticsearch.yml
+++ b/tests/Fixtures/app/config/config_elasticsearch.yml
@@ -1,6 +1,5 @@
 imports:
     - { resource: config_common.yml }
-    - { resource: config_behat_orm.yml }
 
 parameters:
     env(ELASTICSEARCH_URL): http://localhost:9200

--- a/tests/Fixtures/app/config/config_mongodb.yml
+++ b/tests/Fixtures/app/config/config_mongodb.yml
@@ -1,6 +1,5 @@
 imports:
     - { resource: config_common.yml }
-    - { resource: config_behat_mongodb.yml }
 
 parameters:
     env(MONGODB_DB): api_platform_test

--- a/tests/Fixtures/app/config/config_mysql.yml
+++ b/tests/Fixtures/app/config/config_mysql.yml
@@ -1,7 +1,6 @@
 imports:
     - { resource: config_common.yml }
     - { resource: config_doctrine.yml }
-    - { resource: config_behat_orm.yml }
 
 parameters:
     env(DATABASE_URL): mysql://root:@localhost/api_platform_test

--- a/tests/Fixtures/app/config/config_opensearch.yml
+++ b/tests/Fixtures/app/config/config_opensearch.yml
@@ -1,6 +1,5 @@
 imports:
     - { resource: config_common.yml }
-    - { resource: config_behat_orm.yml }
 
 parameters:
     env(ELASTICSEARCH_URL): http://localhost:9200

--- a/tests/Fixtures/app/config/config_postgres.yml
+++ b/tests/Fixtures/app/config/config_postgres.yml
@@ -1,7 +1,6 @@
 imports:
     - { resource: config_common.yml }
     - { resource: config_doctrine.yml }
-    - { resource: config_behat_orm.yml }
 
 parameters:
     env(DATABASE_URL): postgres://postgres:@localhost/api_platform_test

--- a/tests/Fixtures/app/config/config_sqlite.yml
+++ b/tests/Fixtures/app/config/config_sqlite.yml
@@ -1,7 +1,6 @@
 imports:
     - { resource: config_common.yml }
     - { resource: config_doctrine.yml }
-    - { resource: config_behat_orm.yml }
 
 parameters:
     env(DATABASE_URL): sqlite:///%kernel.project_dir%/var/data.db

--- a/tests/Fixtures/app/config/config_swagger.php
+++ b/tests/Fixtures/app/config/config_swagger.php
@@ -13,10 +13,15 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Config\ApiPlatformConfig;
-
-return static function (ApiPlatformConfig $apiPlatformConfig): void {
-    $apiPlatformConfig->swagger()->apiKeys('Some_Authorization_Name')
-        ->name('Authorization')
-        ->type('header');
+return static function (ContainerConfigurator $container): void {
+    $container->extension('api_platform', [
+        'swagger' => [
+            'api_keys' => [
+                'Some_Authorization_Name' => [
+                    'name' => 'Authorization',
+                    'type' => 'header',
+                ],
+            ],
+        ],
+    ]);
 };

--- a/tests/Symfony/Bundle/SwaggerUi/SwaggerUiProviderTest.php
+++ b/tests/Symfony/Bundle/SwaggerUi/SwaggerUiProviderTest.php
@@ -29,7 +29,6 @@ class SwaggerUiProviderTest extends TestCase
     public function testProvideWithBaseUrl(): void
     {
         $openapiFactory = $this->createMock(OpenApiFactoryInterface::class);
-        // Symfony 8.1 added a "set" property hook on Request::$query whose generated double would need to mock the (final) InputBag class — so we cannot use createStub(Request::class) here.
         $request = new class extends Request {
             public function getBaseUrl(): string
             {

--- a/tests/Symfony/Bundle/SwaggerUi/SwaggerUiProviderTest.php
+++ b/tests/Symfony/Bundle/SwaggerUi/SwaggerUiProviderTest.php
@@ -22,8 +22,6 @@ use ApiPlatform\OpenApi\OpenApi;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Symfony\Bundle\SwaggerUi\SwaggerUiProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
 class SwaggerUiProviderTest extends TestCase
@@ -31,11 +29,14 @@ class SwaggerUiProviderTest extends TestCase
     public function testProvideWithBaseUrl(): void
     {
         $openapiFactory = $this->createMock(OpenApiFactoryInterface::class);
-        $request = $this->createStub(Request::class);
-        $request->attributes = new ParameterBag();
-        $request->query = new InputBag();
-        $request->method('getRequestFormat')->willReturn('html');
-        $request->method('getBaseUrl')->willReturn('test');
+        // Symfony 8.1 added a "set" property hook on Request::$query whose generated double would need to mock the (final) InputBag class — so we cannot use createStub(Request::class) here.
+        $request = new class extends Request {
+            public function getBaseUrl(): string
+            {
+                return 'test';
+            }
+        };
+        $request->setRequestFormat('html');
         $decorated = $this->createStub(ProviderInterface::class);
         $provider = new SwaggerUiProvider($decorated, $openapiFactory);
         $openapiFactory->expects($this->once())->method('__invoke')->with(['base_url' => 'test', 'filter_tags' => []])->willReturn(new OpenApi(new Info('test', '1'), [], new Paths()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #7954
| License       | MIT
| Doc PR        | ∅

Symfony 8.1.0-BETA1 introduces a few removals and behaviour changes that
make API Platform 4.3 fail to compile its container or boot the test app.
This PR brings 4.3 up to compatibility and adds a dedicated CI lane so
the combination is exercised on every PR going forward.

## What it changes

* **JsonStreamer** — Skip API Platform's own `DateTimeValueObjectTransformer`
  registration when FrameworkBundle 8.1+ is detected. FrameworkBundle 8.1
  registers the transformer itself and ships a deprecation pass that
  upgrades the now-deprecated `json_streamer.value_transformer` tag, which
  fails `TransformerPass` validation against our service.

* **ConfigBuilder** — Fluent `Symfony\Config\*` typed-closure config files
  were deprecated in symfony/dependency-injection 7.4 and the fallback
  was removed in 8.1. Migrate `tests/Fixtures/app/config/config_swagger.php`
  to `ContainerConfigurator::extension()` (BC across all supported
  FrameworkBundle versions).

* **ObjectMapper** — Mirror FrameworkBundle's own `willBeAvailable` gate
  before loading our object-mapper wiring (`state/object_mapper.php`,
  `mcp/mcp.php`). When `symfony/object-mapper` is dev-only,
  FrameworkBundle skips its `object_mapper` service registration; without
  this gate, our alias dangles and breaks compilation.

* **Test app** — Move `config_behat_*.yml` imports out of the
  database-specific configs and load them conditionally from `AppKernel`
  only when `behat/behat` and the local Behat context classes are
  available. Without this, the kernel cannot boot in any environment that
  does not have behat installed — including a Symfony 8.1 install,
  because `friends-of-behat/*` and `soyuka/contexts` cap behat at 3.x and
  behat 3.x caps `symfony/console` at <8.

* **CI** — Add a `phpunit-symfony-edge` lane that drops behat dev deps,
  pins `symfony/framework-bundle` and `symfony/json-streamer` to
  `8.1.x-dev`, and runs PHPUnit. `continue-on-error: true` since 8.1 is
  pre-stable; the lane is informational until Symfony 8.1 ships stable.