### PR TITLE
test: phpunit exception not restored

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
         "psr/container": "^1.0 || ^2.0",
         "symfony/deprecation-contracts": "^3.1",
         "symfony/http-foundation": "^6.4.14 || ^7.0 || ^8.0",
-        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4.13 || ^7.0 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
         "symfony/property-info": "^6.4 || ^7.1 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.0 || ^8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,8 @@
     backupGlobals="false"
     bootstrap="tests/Fixtures/app/bootstrap.php"
     colors="true"
-    cacheDirectory=".phpunit.cache">
+    cacheDirectory=".phpunit.cache"
+    failOnRisky="true">
   <php>
     <ini name="error_reporting" value="-1"/>
     <ini name="memory_limit" value="-1"/>

--- a/src/Doctrine/Odm/Tests/AppKernel.php
+++ b/src/Doctrine/Odm/Tests/AppKernel.php
@@ -18,7 +18,6 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -43,12 +42,6 @@ class AppKernel extends Kernel
         return [
             new FrameworkBundle(),
             new DoctrineMongoDBBundle(),
-            new class extends Bundle {
-                public function shutdown(): void
-                {
-                    restore_exception_handler();
-                }
-            },
         ];
     }
 

--- a/src/Doctrine/Odm/Tests/DoctrineMongoDbOdmFilterTestCase.php
+++ b/src/Doctrine/Odm/Tests/DoctrineMongoDbOdmFilterTestCase.php
@@ -17,8 +17,11 @@ use ApiPlatform\Doctrine\Odm\Filter\FilterInterface;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 
 /**
  * @internal
@@ -37,6 +40,8 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
 
     protected string $filterClass;
 
+    private bool $symfonyErrorHandlerWasRegistered = false;
+
     protected function setUp(): void
     {
         self::bootKernel();
@@ -44,6 +49,34 @@ abstract class DoctrineMongoDbOdmFilterTestCase extends KernelTestCase
         $this->manager = DoctrineMongoDbOdmTestCase::createTestDocumentManager();
         $this->managerRegistry = self::$kernel->getContainer()->get('doctrine_mongodb');
         $this->repository = $this->manager->getRepository($this->resourceClass);
+    }
+
+    /**
+     * Symfony\Bundle\FrameworkBundle\FrameworkBundle::boot() registers Symfony's ErrorHandler via
+     * set_exception_handler() but never unregisters it: each kernel boot leaks one entry on the
+     * exception handler stack, which PHPUnit flags as Risky. Track whether the handler was already
+     * present before the test so we only pop the entry our own test introduced.
+     */
+    #[Before]
+    protected function captureExceptionHandlerStack(): void
+    {
+        $this->symfonyErrorHandlerWasRegistered = self::isSymfonyErrorHandlerRegistered();
+    }
+
+    #[After]
+    protected function restoreExceptionHandlerStack(): void
+    {
+        if (!$this->symfonyErrorHandlerWasRegistered && self::isSymfonyErrorHandlerRegistered()) {
+            restore_exception_handler();
+        }
+    }
+
+    private static function isSymfonyErrorHandlerRegistered(): bool
+    {
+        $current = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        return \is_array($current) && $current[0] instanceof ErrorHandler;
     }
 
     #[DataProvider('provideApplyTestData')]

--- a/src/Doctrine/Orm/Tests/AppKernel.php
+++ b/src/Doctrine/Orm/Tests/AppKernel.php
@@ -18,7 +18,6 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -44,12 +43,6 @@ class AppKernel extends Kernel
             new FrameworkBundle(),
             new DoctrineBundle(),
             new TestBundle(),
-            new class extends Bundle {
-                public function shutdown(): void
-                {
-                    restore_exception_handler();
-                }
-            },
         ];
     }
 

--- a/src/Doctrine/Orm/Tests/DoctrineOrmFilterTestCase.php
+++ b/src/Doctrine/Orm/Tests/DoctrineOrmFilterTestCase.php
@@ -18,8 +18,11 @@ use ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity\Dummy;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 
 /**
  * @internal
@@ -38,12 +41,42 @@ abstract class DoctrineOrmFilterTestCase extends KernelTestCase
 
     protected string $filterClass;
 
+    private bool $symfonyErrorHandlerWasRegistered = false;
+
     protected function setUp(): void
     {
         self::bootKernel();
 
         $this->managerRegistry = self::$kernel->getContainer()->get('doctrine');
         $this->repository = $this->managerRegistry->getManagerForClass(Dummy::class)->getRepository(Dummy::class);
+    }
+
+    /**
+     * Symfony\Bundle\FrameworkBundle\FrameworkBundle::boot() registers Symfony's ErrorHandler via
+     * set_exception_handler() but never unregisters it: each kernel boot leaks one entry on the
+     * exception handler stack, which PHPUnit flags as Risky. Track whether the handler was already
+     * present before the test so we only pop the entry our own test introduced.
+     */
+    #[Before]
+    protected function captureExceptionHandlerStack(): void
+    {
+        $this->symfonyErrorHandlerWasRegistered = self::isSymfonyErrorHandlerRegistered();
+    }
+
+    #[After]
+    protected function restoreExceptionHandlerStack(): void
+    {
+        if (!$this->symfonyErrorHandlerWasRegistered && self::isSymfonyErrorHandlerRegistered()) {
+            restore_exception_handler();
+        }
+    }
+
+    private static function isSymfonyErrorHandlerRegistered(): bool
+    {
+        $current = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        return \is_array($current) && $current[0] instanceof ErrorHandler;
     }
 
     #[DataProvider('provideApplyTestData')]

