### PR TITLE
fix(tests): symfony 8.1 compat

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -181,3 +181,13 @@ parameters:
 			identifier: method.notFound
 			paths:
 				- tests/Functional/JsonStreamerTest.php
+
+		# Symfony Console 7.4 added Application::addCommand(); 8.1 removed add(). One branch is unreachable depending on installed version.
+		-
+			message: '#Call to an undefined method Symfony\\Component\\Console\\Application::(add|addCommand)\(\)\.#'
+			path: tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
+			reportUnmatched: false
+		-
+			identifier: function.alreadyNarrowedType
+			path: tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
+			reportUnmatched: false

--- a/src/HttpCache/Tests/State/AddTagsProcessorTest.php
+++ b/src/HttpCache/Tests/State/AddTagsProcessorTest.php
@@ -22,24 +22,16 @@ use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\State\ProcessorInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class AddTagsProcessorTest extends TestCase
 {
     public function testAddTags(): void
     {
         $operation = new Get();
-        $response = $this->createMock(Response::class);
-        $response->method('isCacheable')->willReturn(true);
-        $response->headers = $this->createMock(ResponseHeaderBag::class);
-        $response->headers->expects($this->once())->method('set')->with('Cache-Tags', 'a,b');
-        $request = $this->createMock(Request::class);
-        $request->method('isMethodCacheable')->willReturn(true);
-        $request->attributes = $this->createMock(ParameterBag::class);
-        $request->attributes->method('get')->with('_resources', [])->willReturn(['a', 'b']);
+        $response = new Response('', 200, ['Cache-Control' => 'public, max-age=10']);
+        $request = new Request(attributes: ['_resources' => ['a', 'b']]);
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $decorated->method('process')->willReturn($response);
@@ -47,20 +39,15 @@ class AddTagsProcessorTest extends TestCase
         $iriConverter->expects($this->never())->method('getIriFromResource');
         $processor = new AddTagsProcessor($decorated, $iriConverter);
         $processor->process($response, $operation, [], $context);
+
+        $this->assertSame('a,b', $response->headers->get('Cache-Tags'));
     }
 
     public function testAddTagsCollection(): void
     {
         $operation = new GetCollection(class: \stdClass::class, uriVariables: ['id' => new Link()]);
-        $response = $this->createMock(Response::class);
-        $response->method('isCacheable')->willReturn(true);
-        $response->headers = $this->createMock(ResponseHeaderBag::class);
-        $response->headers->expects($this->once())->method('set')->with('Cache-Tags', 'a,b,/foos/1/bars');
-        $request = $this->createMock(Request::class);
-        $request->method('isMethodCacheable')->willReturn(true);
-        $request->attributes = $this->createMock(ParameterBag::class);
-        $request->attributes->method('get')->with('_resources', [])->willReturn(['a', 'b']);
-        $request->attributes->method('all')->willReturn(['id' => 1]);
+        $response = new Response('', 200, ['Cache-Control' => 'public, max-age=10']);
+        $request = new Request(attributes: ['_resources' => ['a', 'b'], 'id' => 1]);
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $decorated->method('process')->willReturn($response);
@@ -68,19 +55,15 @@ class AddTagsProcessorTest extends TestCase
         $iriConverter->expects($this->once())->method('getIriFromResource')->with(\stdClass::class, UrlGeneratorInterface::ABS_PATH, $operation, ['uri_variables' => ['id' => 1]])->willReturn('/foos/1/bars');
         $processor = new AddTagsProcessor($decorated, $iriConverter);
         $processor->process($response, $operation, [], $context);
+
+        $this->assertSame('a,b,/foos/1/bars', $response->headers->get('Cache-Tags'));
     }
 
     public function testAddTagsWithPurger(): void
     {
         $operation = new Get();
-        $response = $this->createMock(Response::class);
-        $response->method('isCacheable')->willReturn(true);
-        $response->headers = $this->createMock(ResponseHeaderBag::class);
-        $response->headers->expects($this->once())->method('set')->with('Cache-Tags', 'a,b');
-        $request = $this->createMock(Request::class);
-        $request->method('isMethodCacheable')->willReturn(true);
-        $request->attributes = $this->createMock(ParameterBag::class);
-        $request->attributes->method('get')->with('_resources', [])->willReturn(['a', 'b']);
+        $response = new Response('', 200, ['Cache-Control' => 'public, max-age=10']);
+        $request = new Request(attributes: ['_resources' => ['a', 'b']]);
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $decorated->method('process')->willReturn($response);
@@ -90,5 +73,7 @@ class AddTagsProcessorTest extends TestCase
         $purger->expects($this->once())->method('getResponseHeaders')->willReturn(['Cache-Tags' => 'a,b']);
         $processor = new AddTagsProcessor($decorated, $iriConverter, $purger);
         $processor->process($response, $operation, [], $context);
+
+        $this->assertSame('a,b', $response->headers->get('Cache-Tags'));
     }
 }

