### PR TITLE
fix(laravel): inject missing dependencies into HydraSchemaFactory

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -914,7 +914,9 @@ class ApiPlatformProvider extends ServiceProvider
 
             return new HydraSchemaFactory(
                 $app->make(JsonApiSchemaFactory::class),
-                $defaultContext
+                $defaultContext,
+                $app->make(DefinitionNameFactoryInterface::class),
+                $app->make(ResourceMetadataCollectionFactoryInterface::class),
             );
         });
 


### PR DESCRIPTION
Summary                                                                                                                                                                                                                         
                                                                                                                                                                                                                                    
  - HydraSchemaFactory was registered in ApiPlatformProvider without ResourceMetadataCollectionFactoryInterface and DefinitionNameFactoryInterface                                                                                  
  - As a result, isResourceClass() always returned false, and Hydra base schemas (HydraItemBaseSchema, HydraCollectionBaseSchema) were never included in the OpenAPI output                                                         
  - This PR injects the two missing dependencies when binding HydraSchemaFactory in the service container                                                                                                                           
                                                                                                                                                                                                                                    
  Context                                                                                                                                                                                                                           
                                                                                                                                                                                                                                    
  This is a follow-up fix to #7924, which corrected isResourceClass() returning true for all classes by changing the fallback to false. That change exposed this registration bug in the Laravel provider: since the dependencies   
  were never injected, the factory always fell back to false regardless.
                                                                                                                                                                                                                                    
  Test plan                                                                                                                                                                                                                       

  - Verify that Hydra base schemas appear in the OpenAPI output for API Platform resources                                                                                                                                          
  - Verify that non-resource classes are still correctly excluded
