### PR TITLE
test(hal): correct context array key type in normalizer test docblock

### DIFF
--- a/src/Hal/Tests/Serializer/ItemNormalizerTest.php
+++ b/src/Hal/Tests/Serializer/ItemNormalizerTest.php
@@ -422,8 +422,8 @@ class ItemNormalizerTest extends TestCase
     }
 
     /**
-     * @param array<int,mixed> $context
-     * @param array<int,mixed> $expected
+     * @param array<string,mixed> $context
+     * @param array<string,mixed> $expected
      */
     #[DataProvider('getSkipNullToOneRelationCases')]
     public function testSkipNullToOneRelation(array $context, array $expected): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | ∅
| License       | MIT
| Doc PR        | ∅

`testSkipNullToOneRelation` docblock declared `@param array<int,mixed>` for both `$context` and `$expected`, but both arrays are string-keyed (option flags like `skip_null_to_one_relations` and HAL response shapes). PHPStan flagged the resulting type mismatch when the context is passed to `ItemNormalizer::normalize()`.