### PR TITLE
fix(phpstan): correct json_decode args and prune stale ignores

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -85,7 +85,6 @@ parameters:
 		# Expected, due to backward compatibility
 		- '#Method GraphQL\\Type\\Definition\\WrappingType::getWrappedType\(\) invoked with 1 parameter, 0 required\.#'
 		- '#Access to an undefined property GraphQL\\Type\\Definition\\NamedType&GraphQL\\Type\\Definition\\Type::\$name\.#'
-		- "#Call to function method_exists\\(\\) with GraphQL\\\\Type\\\\Definition\\\\Type&GraphQL\\\\Type\\\\Definition\\\\WrappingType and 'getInnermostType' will always evaluate to true\\.#"
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\PropertyInfo\\\\\\\\PropertyInfoExtractor' and 'getType' will always evaluate to true\\.#"
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\HttpFoundation\\\\\\\\Request' and 'getContentTypeFormat' will always evaluate to true\\.#"
 		- '#Call to an undefined method Symfony\\Component\\HttpFoundation\\Request::getContentType\(\)\.#'

--- a/src/GraphQl/Action/EntrypointAction.php
+++ b/src/GraphQl/Action/EntrypointAction.php
@@ -125,7 +125,7 @@ final class EntrypointAction
      */
     private function parseData(?string $query, ?string $operationName, array $variables, string $jsonContent): array
     {
-        if (!\is_array($data = json_decode($jsonContent, true, 512, \JSON_ERROR_NONE))) {
+        if (!\is_array($data = json_decode($jsonContent, true))) {
             throw new BadRequestHttpException('GraphQL data is not valid JSON.');
         }
 
@@ -162,7 +162,7 @@ final class EntrypointAction
         [$query, $operationName, $variables] = $this->parseData($query, $operationName, $variables, $operations);
 
         /** @var string $map */
-        if (!\is_array($decodedMap = json_decode($map, true, 512, \JSON_ERROR_NONE))) {
+        if (!\is_array($decodedMap = json_decode($map, true))) {
             throw new BadRequestHttpException('GraphQL multipart request map is not valid JSON.');
         }
 
@@ -218,7 +218,7 @@ final class EntrypointAction
      */
     private function decodeVariables(string $variables): array
     {
-        if (!\is_array($decoded = json_decode($variables, true, 512, \JSON_ERROR_NONE))) {
+        if (!\is_array($decoded = json_decode($variables, true))) {
             throw new BadRequestHttpException('GraphQL variables are not valid JSON.');
         }
 

--- a/src/Laravel/Eloquent/Metadata/Factory/Resource/EloquentResourceCollectionMetadataFactory.php
+++ b/src/Laravel/Eloquent/Metadata/Factory/Resource/EloquentResourceCollectionMetadataFactory.php
@@ -111,7 +111,13 @@ final class EloquentResourceCollectionMetadataFactory implements ResourceMetadat
                 if ($this->partialPatchValidation && $operation instanceof Patch) {
                     $rules = $operation->getRules();
                     if (\is_array($rules)) {
-                        $operation = $operation->withRules($this->replaceRequiredWithSometimes($rules));
+                        $stringKeyedRules = [];
+                        foreach ($rules as $field => $fieldRules) {
+                            if (\is_string($field)) {
+                                $stringKeyedRules[$field] = $fieldRules;
+                            }
+                        }
+                        $operation = $operation->withRules($this->replaceRequiredWithSometimes($stringKeyedRules));
                     }
                 }
 

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -212,7 +212,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         }
 
         if (($filter = $this->getFilterInstance($parameter->getFilter())) && $filter instanceof PropertyAwareFilterInterface) {
-            if (!method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check
+            if (!method_exists($filter, 'getProperties')) { // todo 5.x remove this check
                 trigger_deprecation('api-platform/core', 'In API Platform 5.0 "%s" will implement a method named "getProperties"', PropertyAwareFilterInterface::class);
                 $refl = new \ReflectionClass($filter);
                 $filterProperties = $refl->hasProperty('properties') ? $refl->getProperty('properties')->getValue($filter) : [];

--- a/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
+++ b/src/Symfony/Bundle/Test/ApiTestAssertionsTrait.php
@@ -166,7 +166,7 @@ trait ApiTestAssertionsTrait
     public static function assertMercureUpdateMatchesJsonSchema(Update $update, array $topics, array|object|string $jsonSchema = '', bool $private = false, ?string $id = null, ?string $type = null, ?int $retry = null, string $message = ''): void
     {
         static::assertSame($topics, $update->getTopics(), $message);
-        static::assertThat(json_decode($update->getData(), true, \JSON_THROW_ON_ERROR), new MatchesJsonSchema($jsonSchema), $message);
+        static::assertThat(json_decode($update->getData(), true, flags: \JSON_THROW_ON_ERROR), new MatchesJsonSchema($jsonSchema), $message);
         static::assertSame($private, $update->isPrivate(), $message);
         static::assertSame($id, $update->getId(), $message);
         static::assertSame($type, $update->getType(), $message);


### PR DESCRIPTION
## Summary

PHPStan 2.x / Larastan updates surfaced two real arg-position bugs in `json_decode` calls, one type-contract drift on Eloquent rules, and two stale ignores:

- `GraphQl/Action/EntrypointAction`: `JSON_ERROR_NONE` (an error-code constant from the `json_last_error()` family, value `0`) was passed as `$flags`. Behaviorally a no-op, but semantically wrong. Replaced with default args.
- `Symfony/Bundle/Test/ApiTestAssertionsTrait`: `JSON_THROW_ON_ERROR` was passed as `$depth` (3rd positional arg). Used named arg `flags:` to put it in the correct slot while keeping the default `$depth` of `512`.
- `Laravel/Eloquent/Metadata/Factory/Resource/EloquentResourceCollectionMetadataFactory`: `Metadata::getRules()` returns `mixed`; after `is_array`, PHPStan narrows to `array<int|string, mixed>`, losing the expected `array<string, ...>` shape required by `replaceRequiredWithSometimes`. Filter to string-keyed entries explicitly at the call site so the contract holds for both PHPStan and runtime (Laravel rules with non-string keys would silently break).
- `Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory`: removed an obsolete `@phpstan-ignore-line` that no longer matches any reported error.
- `phpstan.neon.dist`: dropped one unmatched ignore pattern (`getInnermostType`).

## Test plan

- [x] `vendor/bin/phpstan analyse` → `[OK] No errors`
- [x] `cd src/Laravel && ./vendor/bin/phpstan analyse` → `[OK] No errors`
- [ ] CI green