### PR TITLE
fix(jsonapi): merge flat page/itemsPerPage params with bracket filter

### DIFF
--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -70,6 +70,12 @@ final class JsonApiProvider implements ProviderInterface
             $filters = array_merge($pageParameter, $filters);
         }
 
+        foreach (['page', 'itemsPerPage', 'pagination', 'partial'] as $paginationParameter) {
+            if (isset($queryParameters[$paginationParameter]) && !\is_array($queryParameters[$paginationParameter]) && !isset($filters[$paginationParameter])) {
+                $filters[$paginationParameter] = $queryParameters[$paginationParameter];
+            }
+        }
+
         [$included, $properties] = $this->transformFieldsetsParameters($queryParameters, $operation->getShortName() ?? '');
 
         if ($properties) {

--- a/src/JsonApi/Tests/State/JsonApiProviderTest.php
+++ b/src/JsonApi/Tests/State/JsonApiProviderTest.php
@@ -37,4 +37,25 @@ class JsonApiProviderTest extends TestCase
         $provider = new JsonApiProvider($decorated);
         $provider->provide($operation, [], $context);
     }
+
+    public function testProvideMergesFlatPaginationWithBracketFilter(): void
+    {
+        $request = new Request(['page' => '2', 'itemsPerPage' => '5', 'pagination' => 'true', 'filter' => ['custom' => 'true']]);
+        $request->setRequestFormat('jsonapi');
+
+        $operation = new Get(class: \stdClass::class, shortName: 'dummy');
+        $context = ['request' => $request];
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->with($operation, [], $context);
+
+        $provider = new JsonApiProvider($decorated);
+        $provider->provide($operation, [], $context);
+
+        $this->assertSame([
+            'custom' => 'true',
+            'page' => '2',
+            'itemsPerPage' => '5',
+            'pagination' => 'true',
+        ], $request->attributes->get('_api_filters'));
+    }
 }

--- a/tests/Functional/JsonApiFlatPaginationTest.php
+++ b/tests/Functional/JsonApiFlatPaginationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class JsonApiFlatPaginationTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Dummy::class];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->isMongoDB()) {
+            return;
+        }
+
+        $this->recreateSchema([Dummy::class]);
+        $this->loadFixtures();
+    }
+
+    /**
+     * Regression test for issue #7888: when a JSON:API request combines a
+     * bracket-form filter (filter[...]) with a flat pagination param (page=N),
+     * the page param must still drive the current page rather than being
+     * silently dropped.
+     */
+    public function testFlatPageWithBracketFilterDrivesCurrentPage(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('Not tested with mongodb.');
+        }
+
+        $response = self::createClient()->request('GET', '/dummies?filter[name]=foo&page=2', [
+            'headers' => ['Accept' => 'application/vnd.api+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+
+        $data = $response->toArray();
+
+        $this->assertSame(2, $data['meta']['currentPage'] ?? null);
+        $this->assertSame(5, $data['meta']['totalItems'] ?? null);
+    }
+
+    private function loadFixtures(): void
+    {
+        $manager = $this->getManager();
+
+        for ($i = 1; $i <= 5; ++$i) {
+            $dummy = new Dummy();
+            $dummy->setName('foo #'.$i);
+            $manager->persist($dummy);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
## Summary

When a JSON:API request combines a bracket-form filter with flat pagination
params (e.g. `?filter[name]=foo&page=2`), the flat `page` was silently dropped
and the collection always returned page 1, while pagination links still
advertised the requested page.

## Root cause

`Symfony\JsonApi\State\JsonApiProvider` only merged `page[...]` (array form)
into `_api_filters`. With a scalar `page=2` plus a `filter[...]` array, the
partial `_api_filters` set by the provider suppressed `ReadProvider`'s
fallback to `RequestParser::parseRequestParams()`, so `Pagination::getPage()`
never saw the page param and returned its default of 1.

## Fix

Pass through scalar `page`, `itemsPerPage`, `pagination`, `partial` query
params when they are not arrays and not already populated by the bracket
form (bracket values take precedence).

## Test plan

- Unit: `JsonApiProviderTest::testProvideMergesFlatPaginationWithBracketFilter`
  verifies `_api_filters` ends up with both the filter and the flat pagination keys.
- Functional: `JsonApiFlatPaginationTest::testFlatPageWithBracketFilterDrivesCurrentPage`
  hits `/dummies?filter[name]=foo&page=2` with `Accept: application/vnd.api+json`
  and asserts `meta.currentPage === 2`. The test fails without the patch
  (asserts that 1 === 2).

Fixes #7888.

## Notes

The longer-term fix is to port JSON:API parameter handling to dedicated
`ParameterProvider`s (Laravel already moved sort + sparse fieldset that way).
An RFC for that work will follow as a separate issue against `main`.