### PR TITLE
fix(laravel): set application/ld+json content-type on /contexts/{shortName}

### DIFF
--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -304,6 +304,30 @@ class JsonLdTest extends TestCase
         $response->assertNotFound();
     }
 
+    public function testJsonLdContextHasCorrectContentType(): void
+    {
+        $response = $this->get('/api/contexts/Entrypoint', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertArrayHasKey('@context', $response->json());
+    }
+
+    public function testJsonLdResourceContextHasCorrectContentType(): void
+    {
+        $response = $this->get('/api/contexts/Book', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertArrayHasKey('@context', $response->json());
+    }
+
+    public function testJsonLdContextDefaultsToEntrypoint(): void
+    {
+        $response = $this->get('/api/contexts/', ['accept' => 'application/ld+json']);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertArrayHasKey('@context', $response->json());
+    }
+
     public function testHidden(): void
     {
         PostFactory::new()->has(CommentFactory::new()->count(10))->count(10)->create();

--- a/src/Laravel/routes/api.php
+++ b/src/Laravel/routes/api.php
@@ -80,8 +80,9 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(static function ()
 
     Route::group(['prefix' => $prefix], static function (): void {
         Route::group(['middleware' => ApiPlatformMiddleware::class], static function (): void {
-            Route::get('/contexts/{shortName?}{_format?}', ContextAction::class)
-                ->name('api_jsonld_context');
+            Route::get('/contexts/{shortName?}{_format?}', static function (Request $request, ContextAction $contextAction, string $shortName = 'Entrypoint') {
+                return $contextAction($shortName, $request);
+            })->name('api_jsonld_context');
 
             Route::get('/validation_errors/{id}', static fn () => throw new NotExposedHttpException('Not exposed.'))
                 ->name('api_validation_errors')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | -
| License       | MIT
| Doc PR        | -

## Bug

`GET /api/contexts/{shortName}` (and `/api/contexts/` → Entrypoint) returns `Content-Type: application/json` instead of `application/ld+json`. Any Hydra client (`@api-platform/api-doc-parser` → `jsonld.expand`) rejects the response with *"Dereferencing a URL did not result in a valid JSON-LD object"*.

Reproduced against `composer require api-platform/laravel:^4.3` with `curl -sI -H "Accept: application/ld+json" http://localhost:8000/api/contexts/Entrypoint`.

This is the upstream issue called out in the *Known upstream issue* section of api-platform/api-platform#2980 — it breaks the installer's Laravel Blade welcome page (which calls `parseHydraDocumentation('/api')`).

## Root cause

`ContextAction::__invoke` has two branches:

```php
public function __invoke(string $shortName = 'Entrypoint', ?Request $request = null): array|Response
{
    if (null !== $request && $this->provider && $this->processor && $this->serializer) {
        // Symfony path: returns a Response with proper Content-Type
    }

    // Fallback: returns an array, which Laravel auto-serializes as application/json
}
```

Laravel's `Illuminate\Routing\ResolvesRouteDependencies::transformDependency` returns `null` for class-typed method parameters that declare a default value, *without consulting the container*:

```php
return $parameter->isDefaultValueAvailable()
    ? ($isEnum ? $parameter->getDefaultValue() : null)
    : $this->container->make($className);
```

So `?Request \$request = null` is always `null` when Laravel dispatches `ContextAction::class` directly as a route action. The Symfony branch never runs, the array branch returns a plain array, and Laravel emits `application/json`.

Constructor injection works fine: `ProviderInterface`, `ProcessorInterface`, `SerializerInterface` are all bound in `ApiPlatformProvider` and resolve normally via `Container::resolveClass`, which only falls back to defaults on `BindingResolutionException`.

## Fix

Wrap the route in a closure that takes `Request` and `ContextAction` as DI deps (no default values → Laravel injects them) and invokes the action with the request:

```php
Route::get('/contexts/{shortName?}{_format?}', static function (Request \$request, ContextAction \$contextAction, string \$shortName = 'Entrypoint') {
    return \$contextAction(\$shortName, \$request);
})->name('api_jsonld_context');
```

No change to `ContextAction` itself, no BC break.

## Tests

Three new tests in `src/Laravel/Tests/JsonLdTest.php`:

- `testJsonLdContextHasCorrectContentType` — `/api/contexts/Entrypoint`
- `testJsonLdResourceContextHasCorrectContentType` — `/api/contexts/Book`
- `testJsonLdContextDefaultsToEntrypoint` — `/api/contexts/` (empty shortName)

All three fail on `4.3` (assert `application/ld+json; charset=utf-8`, get `application/json`) and pass with this patch.