### PR TITLE
fix(openapi): include jsonapi collection schema

### DIFF
--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -259,15 +259,15 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $properties = $this->buildDefinitionPropertiesSchema($key, $className, $format, $type, $operation, $schema, []);
         $properties['data']['properties']['attributes']['$ref'] = $prefix.$key;
 
+        $properties['data'] = [
+            'type' => 'array',
+            'items' => $properties['data'],
+        ];
+
         $schema['description'] = "$definitionName collection.";
         $schema['allOf'] = [
             ['$ref' => $prefix.(false === $operation->getPaginationEnabled() ? self::COLLECTION_BASE_SCHEMA_NAME_NO_PAGINATION : self::COLLECTION_BASE_SCHEMA_NAME)],
-            ['type' => 'object', 'properties' => [
-                'data' => [
-                    'type' => 'array',
-                    'items' => $properties['data'],
-                ],
-            ]],
+            ['type' => 'object', 'properties' => $properties],
         ];
 
         return $schema;

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -261,6 +261,24 @@ class OpenApiTest extends ApiTestCase
         ], 'description' => 'A resource used for OpenAPI tests.'], $res['components']['schemas']['Crud.jsonld']);
     }
 
+    public function testJsonApiCollectionSchemaDocumentsIncludedResources(): void
+    {
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray();
+        $schema = $json['paths']['/dummies']['get']['responses']['200']['content']['application/vnd.api+json']['schema'];
+        $properties = $schema['allOf'][1]['properties'];
+
+        $this->assertArrayHasKey('included', $properties);
+        $this->assertSame('array', $properties['included']['type']);
+        $this->assertTrue($properties['included']['readOnly']);
+        $this->assertArrayHasKey('anyOf', $properties['included']['items']);
+        $this->assertNotEmpty($properties['included']['items']['anyOf']);
+    }
+
     public function testRetrieveTheOpenApiDocumentation(): void
     {
         $response = self::createClient()->request('GET', '/docs', ['headers' => ['accept' => 'application/vnd.openapi+json']]);


### PR DESCRIPTION
Fixes #7956.

Preserves the JSON:API included schema when building OpenAPI schemas for collection responses and adds a functional regression test.

Tests:
- php -l src/JsonApi/JsonSchema/SchemaFactory.php
- php -l tests/Functional/OpenApiTest.php
- vendor/bin/phpunit tests/Functional/OpenApiTest.php --filter testJsonApiCollectionSchemaDocumentsIncludedResources
- vendor/bin/phpunit tests/Functional/OpenApiTest.php --filter testRetrieveTheOpenApiDocumentation
- vendor/bin/phpunit tests/Functional/OpenApiTest.php --filter testHasSchemasForMultipleFormats
- vendor/bin/phpunit tests/Functional/PaginationDisabledTest.php --filter testSchemaCollectionJsonApi