### PR TITLE
fix(metadata): negotiate wildcard Accept with parameters

### DIFF
--- a/src/Metadata/Util/ContentNegotiationTrait.php
+++ b/src/Metadata/Util/ContentNegotiationTrait.php
@@ -97,7 +97,15 @@ trait ContentNegotiationTrait
         /** @var string|null $accept */
         $accept = $request->headers->get('Accept');
         if (null !== $accept) {
-            if ($mediaType = $this->negotiator->getBest($accept, $mimeTypes)) {
+            $mediaType = $this->negotiator->getBest($accept, $mimeTypes);
+            // willdurand/negotiation treats media-range parameters as match
+            // constraints, so a wildcard carrying informational params
+            // (e.g. `*\/*; charset=utf-8` from PhpStorm) fails negotiation.
+            // Retry on a bare wildcard. See #1532.
+            if (!$mediaType && str_contains($accept, '*/*')) {
+                $mediaType = $this->negotiator->getBest('*/*', $mimeTypes);
+            }
+            if ($mediaType) {
                 return $this->getMimeTypeFormat($mediaType->getType(), $formats);
             }
 

--- a/tests/Fixtures/TestBundle/ApiResource/WildcardAcceptFormat/WildcardAcceptFormat.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WildcardAcceptFormat/WildcardAcceptFormat.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WildcardAcceptFormat;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Get(
+    shortName: 'WildcardAcceptFormat',
+    uriTemplate: '/wildcard_accept_format/{id}',
+    outputFormats: ['jsonld' => ['application/ld+json'], 'html' => ['text/html']],
+    provider: [self::class, 'provide'],
+    extraProperties: ['_api_disable_swagger_provider' => true]
+)]
+class WildcardAcceptFormat
+{
+    #[ApiProperty(identifier: true)]
+    public int $id = 1;
+
+    public string $name = 'hello';
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self|Response
+    {
+        if ('html' === $context['request']?->getRequestFormat()) {
+            return new Response('<h1>hello</h1>', 200, ['Content-Type' => 'text/html']);
+        }
+
+        return new self();
+    }
+}

--- a/tests/Functional/FormatTest.php
+++ b/tests/Functional/FormatTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Tests\Functional;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6384\AcceptHtml;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WildcardAcceptFormat\WildcardAcceptFormat;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 
 final class FormatTest extends ApiTestCase
@@ -28,7 +29,7 @@ final class FormatTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [AcceptHtml::class];
+        return [AcceptHtml::class, WildcardAcceptFormat::class];
     }
 
     public function testShouldReturnHtml(): void
@@ -36,5 +37,38 @@ final class FormatTest extends ApiTestCase
         $r = self::createClient()->request('GET', '/accept_html', ['headers' => ['Accept' => 'text/html']]);
         $this->assertResponseIsSuccessful();
         $this->assertEquals($r->getContent(), '<h1>hello</h1>');
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/1532
+     */
+    public function testWildcardAcceptHeaderPicksFirstConfiguredFormat(): void
+    {
+        $response = self::createClient()->request('GET', '/wildcard_accept_format/1', ['headers' => ['Accept' => '*/*']]);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringStartsWith('application/ld+json', $response->getHeaders()['content-type'][0]);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/1532
+     */
+    public function testWildcardAcceptHeaderWithParametersPicksFirstConfiguredFormat(): void
+    {
+        $response = self::createClient()->request('GET', '/wildcard_accept_format/1', ['headers' => ['Accept' => '*/*; charset=utf-8']]);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringStartsWith('application/ld+json', $response->getHeaders()['content-type'][0]);
+    }
+
+    public function testWildcardAcceptHeaderRespectsQualityOfConcreteType(): void
+    {
+        $response = self::createClient()->request('GET', '/wildcard_accept_format/1', ['headers' => ['Accept' => '*/*; charset=utf-8; q=0.1, text/html; q=0.9']]);
+        $this->assertResponseIsSuccessful();
+        $this->assertStringStartsWith('text/html', $response->getHeaders()['content-type'][0]);
+    }
+
+    public function testConcreteAcceptHeaderWithUnsupportedTypeReturnsNotAcceptable(): void
+    {
+        self::createClient()->request('GET', '/wildcard_accept_format/1', ['headers' => ['Accept' => 'application/xml']]);
+        $this->assertResponseStatusCodeSame(406);
     }
 }


### PR DESCRIPTION
## Summary

- `willdurand/negotiation` treats media-range parameters as match constraints, so `*/*; charset=utf-8` (sent by default by clients like PhpStorm) fails to match offered MIME types and returns `406 Not Acceptable`.
- On failure, retry with a bare `*/*` when the Accept header contains a wildcard. Concrete media types are left untouched so vendor-specific negotiation (e.g. JSON:API `profile`) is preserved.

## Test plan

- [x] `*/*` picks first configured format
- [x] `*/*; charset=utf-8` picks first configured format (the #1532 fix)
- [x] `*/*; charset=utf-8; q=0.1, text/html; q=0.9` still picks `text/html` (q-precedence preserved)
- [x] Unsupported concrete type (e.g. `application/xml`) still returns `406`
- [x] Existing `FormatTest`, `ErrorFormatTest`, `JsonLdTest`, `JsonApiTest`, `ContentNegotiationProviderTest` all green

Closes #1532