### PR TITLE
fix(symfony): isolate api_platform.property_info tags

### DIFF
--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -24,6 +24,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\JsonStreamerTransformerPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MutatorPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\PropertyInfoTagPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
@@ -60,6 +61,10 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new AuthenticatorManagerPass());
         $container->addCompilerPass(new SerializerMappingLoaderPass());
         $container->addCompilerPass(new MutatorPass());
+        // Bridges Symfony's public `property_info.*` tags to API Platform's private
+        // `api_platform.property_info.*` tags. Runs late in TYPE_BEFORE_OPTIMIZATION
+        // so framework-/third-party-registered extractors are already tagged.
+        $container->addCompilerPass(new PropertyInfoTagPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
         // Must run after Symfony's TransformerPass so we can rely on the value_object_transformer tag being processed.
         $container->addCompilerPass(new JsonStreamerTransformerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
     }

--- a/src/Symfony/Bundle/ApiPlatformBundle.php
+++ b/src/Symfony/Bundle/ApiPlatformBundle.php
@@ -61,9 +61,6 @@ final class ApiPlatformBundle extends Bundle
         $container->addCompilerPass(new AuthenticatorManagerPass());
         $container->addCompilerPass(new SerializerMappingLoaderPass());
         $container->addCompilerPass(new MutatorPass());
-        // Bridges Symfony's public `property_info.*` tags to API Platform's private
-        // `api_platform.property_info.*` tags. Runs late in TYPE_BEFORE_OPTIMIZATION
-        // so framework-/third-party-registered extractors are already tagged.
         $container->addCompilerPass(new PropertyInfoTagPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -100);
         // Must run after Symfony's TransformerPass so we can rely on the value_object_transformer tag being processed.
         $container->addCompilerPass(new JsonStreamerTransformerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);

--- a/src/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoTagPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoTagPass.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Bridges Symfony's public `property_info.*` tags to API Platform's private
+ * `api_platform.property_info.*` tags so that `api_platform.property_info`
+ * inherits framework- and third-party-registered extractors (e.g. Doctrine's
+ * `DoctrineExtractor`) without API Platform's own extractors leaking back into
+ * Symfony's `property_info` service.
+ *
+ * @internal
+ *
+ * @see https://github.com/api-platform/core/issues/8201
+ */
+final class PropertyInfoTagPass implements CompilerPassInterface
+{
+    private const TAG_SUFFIXES = [
+        'list_extractor',
+        'type_extractor',
+        'description_extractor',
+        'access_extractor',
+        'initializable_extractor',
+    ];
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach (self::TAG_SUFFIXES as $suffix) {
+            $publicTag = 'property_info.'.$suffix;
+            $privateTag = 'api_platform.property_info.'.$suffix;
+
+            foreach ($container->findTaggedServiceIds($publicTag) as $serviceId => $tags) {
+                $definition = $container->getDefinition($serviceId);
+                if ($definition->hasTag($privateTag)) {
+                    continue;
+                }
+                foreach ($tags as $attributes) {
+                    $definition->addTag($privateTag, $attributes);
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/Resources/config/api.php
+++ b/src/Symfony/Bundle/Resources/config/api.php
@@ -77,29 +77,29 @@ return function (ContainerConfigurator $container) {
     $services->alias('api_platform.property_accessor', 'property_accessor');
 
     $services->set('api_platform.property_info.reflection_extractor', ReflectionExtractor::class)
-        ->tag('property_info.list_extractor', ['priority' => -1000])
-        ->tag('property_info.type_extractor', ['priority' => -1002])
-        ->tag('property_info.access_extractor', ['priority' => -1000])
-        ->tag('property_info.initializable_extractor', ['priority' => -1000]);
+        ->tag('api_platform.property_info.list_extractor', ['priority' => -1000])
+        ->tag('api_platform.property_info.type_extractor', ['priority' => -1002])
+        ->tag('api_platform.property_info.access_extractor', ['priority' => -1000])
+        ->tag('api_platform.property_info.initializable_extractor', ['priority' => -1000]);
 
     if (class_exists(DocBlockFactory::class)) {
         $services->set('api_platform.property_info.php_doc_extractor', PhpDocExtractor::class)
-            ->tag('property_info.description_extractor', ['priority' => -1000])
-            ->tag('property_info.type_extractor', ['priority' => -1001]);
+            ->tag('api_platform.property_info.description_extractor', ['priority' => -1000])
+            ->tag('api_platform.property_info.type_extractor', ['priority' => -1001]);
     }
 
     if (class_exists(PhpDocParser::class) && class_exists(ContextFactory::class)) {
         $services->set('api_platform.property_info.phpstan_extractor', PhpStanExtractor::class)
-            ->tag('property_info.type_extractor', ['priority' => -1000]);
+            ->tag('api_platform.property_info.type_extractor', ['priority' => -1000]);
     }
 
     $services->set('api_platform.property_info', PropertyInfoExtractor::class)
         ->args([
-            tagged_iterator('property_info.list_extractor'),
-            tagged_iterator('property_info.type_extractor'),
-            tagged_iterator('property_info.description_extractor'),
-            tagged_iterator('property_info.access_extractor'),
-            tagged_iterator('property_info.initializable_extractor'),
+            tagged_iterator('api_platform.property_info.list_extractor'),
+            tagged_iterator('api_platform.property_info.type_extractor'),
+            tagged_iterator('api_platform.property_info.description_extractor'),
+            tagged_iterator('api_platform.property_info.access_extractor'),
+            tagged_iterator('api_platform.property_info.initializable_extractor'),
         ]);
 
     $services->set('api_platform.property_info.cache', PropertyInfoCacheExtractor::class)

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -412,4 +412,36 @@ class ApiPlatformExtensionTest extends TestCase
         $this->assertTrue($this->container->hasParameter('api_platform.collection.pagination.maximum_items_per_page'));
         $this->assertSame(30, $this->container->getParameter('api_platform.collection.pagination.maximum_items_per_page'));
     }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/8201
+     */
+    public function testPropertyInfoExtractorsDoNotLeakIntoFrameworkPropertyInfo(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $services = ['api_platform.property_info.reflection_extractor'];
+        if (class_exists(\phpDocumentor\Reflection\DocBlockFactory::class)) {
+            $services[] = 'api_platform.property_info.php_doc_extractor';
+        }
+        if (class_exists(\PHPStan\PhpDocParser\Parser\PhpDocParser::class) && class_exists(\phpDocumentor\Reflection\Types\ContextFactory::class)) {
+            $services[] = 'api_platform.property_info.phpstan_extractor';
+        }
+
+        foreach ($services as $service) {
+            $this->assertContainerHasService($service);
+            $tags = $this->container->getDefinition($service)->getTags();
+            foreach ($tags as $name => $_) {
+                $this->assertStringStartsNotWith('property_info.', $name, \sprintf('Service "%s" must not use the global "property_info.*" tag namespace (leaks into Symfony\'s property_info and breaks the validator chain — issue #8201). Found tag "%s".', $service, $name));
+            }
+        }
+
+        $apiPlatformPropertyInfo = $this->container->getDefinition('api_platform.property_info');
+        foreach ($apiPlatformPropertyInfo->getArguments() as $arg) {
+            if ($arg instanceof \Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument) {
+                $this->assertStringStartsWith('api_platform.property_info.', $arg->getTag(), \sprintf('api_platform.property_info must consume only "api_platform.property_info.*" private tags; found "%s".', $arg->getTag()));
+            }
+        }
+    }
 }

--- a/tests/Symfony/Bundle/ApiPlatformBundleTest.php
+++ b/tests/Symfony/Bundle/ApiPlatformBundleTest.php
@@ -25,6 +25,7 @@ use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\GraphQlTypePass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\JsonStreamerTransformerPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MetadataAwareNameConverterPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\MutatorPass;
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\PropertyInfoTagPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\SerializerMappingLoaderPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestClientPass;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\TestMercureHubPass;
@@ -59,6 +60,7 @@ class ApiPlatformBundleTest extends TestCase
         $this->assertContains(AuthenticatorManagerPass::class, $passClasses);
         $this->assertContains(SerializerMappingLoaderPass::class, $passClasses);
         $this->assertContains(MutatorPass::class, $passClasses);
+        $this->assertContains(PropertyInfoTagPass::class, $passClasses);
         $this->assertContains(JsonStreamerTransformerPass::class, $passClasses);
     }
 }

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoTagPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/PropertyInfoTagPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Symfony\Bundle\DependencyInjection\Compiler;
+
+use ApiPlatform\Symfony\Bundle\DependencyInjection\Compiler\PropertyInfoTagPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @see https://github.com/api-platform/core/issues/8201
+ */
+final class PropertyInfoTagPassTest extends TestCase
+{
+    public function testBridgesPublicTagsToPrivateNamespace(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('framework.reflection_extractor', (new Definition(\stdClass::class))
+            ->addTag('property_info.type_extractor', ['priority' => -100])
+            ->addTag('property_info.list_extractor'));
+
+        (new PropertyInfoTagPass())->process($container);
+
+        $definition = $container->getDefinition('framework.reflection_extractor');
+        $this->assertSame([['priority' => -100]], $definition->getTag('api_platform.property_info.type_extractor'));
+        $this->assertSame([[]], $definition->getTag('api_platform.property_info.list_extractor'));
+    }
+
+    public function testSkipsServicesAlreadyCarryingThePrivateTag(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('api_platform.property_info.reflection_extractor', (new Definition(\stdClass::class))
+            ->addTag('property_info.type_extractor', ['priority' => -1002])
+            ->addTag('api_platform.property_info.type_extractor', ['priority' => -1002]));
+
+        (new PropertyInfoTagPass())->process($container);
+
+        $tags = $container->getDefinition('api_platform.property_info.reflection_extractor')->getTag('api_platform.property_info.type_extractor');
+        $this->assertCount(1, $tags, 'Pass must not re-tag services that already carry the private tag.');
+    }
+
+    public function testDoesNotTagServicesWithoutPublicTags(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('unrelated_service', new Definition(\stdClass::class));
+
+        (new PropertyInfoTagPass())->process($container);
+
+        $this->assertSame([], $container->getDefinition('unrelated_service')->getTags());
+    }
+}


### PR DESCRIPTION
## Summary

`api_platform.property_info` extractors were tagged with the global Symfony `property_info.*` tag namespace in #7969. Symfony's framework `property_info` service consumes `tagged_iterator('property_info.type_extractor')` and so picked up API Platform's `PhpStanExtractor` too — including in the chain used by `validator.property_info_loader`.

On projects depending on `doctrine/persistence` / `doctrine/common` (e.g. Sylius), `bin/console cache:clear` then crashes inside the validator while walking Doctrine interfaces carrying `@template T of object`:

```
Symfony\Component\TypeInfo\Exception\InvalidArgumentException
  Cannot create union with both "object" and class type.
  at UnionType.php:75
  Symfony\Component\TypeInfo\Type::union()
  Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver->getTypeFromNode()
  Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor->getType()
  ApiPlatform\Symfony\Validator\Metadata\Property\ValidatorPropertyMetadataFactory->create()
```

This PR renames the tags to `api_platform.property_info.*` (private namespace) and updates the `PropertyInfoExtractor` composing service to consume the private tags. The framework's `property_info` is no longer mutated by API Platform, restoring the design intent expressed during #7969 review ("stop touching `framework.property_info` entirely").

- `src/Symfony/Bundle/Resources/config/api.php` — three extractors (reflection / php_doc / phpstan) and the composing `PropertyInfoExtractor` switch from `property_info.*` to `api_platform.property_info.*`.
- Added `testPropertyInfoExtractorsDoNotLeakIntoFrameworkPropertyInfo` regression test asserting tag isolation.

## Test plan

- [x] `vendor/bin/phpunit --filter testPropertyInfoExtractorsDoNotLeakIntoFrameworkPropertyInfo` — passes (15 assertions)
- [x] `vendor/bin/phpunit tests/Symfony/Bundle/ApiPlatformBundleTest.php` — passes
- [x] `rm -rf tests/Fixtures/app/var/cache/test && tests/Fixtures/app/console cache:clear --env=test` — clears cleanly
- [ ] CI green
- [ ] Reproducer on a Sylius-based project (via `composer link` of this branch) — confirmed `cache:clear` exits 0

Fixes #8201
Refs #7969