### PR TITLE
test: cover Assert\Choice exposure in OpenAPI schema

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/CompanyWithChoiceValidation.php
+++ b/tests/Fixtures/TestBundle/ApiResource/CompanyWithChoiceValidation.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(operations: [new GetCollection(provider: [CompanyWithChoiceValidation::class, 'provide'])])]
+class CompanyWithChoiceValidation
+{
+    public ?int $id = null;
+
+    #[Assert\Choice(choices: ['SARL', 'SAS', 'SA'])]
+    public ?string $companyType = null;
+
+    #[Assert\Choice(callback: [self::class, 'getCompanyTypeChoices'])]
+    public ?string $companyTypeFromCallback = null;
+
+    /** @var string[] */
+    #[Assert\Choice(choices: ['SARL', 'SAS', 'SA'], multiple: true, min: 1, max: 3)]
+    public array $allowedCompanyTypes = [];
+
+    public static function getCompanyTypeChoices(): array
+    {
+        return ['SARL', 'SAS', 'SA', 'EURL'];
+    }
+
+    public static function provide(): array
+    {
+        return [];
+    }
+}

--- a/tests/Functional/ChoiceValidationOpenApiTest.php
+++ b/tests/Functional/ChoiceValidationOpenApiTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\CompanyWithChoiceValidation;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * @see https://github.com/api-platform/core/issues/1522
+ */
+final class ChoiceValidationOpenApiTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [CompanyWithChoiceValidation::class];
+    }
+
+    public function testChoiceConstraintIsDocumentedInOpenApi(): void
+    {
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+        $this->assertResponseIsSuccessful();
+
+        $json = $response->toArray();
+        $this->assertArrayHasKey('CompanyWithChoiceValidation', $json['components']['schemas']);
+
+        $properties = $json['components']['schemas']['CompanyWithChoiceValidation']['properties'];
+
+        $this->assertSame(['SARL', 'SAS', 'SA'], $properties['companyType']['enum']);
+        $this->assertSame(['SARL', 'SAS', 'SA', 'EURL'], $properties['companyTypeFromCallback']['enum']);
+
+        $this->assertSame('array', $properties['allowedCompanyTypes']['type']);
+        $this->assertSame(['SARL', 'SAS', 'SA'], $properties['allowedCompanyTypes']['items']['enum']);
+        $this->assertSame('string', $properties['allowedCompanyTypes']['items']['type']);
+        $this->assertSame(1, $properties['allowedCompanyTypes']['minItems']);
+        $this->assertSame(3, $properties['allowedCompanyTypes']['maxItems']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds functional `ApiTestCase` verifying `PropertySchemaChoiceRestriction` surfaces `enum`, `items.enum`, `minItems`, `maxItems` in `/docs` (OpenAPI JSON).
- Existing `OpenApiTest` only covered PHP backed enum properties (`genderType`, `playMode`); Symfony Validator `Choice` constraint exposure was uncovered at the functional level.
- Confirms issue #1522 ("Choice Validation to be documented on Swagger") is already resolved; this PR locks the behaviour with regression coverage.

## Test plan

- [x] `vendor/bin/phpunit tests/Functional/ChoiceValidationOpenApiTest.php` — passes (1 test, 9 assertions)

Closes #1522