--- a/src/State/composer.json
+++ b/src/State/composer.json
@@ -30,7 +30,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^4.3",
         "psr/container": "^1.0 || ^2.0",
-        "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4.13 || ^7.0 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.0 || ^8.0",
         "symfony/translation-contracts": "^3.0",
         "symfony/deprecation-contracts": "^3.1"

--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Symfony\Bundle\Test;
 
 use ApiPlatform\Metadata\IriConverterInterface;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\HttpClient\HttpClientTrait;
 
 /**
@@ -37,6 +40,37 @@ abstract class ApiTestCase extends KernelTestCase
      * - `true` always boots the kernel without any deprecation message
      */
     protected static ?bool $alwaysBootKernel = null;
+
+    private bool $symfonyErrorHandlerWasRegistered = false;
+
+    /**
+     * Symfony\Bundle\FrameworkBundle\FrameworkBundle::boot() registers Symfony's ErrorHandler via
+     * set_exception_handler() but never unregisters it: each kernel boot leaks one entry on the
+     * exception handler stack, which PHPUnit flags as Risky. Track whether the handler was already
+     * present before the test (e.g. the kernel was booted from setUpBeforeClass) so we only pop
+     * the entry our own test introduced.
+     */
+    #[Before]
+    protected function captureExceptionHandlerStack(): void
+    {
+        $this->symfonyErrorHandlerWasRegistered = self::isSymfonyErrorHandlerRegistered();
+    }
+
+    #[After]
+    protected function restoreExceptionHandlerStack(): void
+    {
+        if (!$this->symfonyErrorHandlerWasRegistered && self::isSymfonyErrorHandlerRegistered()) {
+            restore_exception_handler();
+        }
+    }
+
+    private static function isSymfonyErrorHandlerRegistered(): bool
+    {
+        $current = set_exception_handler(static fn () => null);
+        restore_exception_handler();
+
+        return \is_array($current) && $current[0] instanceof ErrorHandler;
+    }
 
     /**
      * Creates a Client.

--- a/src/Symfony/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Tests/EventListener/ErrorListenerTest.php
@@ -30,11 +30,6 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 class ErrorListenerTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        restore_exception_handler();
-    }
-
     public function testDuplicateException(): void
     {
         $exception = new \Exception();

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -41,6 +41,7 @@
         "api-platform/openapi": "^4.3",
         "symfony/asset": "^6.4 || ^7.0 || ^8.0",
         "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^6.4.13 || ^7.0 || ^8.0",
         "symfony/property-info": "^6.4 || ^7.0 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.0 || ^8.0",

--- a/src/Validator/composer.json
+++ b/src/Validator/composer.json
@@ -25,7 +25,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^4.3",
         "symfony/type-info": "^7.3 || ^8.0",
-        "symfony/http-kernel": "^6.4 || ^7.1 || ^8.0",
+        "symfony/http-kernel": "^6.4.13 || ^7.1 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.1 || ^8.0",
         "symfony/validator": "^6.4.11 || ^7.1 || ^8.0",
         "symfony/web-link": "^6.4 || ^7.1 || ^8.0"

--- a/tests/Fixtures/app/AppKernel.php
+++ b/tests/Fixtures/app/AppKernel.php
@@ -98,12 +98,6 @@ class AppKernel extends Kernel
         return $bundles;
     }
 
-    public function shutdown(): void
-    {
-        parent::shutdown();
-        restore_exception_handler();
-    }
-
     public function getProjectDir(): string
     {
         return __DIR__;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | ∅
| License       | MIT
| Doc PR        | ∅

Backport of #7949 to the 4.3 branch.

`Symfony\Bundle\FrameworkBundle\FrameworkBundle::boot()` registers Symfony's `ErrorHandler` via `set_exception_handler()` but never unregisters it: each kernel boot leaks one entry on the exception handler stack, which PHPUnit flags as Risky.

`ApiTestCase` (and the Doctrine ORM/ODM filter base test cases) now snapshot the exception handler stack via `#[Before]`/`#[After]` hooks (works even when subclasses override `setUp` without `parent::setUp()`). `symfony/http-kernel` is bumped to `^6.4.13` to skip the upstream `ErrorListener` handler leak so the `AppKernel` `restore_exception_handler()` workarounds can be dropped.