### PR TITLE
fix(symfony,laravel): IriConverter local cache key collision between item and collection ops

### DIFF
--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -103,7 +103,7 @@ class IriConverter implements IriConverterInterface
             $operation = $this->operationMetadataFactory->create($context['item_uri_template']);
         }
 
-        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_c' : '_i');
+        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_s' : '_o').($operation instanceof CollectionOperationInterface ? '_c' : '_i');
         if ($operation && isset($this->localOperationCache[$localOperationCacheKey])) {
             return $this->generateRoute($resource, $referenceType, $this->localOperationCache[$localOperationCacheKey], $context, $this->localIdentifiersExtractorOperationCache[$localOperationCacheKey] ?? null);
         }

--- a/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
+++ b/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Unit\Routing;
+
+use ApiPlatform\Laravel\Routing\IriConverter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\IdentifiersExtractorInterface;
+use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use ApiPlatform\Metadata\ResourceClassResolverInterface;
+use ApiPlatform\Metadata\UrlGeneratorInterface;
+use ApiPlatform\State\ProviderInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouterInterface;
+use Workbench\App\Models\Book;
+
+class IriConverterTest extends TestCase
+{
+    public function testLocalCacheKeyDistinguishesItemAndCollectionForStringResource(): void
+    {
+        $collectionOpName = 'collection_op';
+        $itemOpName = 'item_op';
+
+        $collectionOp = (new GetCollection())->withName($collectionOpName)->withClass(Book::class);
+        $itemOp = (new Get())->withName($itemOpName)->withClass(Book::class);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturnCallback(function (string $routeName, array $params) use ($collectionOpName, $itemOpName): string {
+                if ($collectionOpName === $routeName) {
+                    return '/api/books';
+                }
+                if ($itemOpName === $routeName) {
+                    return '/api/books/'.$params['id'];
+                }
+                $this->fail(\sprintf('Unexpected route name "%s".', $routeName));
+            });
+
+        $metadataCollection = new ResourceMetadataCollection(Book::class, [
+            (new ApiResource())->withOperations(new Operations([
+                $collectionOpName => $collectionOp,
+                $itemOpName => $itemOp,
+            ])),
+        ]);
+
+        $resourceMetadataFactory = $this->createStub(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactory->method('create')->willReturn($metadataCollection);
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturn(true);
+
+        $iriConverter = new IriConverter(
+            $this->createStub(ProviderInterface::class),
+            $this->createStub(OperationMetadataFactoryInterface::class),
+            $router,
+            $this->createStub(IdentifiersExtractorInterface::class),
+            $resourceClassResolver,
+            $resourceMetadataFactory,
+        );
+
+        $this->assertSame('/api/books', $iriConverter->getIriFromResource(
+            Book::class,
+            UrlGeneratorInterface::ABS_PATH,
+            new GetCollection(),
+        ));
+
+        $this->assertSame('/api/books/1', $iriConverter->getIriFromResource(
+            Book::class,
+            UrlGeneratorInterface::ABS_PATH,
+            new Get(),
+            ['uri_variables' => ['id' => 1]],
+        ));
+    }
+}

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -122,7 +122,7 @@ final class IriConverter implements IriConverterInterface
             $operation = $this->operationMetadataFactory->create($context['item_uri_template']);
         }
 
-        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.((\is_string($resource) || $operation instanceof CollectionOperationInterface) ? '_c' : '_i');
+        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_s' : '_o').($operation instanceof CollectionOperationInterface ? '_c' : '_i');
         if ($operation && isset($this->localOperationCache[$localOperationCacheKey])) {
             return $this->generateSymfonyRoute($resource, $referenceType, $this->localOperationCache[$localOperationCacheKey], $context, $this->localIdentifiersExtractorOperationCache[$localOperationCacheKey] ?? null);
         }

