### PR TITLE
fix(state): omit Content-Type when response has no body

### DIFF
--- a/src/State/Util/HttpResponseHeadersTrait.php
+++ b/src/State/Util/HttpResponseHeadersTrait.php
@@ -52,12 +52,25 @@ trait HttpResponseHeadersTrait
     private function getHeaders(Request $request, HttpOperation $operation, array $context): array
     {
         $status = $this->getStatus($request, $operation, $context);
+        $method = $request->getMethod();
+        $output = $operation->getOutput();
+        $outputMetadata = $output ?? ['class' => $operation->getClass()];
+        $hasOutput = \is_array($outputMetadata) && \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'];
+        $outputExplicitlyDisabled = \is_array($output) && \array_key_exists('class', $output) && null === $output['class'];
+        // RFC 7230 §3.3.2 / §3.3.3: 204, 205 and 304 responses MUST NOT include a payload body,
+        // and a sender MUST NOT generate a Content-Type field for a message without a body.
+        $isBodylessStatus = \in_array($status, [Response::HTTP_NO_CONTENT, Response::HTTP_RESET_CONTENT, Response::HTTP_NOT_MODIFIED], true);
+        $hasBody = !$outputExplicitlyDisabled && !$isBodylessStatus;
+
         $headers = [
-            'Content-Type' => \sprintf('%s; charset=utf-8', $request->getMimeType($request->getRequestFormat())),
             'Vary' => 'Accept',
             'X-Content-Type-Options' => 'nosniff',
             'X-Frame-Options' => 'deny',
         ];
+
+        if ($hasBody) {
+            $headers['Content-Type'] = \sprintf('%s; charset=utf-8', $request->getMimeType($request->getRequestFormat()));
+        }
 
         $exception = $request->attributes->get('exception');
         if (($exception instanceof HttpExceptionInterface || $exception instanceof SymfonyHttpExceptionInterface) && $exceptionHeaders = $exception->getHeaders()) {
@@ -76,10 +89,7 @@ trait HttpResponseHeadersTrait
             $headers['Accept-Patch'] = $acceptPatch;
         }
 
-        $method = $request->getMethod();
         $originalData = $context['original_data'] ?? null;
-        $outputMetadata = $operation->getOutput() ?? ['class' => $operation->getClass()];
-        $hasOutput = \is_array($outputMetadata) && \array_key_exists('class', $outputMetadata) && null !== $outputMetadata['class'];
         $hasData = !$hasOutput ? false : ($this->resourceClassResolver && $originalData && \is_object($originalData) && $this->resourceClassResolver->isResourceClass($this->getObjectClass($originalData)));
 
         if ($hasData) {

--- a/tests/State/RespondProcessorTest.php
+++ b/tests/State/RespondProcessorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\State;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
@@ -160,6 +161,81 @@ class RespondProcessorTest extends TestCase
 
         $this->assertSame('OPTIONS, HEAD, GET, POST', $response->headers->get('Allow'));
         $this->assertSame('application/ld+json', $response->headers->get('Accept-Post'));
+    }
+
+    public function testDoesNotSetContentTypeWhenOutputIsFalse(): void
+    {
+        $operation = new Post(class: Employee::class, output: ['class' => null], status: 204);
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Employee::class)->willReturn(true);
+
+        $respondProcessor = new RespondProcessor(null, $resourceClassResolver->reveal());
+
+        $req = new Request();
+        $req->setMethod('POST');
+        $response = $respondProcessor->process(null, $operation, context: [
+            'request' => $req,
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
+    public function testDoesNotSetContentTypeWhenOutputIsFalseWithCreatedStatus(): void
+    {
+        $operation = new Post(class: Employee::class, output: ['class' => null], status: 201);
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Employee::class)->willReturn(true);
+
+        $respondProcessor = new RespondProcessor(null, $resourceClassResolver->reveal());
+
+        $req = new Request();
+        $req->setMethod('POST');
+        $response = $respondProcessor->process(null, $operation, context: [
+            'request' => $req,
+            'original_data' => new Employee(),
+        ]);
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
+    public function testDoesNotSetContentTypeOnBodylessStatusCodes(): void
+    {
+        $operation = new Delete(class: Employee::class);
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Employee::class)->willReturn(true);
+
+        $respondProcessor = new RespondProcessor(null, $resourceClassResolver->reveal());
+
+        $req = new Request();
+        $req->setMethod('DELETE');
+        $response = $respondProcessor->process(null, $operation, context: [
+            'request' => $req,
+        ]);
+
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('Content-Type'));
+    }
+
+    public function testKeepsContentTypeForOperationWithoutOutputAndClass(): void
+    {
+        $operation = new Get(outputFormats: ['jsonld' => ['application/ld+json']], serialize: false, read: true);
+
+        $respondProcessor = new RespondProcessor();
+
+        $req = new Request();
+        $req->setRequestFormat('jsonld');
+        $response = $respondProcessor->process('{"@context":{}}', $operation, context: [
+            'request' => $req,
+        ]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/ld+json; charset=utf-8', $response->headers->get('Content-Type'));
     }
 
     public function testDoesNotAddLinkedDataPlatformHeadersWithoutFactory(): void


### PR DESCRIPTION
Fixes #2929.

## Summary

Per [RFC 7230 §3.3.2](https://tools.ietf.org/html/rfc7230#section-3.3.2): _"A sender MUST NOT generate a Content-Type header field in a message that does not contain a payload body."_

Per [RFC 7230 §3.3.3](https://tools.ietf.org/html/rfc7230#section-3.3.3): responses with status `204 No Content`, `205 Reset Content`, and `304 Not Modified` MUST NOT include a payload body.

`HttpResponseHeadersTrait::getHeaders()` was unconditionally setting `Content-Type` even when the operation produced no body (e.g. `output: false`) or when the status code mandates an empty body (DELETE → 204).

## Change

Gate the `Content-Type` header behind:

```php
$hasBody = $hasOutput && !\in_array($status, [
    Response::HTTP_NO_CONTENT,
    Response::HTTP_RESET_CONTENT,
    Response::HTTP_NOT_MODIFIED,
], true);
```

Where `$hasOutput` is `false` when `output['class'] === null` (i.e. `output: false` was passed to the operation).

## Tests

Three new unit tests in `RespondProcessorTest`:

- `testDoesNotSetContentTypeWhenOutputIsFalse` — POST with `output: false` + 204
- `testDoesNotSetContentTypeWhenOutputIsFalseWithCreatedStatus` — POST with `output: false` + 201
- `testDoesNotSetContentTypeOnBodylessStatusCodes` — DELETE (default 204)

## Note on Symfony `Response::prepare()`

Symfony's `Response::prepare()` automatically re-adds a `Content-Type` header derived from the request format for all responses whose status is **not** `204` or `304` (see `Response::isEmpty()`). For the typical `output: false` flow (status defaults to `204` via `InputOutputResourceMetadataCollectionFactory`), Symfony's strip aligns with this fix and the header is fully omitted on the wire.

For the edge case where a user sets `output: false` together with a status that Symfony does not treat as empty (e.g. `201`, `202`), Symfony will re-add `Content-Type`. A follow-up tied to #7875 (which introduces `ResponseHeaderParameter` for declarative header customization) can add a `kernel.response` listener that honours the no-body intent regardless of status.