### PR TITLE
feat(symfony,laravel): `withCredentials` option to Swagger UI

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -767,7 +767,8 @@ class ApiPlatformProvider extends ServiceProvider
                 httpAuth: $config->get('api-platform.swagger_ui.http_auth', []),
                 tags: $config->get('api-platform.openapi.tags', []),
                 errorResourceClass: Error::class,
-                validationErrorResourceClass: ValidationError::class
+                validationErrorResourceClass: ValidationError::class,
+                withCredentials: $config->get('api-platform.swagger_ui.with_credentials', false),
             );
         });
 

--- a/src/Laravel/State/SwaggerUiProcessor.php
+++ b/src/Laravel/State/SwaggerUiProcessor.php
@@ -83,6 +83,7 @@ final class SwaggerUiProcessor implements ProcessorInterface
                 'clientSecret' => $this->oauthClientSecret,
                 'pkce' => $this->oauthPkce,
             ],
+            'withCredentials' => $this->openApiOptions->getWithCredentials(),
         ];
 
         $status = 200;

--- a/src/Laravel/Tests/DocsTest.php
+++ b/src/Laravel/Tests/DocsTest.php
@@ -85,4 +85,10 @@ class DocsTest extends TestCase
         $this->assertStringContainsString('init-scalar-ui.js', $content);
         $this->assertStringNotContainsString('id="formats"', $content);
     }
+
+    public function testSwaggerDataDoesNotContainWithCredentialsByDefault(): void
+    {
+        $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
+        $this->assertStringNotContainsString('"withCredentials":true', (string) $res->getContent());
+    }
 }

--- a/src/Laravel/Tests/DocsWithCredentialsTest.php
+++ b/src/Laravel/Tests/DocsWithCredentialsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Config\Repository;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class DocsWithCredentialsTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use WithWorkbench;
+
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config): void {
+            $config->set('api-platform.swagger_ui.with_credentials', true);
+        });
+    }
+
+    public function testSwaggerDataContainsWithCredentialsTrueWhenEnabled(): void
+    {
+        $res = $this->get('/api/docs', headers: ['accept' => 'text/html']);
+        $res->assertOk();
+        $content = (string) $res->getContent();
+        $this->assertStringContainsString('"withCredentials":true', $content);
+    }
+}

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -143,6 +143,8 @@ return [
         //         'bearerFormat' => 'JWT',
         //     ],
         // ],
+        //
+        // 'with_credentials' => true,
     ],
 
     // 'openapi' => [

--- a/src/Laravel/public/init-swagger-ui.js
+++ b/src/Laravel/public/init-swagger-ui.js
@@ -41,7 +41,8 @@ window.onload = function() {
     }).observe(document, {childList: true, subtree: true});
 
     const data = JSON.parse(document.getElementById('swagger-data').innerText);
