### PR TITLE
ci: bump actions/setup-node to v6 for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
           composer global config allow-plugins.soyuka/pmu true --no-interaction
           composer global link .
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Install Redocly CLI


### PR DESCRIPTION
## Summary

Bump `actions/setup-node@v4` → `@v6` in `ci.yml`. Only outdated `setup-node` instance — the other one in the same workflow is already on v6.

## Context

GitHub Actions emits a Node 20 deprecation warning. Node 20 will be forced to Node 24 by default on **June 2nd, 2026** and removed from runners on **September 16th, 2026** (see the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

Inspected `action.yml` for every action used in the repo. `setup-node@v4` is the only remaining Node 20 runtime on `4.3`. Other actions (`checkout@v6`, `cache@v5`, `upload-artifact@v6`) are already on Node 24; `codecov-action@v5` is a composite action.

A follow-up PR on `main` will bump `stale.yml` (`checkout@v4`, `github-script@v7`) which does not exist on this branch.

## Test plan

- [ ] CI green on this PR