--- a/src/Hydra/Tests/State/HydraLinkProcessorTest.php
+++ b/src/Hydra/Tests/State/HydraLinkProcessorTest.php
@@ -19,7 +19,6 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\State\ProcessorInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\WebLink\GenericLinkProvider;
 use Symfony\Component\WebLink\Link;
@@ -30,19 +29,16 @@ class HydraLinkProcessorTest extends TestCase
     {
         $data = new \stdClass();
         $operation = new Get(links: [new Link('a', 'b')]);
-        $request = $this->createMock(Request::class);
-        $request->attributes = $this->createMock(ParameterBag::class);
+        $request = new Request();
 
-        $request->attributes->expects($this->once())->method('set')->with('_api_platform_links', $this->callback(function ($linkProvider) {
-            $this->assertInstanceOf(GenericLinkProvider::class, $linkProvider);
-            $this->assertEquals($linkProvider->getLinks(), [new Link('a', 'b'), new Link(ContextBuilder::HYDRA_NS.'apiDocumentation', '/docs')]);
-
-            return true;
-        }));
         $context = ['request' => $request];
         $decorated = $this->createMock(ProcessorInterface::class);
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->once())->method('generate')->with('api_doc', ['_format' => 'jsonld'], UrlGeneratorInterface::ABS_URL)->willReturn('/docs');
         (new HydraLinkProcessor($decorated, $urlGenerator))->process($data, $operation, [], $context);
+
+        $linkProvider = $request->attributes->get('_api_platform_links');
+        $this->assertInstanceOf(GenericLinkProvider::class, $linkProvider);
+        $this->assertEquals([new Link('a', 'b'), new Link(ContextBuilder::HYDRA_NS.'apiDocumentation', '/docs')], $linkProvider->getLinks());
     }
 }

--- a/src/JsonApi/Tests/State/JsonApiProviderTest.php
+++ b/src/JsonApi/Tests/State/JsonApiProviderTest.php
@@ -17,25 +17,22 @@ use ApiPlatform\JsonApi\State\JsonApiProvider;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\State\ProviderInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\InputBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 
 class JsonApiProviderTest extends TestCase
 {
     public function testProvide(): void
     {
-        $request = $this->createMock(Request::class);
-        $request->expects($this->once())->method('getRequestFormat')->willReturn('jsonapi');
-        $request->attributes = $this->createMock(ParameterBag::class);
-        $request->attributes->expects($this->once())->method('get')->with('_api_filters', [])->willReturn([]);
-        $request->attributes->method('set')->with($this->logicalOr('_api_filter_property', '_api_included', '_api_filters'), $this->logicalOr(['id', 'name', 'dummyFloat', 'relatedDummy' => ['id', 'name']], ['relatedDummy'], []));
-        $request->query = new InputBag(['fields' => ['dummy' => 'id,name,dummyFloat', 'relatedDummy' => 'id,name'], 'include' => 'relatedDummy,foo']);
+        $request = new Request(query: ['fields' => ['dummy' => 'id,name,dummyFloat', 'relatedDummy' => 'id,name'], 'include' => 'relatedDummy,foo']);
+        $request->setRequestFormat('jsonapi');
         $operation = new Get(class: \stdClass::class, shortName: 'dummy');
         $context = ['request' => $request];
         $decorated = $this->createMock(ProviderInterface::class);
         $provider = new JsonApiProvider($decorated);
         $provider->provide($operation, [], $context);
+
+        $this->assertSame(['id', 'name', 'dummyFloat', 'relatedDummy' => ['id', 'name']], $request->attributes->get('_api_filter_property'));
+        $this->assertSame(['relatedDummy'], $request->attributes->get('_api_included'));
     }
 
     public function testProvideMergesFlatPaginationWithBracketFilter(): void

--- a/src/State/Tests/Provider/SecurityParameterProviderTest.php
+++ b/src/State/Tests/Provider/SecurityParameterProviderTest.php
@@ -19,7 +19,6 @@ use ApiPlatform\Metadata\ResourceAccessCheckerInterface;
 use ApiPlatform\State\Provider\SecurityParameterProvider;
 use ApiPlatform\State\ProviderInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
@@ -34,10 +33,7 @@ final class SecurityParameterProviderTest extends TestCase
         ], class: \stdClass::class);
         $decorated = $this->createMock(ProviderInterface::class);
         $decorated->method('provide')->willReturn($obj);
-        $request = $this->createMock(Request::class);
-        $parameterBag = new ParameterBag();
-        $request->attributes = $parameterBag;
-        $request->attributes->set('bar', $barObj);
+        $request = new Request(attributes: ['bar' => $barObj]);
         $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
         $resourceAccessChecker->expects($this->once())->method('isGranted')->with('Bar', 'is_granted("some_voter", "bar")', ['object' => $obj, 'previous_object' => null, 'request' => $request, 'bar' => $barObj, 'barId' => 1, 'operation' => $operation])->willReturn(true);
         $accessChecker = new SecurityParameterProvider($decorated, $resourceAccessChecker);
