### PR TITLE
fix(metadata): :property dedup drops repeated parameters

### DIFF
--- a/src/Metadata/Parameters.php
+++ b/src/Metadata/Parameters.php
@@ -37,7 +37,12 @@ final class Parameters implements \IteratorAggregate, \Countable
                 $parameterName = $parameter->getKey();
             }
 
-            $key = \sprintf('%s.%s', $parameter::class, $parameterName);
+            // `:property` is a template expanded per-property later; multiple templates with disjoint properties must coexist.
+            if (str_contains((string) $parameterName, ':property')) {
+                $key = \sprintf('%s.%s.%s', $parameter::class, $parameterName, self::propertyDiscriminator($parameter));
+            } else {
+                $key = \sprintf('%s.%s', $parameter::class, $parameterName);
+            }
 
             $this->parameters[$key] = [$parameterName, $parameter];
         }
@@ -61,17 +66,36 @@ final class Parameters implements \IteratorAggregate, \Countable
 
     public function add(string $key, Parameter $value): self
     {
-        foreach ($this->parameters as $i => [$parameterName, $parameter]) {
-            if ($parameterName === $key && $value::class === $parameter::class) {
-                $this->parameters[$i] = [$key, $value];
+        // `:property` is a template expanded per-property later; templates with disjoint properties coexist, identical ones override.
+        $isTemplate = str_contains($key, ':property');
+        $valueDiscriminator = $isTemplate ? self::propertyDiscriminator($value) : null;
 
-                return $this;
+        foreach ($this->parameters as $i => [$parameterName, $parameter]) {
+            if ($parameterName !== $key || $value::class !== $parameter::class) {
+                continue;
             }
+
+            if ($isTemplate && self::propertyDiscriminator($parameter) !== $valueDiscriminator) {
+                continue;
+            }
+
+            $this->parameters[$i] = [$key, $value];
+
+            return $this;
         }
 
         $this->parameters[] = [$key, $value];
 
         return $this;
+    }
+
+    private static function propertyDiscriminator(Parameter $parameter): string
+    {
+        if ($properties = $parameter->getProperties()) {
+            return '['.implode(',', $properties).']';
+        }
+
+        return $parameter->getProperty() ?? '';
     }
 
     /**

--- a/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
+++ b/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
@@ -288,7 +288,8 @@ trait MetadataCollectionFactoryTrait
                 $parameterName = $key;
             }
 
-            if (!$parameters->has($parameterName, $parameter::class)) {
+            // `:property` is a template expanded per-property later; multiple templates must coexist.
+            if (str_contains((string) $parameterName, ':property') || !$parameters->has($parameterName, $parameter::class)) {
                 $parameters->add($parameterName, $parameter);
             }
         }

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -113,7 +113,9 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         if ($parameter) {
             $paramKey = $parameter->getProperties() ? ($parameter->getKey() ?? '') : ($parameter->getProperty() ?? $parameter->getKey() ?? '');
         }
-        $k = $resourceClass.$paramKey.(\is_string($parameter->getFilter()) ? $parameter->getFilter() : '').$filterClass;
+        // Include properties list so repeated `:property` templates with disjoint properties get distinct cache entries.
+        $paramProperties = $parameter?->getProperties() ? '['.implode(',', $parameter->getProperties()).']' : '';
+        $k = $resourceClass.$paramKey.$paramProperties.(\is_string($parameter->getFilter()) ? $parameter->getFilter() : '').$filterClass;
         if (isset($this->localPropertyCache[$k])) {
             return $this->localPropertyCache[$k];
         }

--- a/src/Metadata/Tests/ParametersTest.php
+++ b/src/Metadata/Tests/ParametersTest.php
@@ -49,4 +49,32 @@ class ParametersTest extends TestCase
         $this->assertSame($r2, $parameters->get('a'));
         $this->assertSame($r4, $parameters->get('a', HeaderParameter::class));
     }
+
+    public function testPropertyPlaceholderKeysAreNotDeduplicated(): void
+    {
+        $r1 = new QueryParameter(key: ':property', properties: ['field1', 'field2']);
+        $r2 = new QueryParameter(key: ':property', properties: ['field3', 'field4']);
+        $parameters = new Parameters([$r1, $r2]);
+
+        $this->assertCount(2, $parameters);
+
+        $collected = [];
+        foreach ($parameters as $key => $parameter) {
+            $collected[] = [$key, $parameter];
+        }
+
+        $this->assertSame(':property', $collected[0][0]);
+        $this->assertSame(':property', $collected[1][0]);
+        $this->assertSame(['field1', 'field2'], $collected[0][1]->getProperties());
+        $this->assertSame(['field3', 'field4'], $collected[1][1]->getProperties());
+    }
+
+    public function testPropertyPlaceholderKeysAreNotDeduplicatedViaAdd(): void
+    {
+        $parameters = new Parameters();
+        $parameters->add(':property', new QueryParameter(key: ':property', properties: ['field1', 'field2']));
+        $parameters->add(':property', new QueryParameter(key: ':property', properties: ['field3', 'field4']));
+
+        $this->assertCount(2, $parameters);
+    }
 }

--- a/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
@@ -323,6 +323,40 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertSame('search[related.nested]', $searchNestedParam->getKey());
     }
 
+    public function testRepeatedPropertyPlaceholderAttributesExpandPerPropertyFilter(): void
+    {
+        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['field1', 'field2', 'field3', 'field4']));
+
+        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadata->method('create')->willReturn(new ApiProperty(readable: true));
+
+        $filterLocator = $this->createStub(ContainerInterface::class);
+        $filterLocator->method('has')->willReturn(false);
+
+        $parameterFactory = new ParameterResourceMetadataCollectionFactory(
+            $nameCollection,
+            $propertyMetadata,
+            new AttributesResourceMetadataCollectionFactory(),
+            $filterLocator
+        );
+
+        $collection = $parameterFactory->create(HasRepeatedPropertyPlaceholderParameter::class);
+        $operation = $collection->getOperation(forceCollection: true);
+        $parameters = $operation->getParameters();
+
+        $this->assertInstanceOf(Parameters::class, $parameters);
+
+        foreach (['field1', 'field2', 'field3', 'field4'] as $field) {
+            $this->assertTrue($parameters->has($field), \sprintf('Parameter "%s" should exist after :property expansion', $field));
+        }
+
+        $this->assertInstanceOf(RepeatedPlaceholderExactFilter::class, $parameters->get('field1')->getFilter());
+        $this->assertInstanceOf(RepeatedPlaceholderExactFilter::class, $parameters->get('field2')->getFilter());
+        $this->assertInstanceOf(RepeatedPlaceholderBooleanFilter::class, $parameters->get('field3')->getFilter());
+        $this->assertInstanceOf(RepeatedPlaceholderBooleanFilter::class, $parameters->get('field4')->getFilter());
+    }
+
     private function createNestedPropertyFactory(): ParameterResourceMetadataCollectionFactory
     {
         $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
@@ -426,6 +460,34 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertNotNull($param);
         $this->assertArrayNotHasKey('nested_properties_info', $param->getExtraProperties());
     }
+}
+
+class RepeatedPlaceholderExactFilter implements FilterInterface
+{
+    public function getDescription(string $resourceClass): array
+    {
+        return [];
+    }
+}
+
+class RepeatedPlaceholderBooleanFilter implements FilterInterface
+{
+    public function getDescription(string $resourceClass): array
+    {
+        return [];
+    }
+}
+
+#[ApiResource]
+#[QueryParameter(key: ':property', filter: new RepeatedPlaceholderExactFilter(), properties: ['field1', 'field2'])]
+#[QueryParameter(key: ':property', filter: new RepeatedPlaceholderBooleanFilter(), properties: ['field3', 'field4'])]
+class HasRepeatedPropertyPlaceholderParameter
+{
+    public $id;
+    public $field1;
+    public $field2;
+    public $field3;
+    public $field4;
 }
 
 #[ApiResource(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.2
| Tickets       | Closes #8184
| License       | MIT

## Summary

Multiple `#[QueryParameter(key: ':property', ...)]` class-level attributes with disjoint `properties` lists were silently collapsed to the last attribute. Same key, different filter per property was unreachable without awkward namespacing (`exact[:property]`, `partial[:property]`).

### Example

```php
#[ApiResource]
#[QueryParameter(key: ':property', filter: new ExactFilter(), properties: ['field1', 'field2'])]
#[QueryParameter(key: ':property', filter: new BooleanFilter(), properties: ['field3', 'field4'])]
class Task { /* ... */ }
```

Before this fix only the second attribute survived; after the fix all four properties resolve to their declared filters.

## Why

`Parameters::add()`, `Parameters::__construct()`, and `MetadataCollectionFactoryTrait::mergeOperationParameters()` deduplicated by `(class, key)` before the `:property` placeholder was expanded. `ParameterResourceMetadataCollectionFactory::getProperties()` cache key was also shared between disjoint templates.

`:property` is a template, not a final key — it expands per-property in `ParameterResourceMetadataCollectionFactory::getDefaultParameters`. Two templates with disjoint `properties` lists must coexist; the final per-property keys are concrete and dedup normally.

## What changed

- `Parameters::add` / `Parameters::__construct`: when key contains `:property`, the storage key includes a discriminator built from the parameter's `properties` (or `property`) list. Deterministic, cache-safe.
- `MetadataCollectionFactoryTrait::mergeOperationParameters`: skip the `has()` short-circuit for `:property` templated keys.
- `ParameterResourceMetadataCollectionFactory::getProperties`: include `properties` list in the local cache key.

Templates with identical `properties` keep last-write-wins (intentional override).

## Tests

- `Metadata\Tests\ParametersTest`: two new tests cover constructor and `add()` paths.
- `Metadata\Tests\Resource\Factory\ParameterResourceMetadataCollectionFactoryTest::testRepeatedPropertyPlaceholderAttributesExpandPerPropertyFilter`: end-to-end factory expansion verifying each property receives its declared filter.

## Related

#7870 (per-property `Parameter` attributes via `TARGET_PROPERTY`) provides a complementary, cleaner declaration model for the original use case in #8184 once it lands.