### PR TITLE
[Mcp] Properly handle oneOf and anyOf in generated mcp schema so that JSONLD output is actually valid

### DIFF
--- a/src/Mcp/JsonSchema/SchemaFactory.php
+++ b/src/Mcp/JsonSchema/SchemaFactory.php
@@ -109,6 +109,13 @@ final class SchemaFactory implements SchemaFactoryInterface
             return self::resolveDeep($merged, $definitions, $resolving);
         }
 
+        // oneOf/anyOf nodes must not receive a type fallback — their type is expressed
+        // through the sub-schemas. Adding 'type: object' here would break schemas like
+        // HydraItemBaseSchema's @context, which is oneOf: [string, object].
+        if (isset($node['oneOf']) || isset($node['anyOf'])) {
+            return self::resolveDeep($node, $definitions, $resolving);
+        }
+
         if (!isset($node['type'])) {
             $node['type'] = 'object';
         }

--- a/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
@@ -302,4 +302,73 @@ class SchemaFactoryTest extends TestCase
         $arr = $result->getArrayCopy();
         $this->assertSame(['type' => 'object'], $arr);
     }
+
+    public function testOneOfPropertyKeepsSubSchemasWithoutTypeFallback(): void
+    {
+        $innerSchema = new Schema(Schema::VERSION_JSON_SCHEMA);
+        unset($innerSchema['$schema']);
+        $definitions = $innerSchema->getDefinitions();
+        $definitions['Root'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                '@context' => new \ArrayObject([
+                    'oneOf' => [
+                        ['type' => 'string'],
+                        [
+                            'type' => 'object',
+                            'properties' => [
+                                '@vocab' => ['type' => 'string'],
+                            ],
+                            'required' => ['@vocab'],
+                        ],
+                    ],
+                ]),
+            ],
+        ]);
+        $innerSchema['$ref'] = '#/definitions/Root';
+
+        $inner = $this->createMock(SchemaFactoryInterface::class);
+        $inner->method('buildSchema')->willReturn($innerSchema);
+
+        $factory = new SchemaFactory($inner);
+        $result = $factory->buildSchema('App\\Dummy', 'json');
+
+        $arr = $result->getArrayCopy();
+        $context = $arr['properties']['@context'];
+        $this->assertArrayNotHasKey('type', $context);
+        $this->assertArrayHasKey('oneOf', $context);
+        $this->assertSame(['type' => 'string'], $context['oneOf'][0]);
+        $this->assertSame('object', $context['oneOf'][1]['type']);
+        $this->assertSame(['@vocab' => ['type' => 'string']], $context['oneOf'][1]['properties']);
+    }
+
+    public function testAnyOfPropertyKeepsSubSchemasWithoutTypeFallback(): void
+    {
+        $innerSchema = new Schema(Schema::VERSION_JSON_SCHEMA);
+        unset($innerSchema['$schema']);
+        $definitions = $innerSchema->getDefinitions();
+        $definitions['Root'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'value' => new \ArrayObject([
+                    'anyOf' => [
+                        ['type' => 'string'],
+                        ['type' => 'integer'],
+                    ],
+                ]),
+            ],
+        ]);
+        $innerSchema['$ref'] = '#/definitions/Root';
+
+        $inner = $this->createMock(SchemaFactoryInterface::class);
+        $inner->method('buildSchema')->willReturn($innerSchema);
+
+        $factory = new SchemaFactory($inner);
+        $result = $factory->buildSchema('App\\Dummy', 'json');
+
+        $arr = $result->getArrayCopy();
+        $value = $arr['properties']['value'];
+        $this->assertArrayNotHasKey('type', $value);
+        $this->assertSame([['type' => 'string'], ['type' => 'integer']], $value['anyOf']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3 (bugfix)
| Tickets       | None
| License       | MIT
| Doc PR        | Bugfix

So far, the generated output schemas for Mcp does not handle oneOf and anyOf correctly. The JSONLD @context property which can either bei "string" or "object" gets flattended to "object" only, and the schema validation will fail on outputs where the @context is a string (which seems to be the default). Breaking tool use on validating software like Claude Desktop.

This PR fixed this issue.