-    const ui = SwaggerUIBundle(Object.assign({
+
+    const config = {
         spec: data.spec,
         dom_id: '#swagger-ui',
         validatorUrl: null,
@@ -55,7 +56,18 @@ window.onload = function() {
             SwaggerUIBundle.plugins.DownloadUrl,
         ],
         layout: 'StandaloneLayout',
-    }, data.extraConfiguration));
+    };
+
+    if (data.withCredentials) {
+        // Cloudflare Access fix: ensure cookies are sent on token / CORS calls
+        config.requestInterceptor = (req) => {
+            req.credentials = 'include';
+            return req;
+        };
+    }
+
+    const withExtraConfig = Object.assign(config, data.extraConfiguration);
+    const ui = SwaggerUIBundle(withExtraConfig);
 
     if (data.oauth.enabled) {
         ui.initOAuth({

--- a/src/OpenApi/Options.php
+++ b/src/OpenApi/Options.php
@@ -47,6 +47,7 @@ final readonly class Options
         private ?string $errorResourceClass = null,
         private ?string $validationErrorResourceClass = null,
         private ?string $licenseIdentifier = null,
+        private bool $withCredentials = false,
     ) {
     }
 
@@ -177,5 +178,10 @@ final readonly class Options
     public function getLicenseIdentifier(): ?string
     {
         return $this->licenseIdentifier;
+    }
+
+    public function getWithCredentials(): bool
+    {
+        return $this->withCredentials;
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -684,6 +684,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.enable_scalar', $config['enable_scalar']);
         $container->setParameter('api_platform.swagger.api_keys', $config['swagger']['api_keys']);
         $container->setParameter('api_platform.swagger.persist_authorization', $config['swagger']['persist_authorization']);
+        $container->setParameter('api_platform.swagger.with_credentials', $config['swagger']['with_credentials']);
         $container->setParameter('api_platform.swagger.http_auth', $config['swagger']['http_auth']);
         if ($config['openapi']['swagger_ui_extra_configuration'] && $config['swagger']['swagger_ui_extra_configuration']) {
             throw new RuntimeException('You can not set "swagger_ui_extra_configuration" twice - in "openapi" and "swagger" section.');

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -324,6 +324,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('persist_authorization')->defaultValue(false)->info('Persist the SwaggerUI Authorization in the localStorage.')->end()
+                        ->booleanNode('with_credentials')->defaultValue(false)->info('Send credentials (cookies, authorization headers) on Swagger UI cross-origin requests (e.g. when running behind Cloudflare Access).')->end()
                         ->arrayNode('versions')
                             ->info('The active versions of OpenAPI to be exported or used in Swagger UI. The first value is the default.')
                             ->defaultValue($supportedVersions)

--- a/src/Symfony/Bundle/Resources/config/openapi.php
+++ b/src/Symfony/Bundle/Resources/config/openapi.php
@@ -70,6 +70,7 @@ return function (ContainerConfigurator $container) {
             '%api_platform.openapi.errorResourceClass%',
             '%api_platform.openapi.validationErrorResourceClass%',
             '%api_platform.openapi.license.identifier%',
+            '%api_platform.swagger.with_credentials%',
         ]);
 
     $services->alias(Options::class, 'api_platform.openapi.options');

--- a/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
+++ b/src/Symfony/Bundle/Resources/public/init-swagger-ui.js
@@ -41,7 +41,7 @@ window.onload = function() {
     }).observe(document, {childList: true, subtree: true});
 
     const data = JSON.parse(document.getElementById('swagger-data').innerText);
-    const ui = SwaggerUIBundle(Object.assign({
+    const config = {
         spec: data.spec,
         dom_id: '#swagger-ui',
         validatorUrl: null,
@@ -56,7 +56,16 @@ window.onload = function() {
             SwaggerUIBundle.plugins.DownloadUrl,
         ],
         layout: 'StandaloneLayout',
-    }, data.extraConfiguration));
+    };
+
+    if (data.withCredentials) {
+        config.requestInterceptor = (req) => {
+            req.credentials = 'include';
+            return req;
+        };
+    }
+
+    const ui = SwaggerUIBundle(Object.assign(config, data.extraConfiguration));
 
     if (data.oauth.enabled) {
         ui.initOAuth({

--- a/src/Symfony/Bundle/SwaggerUi/SwaggerUiProcessor.php
+++ b/src/Symfony/Bundle/SwaggerUi/SwaggerUiProcessor.php
@@ -64,6 +64,7 @@ final class SwaggerUiProcessor implements ProcessorInterface
             'url' => $this->urlGenerator->generate('api_doc', ['format' => 'json']),
             'spec' => $this->normalizer->normalize($openApi, 'json', []),
             'persistAuthorization' => $this->openApiOptions->hasPersistAuthorization(),
+            'withCredentials' => $this->openApiOptions->getWithCredentials(),
             'oauth' => [
                 'enabled' => $this->openApiOptions->getOAuthEnabled(),
                 'type' => $this->openApiOptions->getOAuthType(),

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -161,6 +161,7 @@ class ConfigurationTest extends TestCase
                 'http_auth' => [],
                 'swagger_ui_extra_configuration' => [],
                 'persist_authorization' => false,
+                'with_credentials' => false,
             ],
             'eager_loading' => [
                 'enabled' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        |  api-platform/docs#2285

## 

### Problem

When an API Platform Laravel application is deployed behind Cloudflare Access, the Swagger UI's token and CORS requests are intercepted and rejected with a `401` response. This happens because the Cloudflare Access authentication cookie is not forwarded with these requests — browsers only include cookies in cross-origin requests when `credentials: 'include'` is explicitly set.

### Solution

This PR adds a `withCredentials` boolean option to `OpenApi\Options`. When enabled, a `requestInterceptor` is injected into the SwaggerUIBundle configuration that sets `credentials: 'include'` on every outgoing request, ensuring the Cloudflare Access cookie is forwarded.

The option is disabled by default to preserve existing behaviour.

### Changes

- `src/OpenApi/Options.php` — new `withCredentials` constructor parameter (default `false`) and `getWithCredentials()` getter
- `src/Laravel/ApiPlatformProvider.php` — reads `swagger_ui.with_credentials` from config and passes it to `Options`
- `src/Laravel/State/SwaggerUiProcessor.php` — includes `withCredentials` in the `swagger-data` JSON payload
- `src/Laravel/public/init-swagger-ui.js` — conditionally adds a `requestInterceptor` that sets `req.credentials = 'include'`
- `src/Laravel/config/api-platform.php` — documents the new `with_credentials` config key (disabled by default)

### Configuration

```php
// config/api-platform.php
'swagger_ui' => [
    'with_credentials' => true,
],
```

### Testing

- Added `Tests/DocsWithCredentialsTest.php` — integration test verifying that `"withCredentials":true` is present in the rendered `swagger-data` JSON when the option is enabled, and absent by default.
