### PR TITLE
fix(metadata): apply YAML/XML attributes to virtual (method-backed) properties

### DIFF
--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -50,10 +50,7 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
             }
         }
 
-        if (
-            !property_exists($resourceClass, $property) && !interface_exists($resourceClass)
-            || null === ($propertyMetadata = $this->extractor->getProperties()[$resourceClass][$property] ?? null)
-        ) {
+        if (null === ($propertyMetadata = $this->extractor->getProperties()[$resourceClass][$property] ?? null)) {
             return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
         }
 

--- a/src/Metadata/Tests/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
+++ b/src/Metadata/Tests/Property/Factory/ExtractorPropertyMetadataFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Property\Factory;
+
+use ApiPlatform\Metadata\Extractor\PropertyExtractorInterface;
+use ApiPlatform\Metadata\Property\Factory\ExtractorPropertyMetadataFactory;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\Comment;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+final class ExtractorPropertyMetadataFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testCreateVirtualPropertyFromExtractor(): void
+    {
+        $extractorProphecy = $this->prophesize(PropertyExtractorInterface::class);
+        $extractorProphecy->getProperties()->willReturn([
+            Comment::class => [
+                'admin' => [
+                    'security' => 'user.isAdmin() === true',
+                ],
+            ],
+        ]);
+
+        $factory = new ExtractorPropertyMetadataFactory($extractorProphecy->reveal());
+        $metadata = $factory->create(Comment::class, 'admin');
+
+        self::assertSame('user.isAdmin() === true', $metadata->getSecurity());
+    }
+}


### PR DESCRIPTION
## Summary

`ExtractorPropertyMetadataFactory::create()` short-circuited to `handleNotFound()` whenever the resource class did not declare a real PHP property matching the requested name:

```php
if (
    !property_exists($resourceClass, $property) && !interface_exists($resourceClass)
    || null === ($propertyMetadata = $this->extractor->getProperties()[$resourceClass][$property] ?? null)
) {
    return $this->handleNotFound($parentPropertyMetadata, $resourceClass, $property);
}
```

YAML and XML mappings can legitimately declare virtual properties backed by methods — e.g. `admin` mapped to `isAdmin()` — and `ExtractorPropertyNameCollectionFactory` already surfaces those names. The guard silently dropped configured metadata (security expressions, descriptions, IRIs, …) for any such property. PHP `#[ApiProperty]` attributes worked because they bypass this factory.

The remaining null-coalesce on the extractor lookup already provides the correct fallback to `handleNotFound()` when the property is not in the extracted mapping, so the `property_exists` clause is redundant for real PHP properties and incorrect for virtual ones.

Truth table after the change:

| Real PHP prop | Declared in YAML/XML | Before | After |
|---|---|---|---|
| yes | yes | extractor | extractor |
| yes | no | handleNotFound | handleNotFound (via `?? null`) |
| no  | yes | **handleNotFound (bug)** | **extractor (fix)** |
| no  | no  | handleNotFound | handleNotFound (via `?? null`) |

Only the third row changes.

Closes #8178

## Test plan

- [x] New unit test `ExtractorPropertyMetadataFactoryTest::testCreateVirtualPropertyFromExtractor` — fails before the fix with `PropertyNotFoundException: Property "admin" of the resource class … not found.`, green after.
- [x] `src/Metadata/Tests/Property` suite green (37/37).
- [x] `PropertyMetadataCompatibilityTest` (YAML + XML) still green.