### PR TITLE
fix(jsonapi): keep flat custom params with flat page (#8216)

### DIFF
--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\JsonApi\State;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
+use ApiPlatform\State\Util\RequestParser;
 
 final class JsonApiProvider implements ProviderInterface
 {
@@ -87,6 +88,12 @@ final class JsonApiProvider implements ProviderInterface
         }
 
         if ($filters) {
+            // ReadProvider skips its raw-query fallback when _api_filters is set,
+            // so preserve flat custom params here too. JSON:API transforms win.
+            $queryString = RequestParser::getQueryString($request);
+            $rawParams = $queryString ? RequestParser::parseRequestParams($queryString) : [];
+            $filters = array_replace($rawParams, $filters);
+
             $request->attributes->set('_api_filters', $filters);
         }
 

--- a/src/JsonApi/State/JsonApiProvider.php
+++ b/src/JsonApi/State/JsonApiProvider.php
@@ -90,8 +90,12 @@ final class JsonApiProvider implements ProviderInterface
         if ($filters) {
             // ReadProvider skips its raw-query fallback when _api_filters is set,
             // so preserve flat custom params here too. JSON:API transforms win.
-            $queryString = RequestParser::getQueryString($request);
-            $rawParams = $queryString ? RequestParser::parseRequestParams($queryString) : [];
+            $rawParams = $request->attributes->get('_api_query_parameters');
+            if (null === $rawParams) {
+                $queryString = RequestParser::getQueryString($request);
+                $rawParams = $queryString ? RequestParser::parseRequestParams($queryString) : [];
+                $request->attributes->set('_api_query_parameters', $rawParams);
+            }
             $filters = array_replace($rawParams, $filters);
 
             $request->attributes->set('_api_filters', $filters);

--- a/src/JsonApi/Tests/State/JsonApiProviderTest.php
+++ b/src/JsonApi/Tests/State/JsonApiProviderTest.php
@@ -77,4 +77,25 @@ class JsonApiProviderTest extends TestCase
         $this->assertSame(['distance' => 'asc'], $filters['order'] ?? null);
         $this->assertSame('1', $filters['page'] ?? null);
     }
+
+    // _api_query_parameters set by an earlier listener / ParameterProvider must be reused.
+    public function testProvideHonoursPrePopulatedApiQueryParameters(): void
+    {
+        $request = Request::create('/sessions?page=1');
+        $request->setRequestFormat('jsonapi');
+        $request->attributes->set('_api_query_parameters', ['custom_override' => 'yes', 'page' => '1']);
+
+        $operation = new Get(class: \stdClass::class, shortName: 'dummy');
+        $context = ['request' => $request];
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->with($operation, [], $context);
+
+        $provider = new JsonApiProvider($decorated);
+        $provider->provide($operation, [], $context);
+
+        $filters = $request->attributes->get('_api_filters');
+
+        $this->assertSame('yes', $filters['custom_override'] ?? null);
+        $this->assertSame('1', $filters['page'] ?? null);
+    }
 }

--- a/src/JsonApi/Tests/State/JsonApiProviderTest.php
+++ b/src/JsonApi/Tests/State/JsonApiProviderTest.php
@@ -55,4 +55,26 @@ class JsonApiProviderTest extends TestCase
             'pagination' => 'true',
         ], $request->attributes->get('_api_filters'));
     }
+
+    // #8216: flat custom params must survive when _api_filters is pre-set by JSON:API.
+    public function testProvidePreservesFlatCustomQueryParamsWithoutBracketFilter(): void
+    {
+        $request = Request::create('/sessions?city_id=3152&order[distance]=asc&page=1');
+        $request->setRequestFormat('jsonapi');
+
+        $operation = new Get(class: \stdClass::class, shortName: 'dummy');
+        $context = ['request' => $request];
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->expects($this->once())->method('provide')->with($operation, [], $context);
+
+        $provider = new JsonApiProvider($decorated);
+        $provider->provide($operation, [], $context);
+
+        $filters = $request->attributes->get('_api_filters');
+
+        $this->assertIsArray($filters);
+        $this->assertSame('3152', $filters['city_id'] ?? null);
+        $this->assertSame(['distance' => 'asc'], $filters['order'] ?? null);
+        $this->assertSame('1', $filters['page'] ?? null);
+    }
 }

--- a/tests/Functional/JsonApiFlatPaginationTest.php
+++ b/tests/Functional/JsonApiFlatPaginationTest.php
@@ -70,6 +70,26 @@ final class JsonApiFlatPaginationTest extends ApiTestCase
         $this->assertSame(5, $data['meta']['totalItems'] ?? null);
     }
 
+    // #8216: flat filter param combined with flat page must still drive filtering.
+    public function testFlatCustomParamWithFlatPagePreservesFilter(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('Not tested with mongodb.');
+        }
+
+        $response = self::createClient()->request('GET', '/dummies?name=foo&page=1', [
+            'headers' => ['Accept' => 'application/vnd.api+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+
+        $data = $response->toArray();
+
+        $this->assertSame(1, $data['meta']['currentPage'] ?? null);
+        $this->assertSame(5, $data['meta']['totalItems'] ?? null);
+    }
+
     private function loadFixtures(): void
     {
         $manager = $this->getManager();
@@ -79,6 +99,10 @@ final class JsonApiFlatPaginationTest extends ApiTestCase
             $dummy->setName('foo #'.$i);
             $manager->persist($dummy);
         }
+
+        $bar = new Dummy();
+        $bar->setName('bar');
+        $manager->persist($bar);
 
         $manager->flush();
     }


### PR DESCRIPTION
## Summary

Fixes #8216 — regression introduced in #8193.

`JsonApiProvider` was setting `_api_filters` from flat pagination params
(`page`, `itemsPerPage`, `pagination`, `partial`) even when no `filter[...]`
bracket was present. `ReadProvider:63-65` short-circuits its raw query
fallback (`RequestParser::parseRequestParams`) whenever `_api_filters` is
non-null, so any flat custom filter (`?city_id=3&order[distance]=asc`)
combined with `page=N` was silently dropped.

## Fix

Parse the raw query string in `JsonApiProvider` and merge it as a base
layer under the existing JSON:API transformations:

```php
$queryString = RequestParser::getQueryString($request);
$rawParams = $queryString ? RequestParser::parseRequestParams($queryString) : [];
$filters = array_replace($rawParams, $filters);
```

JSON:API transformations (`sort` → `order`, `filter[foo]` → `foo`, flat
pagination keys) still take precedence via `array_replace`.

## Tests

- Unit (`JsonApiProviderTest::testProvidePreservesFlatCustomQueryParamsWithoutBracketFilter`)
  asserts `_api_filters` contains `city_id`, `order`, and `page` after the
  provider runs.
- Functional (`JsonApiFlatPaginationTest::testFlatCustomParamWithFlatPagePreservesFilter`)
  hits `/dummies?name=foo&page=1` w/ `Accept: application/vnd.api+json` and
  asserts the SearchFilter is applied (`totalItems === 5` out of 6 fixtures).
  Verified the functional test fails on the prior code (returns 6).

## Test plan

- [x] `vendor/bin/phpunit src/JsonApi/Tests/State/JsonApiProviderTest.php`
- [x] `vendor/bin/phpunit tests/Functional/JsonApiFlatPaginationTest.php`
- [x] Confirmed functional test fails without the patch (asserts 6 === 5).