### PR TITLE
ci(stale): bump checkout to v6 and github-script to v8

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,8 +25,8 @@ jobs:
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
       MAX_ACTIONS_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.max_actions || '25' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/github-script@v7
+      - uses: actions/checkout@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             const script = require('./.github/scripts/stale.js');


### PR DESCRIPTION
## Summary

Bump `actions/checkout@v4` → `@v6` and `actions/github-script@v7` → `@v8` in `.github/workflows/stale.yml`.

## Context

GitHub Actions emits a Node 20 deprecation warning when the workflow runs (visible in [the latest run](https://github.com/api-platform/core/actions/runs/26639503652/job/78508421936)). Node 20 will be forced to Node 24 by default on **June 2nd, 2026** and removed from runners on **September 16th, 2026** (see the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

`stale.yml` was the last workflow on `main` still pinned to `checkout@v4` / `github-script@v7`. Everything else either runs on Node 24 (`checkout@v6`, `cache@v5`, `upload-artifact@v6`) or has no Node runtime (`codecov-action@v5`, composite).

The companion `actions/setup-node@v4` → `@v6` bump is on #8212 against `4.3` and will reach `main` through the usual merge-up.

## Test plan

- [ ] Trigger `Mark stale issues` workflow from this branch (`workflow_dispatch`, `dry_run=true`) and verify no Node 20 deprecation warning in the job summary.