@@ -55,10 +51,7 @@ final class SecurityParameterProviderTest extends TestCase
         ], class: \stdClass::class);
         $decorated = $this->createMock(ProviderInterface::class);
         $decorated->method('provide')->willReturn($obj);
-        $request = $this->createMock(Request::class);
-        $parameterBag = new ParameterBag();
-        $request->attributes = $parameterBag;
-        $request->attributes->set('bar', $barObj);
+        $request = new Request(attributes: ['bar' => $barObj]);
         $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
         $resourceAccessChecker->expects($this->once())->method('isGranted')->with('Bar', 'is_granted("some_voter", "bar")', ['object' => $obj, 'previous_object' => null, 'request' => $request, 'bar' => $barObj, 'barId' => 1, 'operation' => $operation])->willReturn(false);
         $accessChecker = new SecurityParameterProvider($decorated, $resourceAccessChecker);
@@ -77,10 +70,7 @@ final class SecurityParameterProviderTest extends TestCase
         ], class: \stdClass::class);
         $decorated = $this->createMock(ProviderInterface::class);
         $decorated->method('provide')->willReturn($obj);
-        $request = $this->createMock(Request::class);
-        $parameterBag = new ParameterBag();
-        $request->attributes = $parameterBag;
-        $request->attributes->set('bar', $barObj);
+        $request = new Request(attributes: ['bar' => $barObj]);
         $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
         $resourceAccessChecker->expects($this->once())->method('isGranted')->with('Bar', 'is_granted("some_voter", "bar")', ['object' => $obj, 'previous_object' => null, 'request' => $request, 'bar' => $barObj, 'barId' => 1, 'operation' => $operation])->willReturn(false);
         $accessChecker = new SecurityParameterProvider($decorated, $resourceAccessChecker);

--- a/tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
+++ b/tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
@@ -37,7 +37,7 @@ class DebugResourceCommandTest extends TestCase
         $application->setCatchExceptions(false);
         $application->setAutoExit(false);
 
-        if (method_exists($application, 'addCommand')) { // @phpstan-ignore-line
+        if (method_exists($application, 'addCommand')) {
             $application->addCommand(new DebugResourceCommand(new AttributesResourceMetadataCollectionFactory(), new VarCloner(), $dumper ?? new CliDumper()));
         } else {
             $application->add(new DebugResourceCommand(new AttributesResourceMetadataCollectionFactory(), new VarCloner(), $dumper ?? new CliDumper()));

--- a/tests/Symfony/State/MercureLinkProcessorTest.php
+++ b/tests/Symfony/State/MercureLinkProcessorTest.php
@@ -17,7 +17,6 @@ use ApiPlatform\Metadata\Get;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\Symfony\State\MercureLinkProcessor;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mercure\Discovery;
 use Symfony\Component\Mercure\HubInterface;
@@ -28,8 +27,7 @@ class MercureLinkProcessorTest extends TestCase
     public function testProcess(): void
     {
         $obj = new \stdClass();
-        $request = $this->createMock(Request::class);
-        $request->attributes = $this->createMock(ParameterBag::class);
+        $request = new Request();
         $decorated = $this->createMock(ProcessorInterface::class);
         $decorated->expects($this->once())->method('process');
         $discovery = new Discovery(new HubRegistry($this->createMock(HubInterface::class), ['example.com' => $this->createMock(HubInterface::class)]));


### PR DESCRIPTION
## Summary

Restores HttpCache / Hydra / JsonApi / Symfony Bundle PHPUnit jobs and PHPStan against Symfony 8.1.0:

- `ResponseHeaderBag` and `ParameterBag` became `final` in Symfony HttpFoundation 8.1.0. `createMock()` on a final class triggers a fatal in PHPUnit 12. Swap the mocks in `AddTagsProcessorTest`, `HydraLinkProcessorTest`, `JsonApiProviderTest` and `MercureLinkProcessorTest` for real instances and assert on bag state after the call. Behaviour identical, assertions tightened (now verify the actual stored value instead of `expects(...)->method('set')`).
- Symfony Console 8.1.0 removed `Application::add()`. The fallback branch in `DebugResourceCommandTest::getCommandTester()` is unreachable on Symfony ≥ 7.4 but must be kept for Symfony 6.4 support. Add a targeted `phpstan.neon.dist` ignore (`reportUnmatched: false`) so analysis passes on both Symfony 6.4 and 8.1.

## Test plan

- [x] `vendor/bin/phpunit src/HttpCache/Tests src/Hydra/Tests src/JsonApi/Tests tests/Symfony/Bundle/Command/DebugResourceCommandTest.php tests/Symfony/State/MercureLinkProcessorTest.php` — green locally on Symfony 7.4
- [x] `vendor/bin/phpstan analyse` — no errors
- [ ] CI green on Symfony 8.1.0 across the four PHPUnit components (`http-cache`, `hydra`, `json-api`, `state`) and the PHPStan job