--- a/tests/Functional/Json/RelationTest.php
+++ b/tests/Functional/Json/RelationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Json;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ThirdLevel;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class RelationTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    public static function getResources(): array
+    {
+        return [ThirdLevel::class, RelatedDummy::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('Not tested with MongoDB.');
+        }
+
+        $this->recreateSchema([ThirdLevel::class, RelatedDummy::class]);
+    }
+
+    public function testCreateRelatedDummyWithPlainIdentifierForRelation(): void
+    {
+        // Creates a ThirdLevel; PurgeHttpCacheListener::postFlush caches the GetCollection
+        // operation under the '' + ThirdLevel + '_c' slot of IriConverter::$localOperationCache.
+        self::createClient()->request('POST', '/third_levels', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => ['level' => 3],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        // RelatedDummyPlainIdentifierDenormalizer calls getIriFromResource(ThirdLevel::class, new Get(), …).
+        // Without the fix the '_c' slot collision returns the GetCollection op, producing
+        // "/third_levels?id=1" instead of "/third_levels/1".
+        $response = self::createClient()->request('POST', '/related_dummies', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'json' => ['thirdLevel' => '1'],
+        ]);
+        $this->assertResponseStatusCodeSame(201);
+
+        $data = $response->toArray(false);
+        $this->assertArrayHasKey('thirdLevel', $data);
+        $this->assertIsArray($data['thirdLevel']);
+        $this->assertSame('/third_levels/1', $data['thirdLevel']['@id']);
+    }
+}


### PR DESCRIPTION
## Summary

The `IriConverter::$localOperationCache` key in both the Symfony and Laravel routing converters used a suffix scheme that collided for legitimately distinct call patterns. Under worker runtimes (FrankenPHP, Swoole, Octane) the converter survives across requests, so the collision corrupts IRI generation for any subsequent request that lands on the leaked slot.

**Symfony** (`src/Symfony/Routing/IriConverter.php`): `_c` was shared by `is_string(\$resource)` AND `\$operation instanceof CollectionOperationInterface`. After a POST that triggers `PurgeHttpCacheListener::postFlush`, a `GetCollection` operation is cached under `'' . Class . '_c'`. Any later call like `getIriFromResource(Class::class, ABS_PATH, new Get(), ['uri_variables' => ['id' => 1]])` hits the same slot and gets the cached `GetCollection` — producing `/things?id=1` instead of `/things/1`. `AbstractItemNormalizer::getResourceFromIri` then throws `Invalid IRI`.

**Laravel** (`src/Laravel/Routing/IriConverter.php`): broader scope — the key didn't check `CollectionOperationInterface` at all, so any string-resource call shared one slot regardless of operation type. `PurgeHttpCacheListener` already primes that slot with a `GetCollection` on every save/delete (see `src/Laravel/Eloquent/Listener/PurgeHttpCacheListener.php:50`).

## Fix

Both converters now encode the two axes independently in the cache suffix:

- `_s` / `_o` — string vs object resource
- `_c` / `_i` — collection vs item operation

Yielding four distinct slots (`_s_c`, `_s_i`, `_o_c`, `_o_i`) with no overlap.

## Test plan

- [x] `tests/Functional/Json/RelationTest::testCreateRelatedDummyWithPlainIdentifierForRelation` — end-to-end Symfony repro using `RelatedDummyPlainIdentifierDenormalizer`; sequential `POST /third_levels` then `POST /related_dummies` in the same kernel (`\$alwaysBootKernel = false`). Fails on `4.3` without the fix with `Invalid IRI "/third_levels?id=1"`.
- [x] `src/Laravel/Tests/Unit/Routing/IriConverterTest::testLocalCacheKeyDistinguishesItemAndCollectionForStringResource` — unit-level repro: anonymous `new GetCollection()` then anonymous `new Get()` for the same class-string. Fails on `4.3` without the fix (returns `/api/books` instead of `/api/books/1`).
- [x] `tests/Symfony/Routing/IriConverterTest` (14 tests) and the broader `tests/Symfony/Routing/` + `tests/Functional/` run (691 tests) stay green.
- [x] Laravel `PurgerTest` failures pre-exist on `4.3` and are unrelated to this change (verified by stashing the fix).