### PR TITLE
fix(openapi): emit Draft 4 boolean exclusive bounds for spec 3.0.0

### DIFF
--- a/src/JsonSchema/BackwardCompatibleSchemaFactory.php
+++ b/src/JsonSchema/BackwardCompatibleSchemaFactory.php
@@ -52,11 +52,11 @@ final class BackwardCompatibleSchemaFactory implements SchemaFactoryInterface, S
                         continue;
                     }
 
-                    if (isset($property['exclusiveMinimum'])) {
+                    if (isset($property['exclusiveMinimum']) && !\is_bool($property['exclusiveMinimum'])) {
                         $property['minimum'] = $property['exclusiveMinimum'];
                         $property['exclusiveMinimum'] = true;
                     }
-                    if (isset($property['exclusiveMaximum'])) {
+                    if (isset($property['exclusiveMaximum']) && !\is_bool($property['exclusiveMaximum'])) {
                         $property['maximum'] = $property['exclusiveMaximum'];
                         $property['exclusiveMaximum'] = true;
                     }

--- a/src/OpenApi/Command/OpenApiCommand.php
+++ b/src/OpenApi/Command/OpenApiCommand.php
@@ -56,10 +56,14 @@ final class OpenApiCommand extends Command
     {
         $filesystem = new Filesystem();
         $io = new SymfonyStyle($input, $output);
+        $specVersion = $input->getOption('spec-version');
         $data = $this->normalizer->normalize(
-            $this->openApiFactory->__invoke(['filter_tags' => $input->getOption('filter-tags')]),
+            $this->openApiFactory->__invoke([
+                'filter_tags' => $input->getOption('filter-tags'),
+                'spec_version' => $specVersion,
+            ]),
             'json',
-            ['spec_version' => $input->getOption('spec-version')]
+            ['spec_version' => $specVersion]
         );
 
         if ($input->getOption('yaml') && !class_exists(Yaml::class)) {

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\OpenApi\Factory;
 
+use ApiPlatform\JsonSchema\BackwardCompatibleSchemaFactory;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Metadata\ApiResource;
@@ -167,6 +168,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             return;
         }
 
+        $schemaSerializerContext = '3.0.0' === ($context['spec_version'] ?? null)
+            ? [BackwardCompatibleSchemaFactory::SCHEMA_DRAFT4_VERSION => true]
+            : null;
+
         $defaultError = $this->getErrorResource($this->openApiOptions->getErrorResourceClass() ?? ApiResourceError::class);
         $defaultValidationError = $this->getErrorResource($this->openApiOptions->getValidationErrorResourceClass() ?? ValidationException::class, 422, 'Unprocessable entity');
 
@@ -268,7 +273,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
 
             foreach ($responseMimeTypes as $operationFormat) {
                 $operationOutputSchema = null;
-                $operationOutputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_OUTPUT, $operation, $schema, null, $forceSchemaCollection);
+                $operationOutputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_OUTPUT, $operation, $schema, $schemaSerializerContext, $forceSchemaCollection);
                 $this->appendSchemaDefinitions($schemas, $operationOutputSchema->getDefinitions());
 
                 $operationOutputSchemas[$operationFormat] = $operationOutputSchema;
@@ -409,7 +414,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     $errorOperations[$error] = $this->getErrorResource($error);
                 }
 
-                $openapiOperation = $this->addOperationErrors($openapiOperation, $errorOperations, $resourceMetadataCollection, $schema, $schemas, $operation);
+                $openapiOperation = $this->addOperationErrors($openapiOperation, $errorOperations, $resourceMetadataCollection, $schema, $schemas, $operation, $schemaSerializerContext);
             }
 
             if ($overrideResponses || !$existingResponses) {
@@ -427,7 +432,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                             $openapiOperation = $this->addOperationErrors($openapiOperation, [
                                 $defaultError->withStatus(400)->withDescription('Invalid input'),
                                 $defaultValidationError,
-                            ], $resourceMetadataCollection, $schema, $schemas, $operation);
+                            ], $resourceMetadataCollection, $schema, $schemas, $operation, $schemaSerializerContext);
                         }
                         break;
                     case 'PATCH':
@@ -439,7 +444,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                             $openapiOperation = $this->addOperationErrors($openapiOperation, [
                                 $defaultError->withStatus(400)->withDescription('Invalid input'),
                                 $defaultValidationError,
-                            ], $resourceMetadataCollection, $schema, $schemas, $operation);
+                            ], $resourceMetadataCollection, $schema, $schemas, $operation, $schemaSerializerContext);
                         }
                         break;
                     case 'DELETE':
@@ -452,13 +457,13 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             if ($overrideResponses && !isset($existingResponses[403]) && $operation->getSecurity()) {
                 $openapiOperation = $this->addOperationErrors($openapiOperation, [
                     $defaultError->withStatus(403)->withDescription('Forbidden'),
-                ], $resourceMetadataCollection, $schema, $schemas, $operation);
+                ], $resourceMetadataCollection, $schema, $schemas, $operation, $schemaSerializerContext);
             }
 
             if ($overrideResponses && !$operation instanceof CollectionOperationInterface && 'POST' !== $operation->getMethod() && !isset($existingResponses[404]) && null === $errors) {
                 $openapiOperation = $this->addOperationErrors($openapiOperation, [
                     $defaultError->withStatus(404)->withDescription('Not found'),
-                ], $resourceMetadataCollection, $schema, $schemas, $operation);
+                ], $resourceMetadataCollection, $schema, $schemas, $operation, $schemaSerializerContext);
             }
 
             if (!$openapiOperation->getResponses()) {
@@ -474,7 +479,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     $operationInputSchemas = [];
                     foreach ($requestMimeTypes as $operationFormat) {
                         $operationInputSchema = null;
-                        $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, null, $forceSchemaCollection);
+                        $operationInputSchema = $this->jsonSchemaFactory->buildSchema($resourceClass, $operationFormat, Schema::TYPE_INPUT, $operation, $schema, $schemaSerializerContext, $forceSchemaCollection);
                         $this->appendSchemaDefinitions($schemas, $operationInputSchema->getDefinitions());
 
                         $operationInputSchemas[$operationFormat] = $operationInputSchema;
@@ -997,6 +1002,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
         Schema $schema,
         \ArrayObject $schemas,
         HttpOperation $originalOperation,
+        ?array $serializerContext = null,
     ): Operation {
         foreach ($errors as $errorResource) {
             $responseMimeTypes = $this->flattenMimeTypes($errorResource->getOutputFormats() ?: $this->errorFormats);
@@ -1017,7 +1023,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
             $operationErrorSchemas = [];
             foreach ($responseMimeTypes as $operationFormat) {
                 $operationErrorSchema = null;
-                $operationErrorSchema = $this->jsonSchemaFactory->buildSchema($errorResource->getClass(), $operationFormat, Schema::TYPE_OUTPUT, null, $schema);
+                $operationErrorSchema = $this->jsonSchemaFactory->buildSchema($errorResource->getClass(), $operationFormat, Schema::TYPE_OUTPUT, null, $schema, $serializerContext);
                 $this->appendSchemaDefinitions($schemas, $operationErrorSchema->getDefinitions());
                 $operationErrorSchemas[$operationFormat] = $operationErrorSchema;
             }

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -35,6 +35,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyCar;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyFriend;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyTableInheritance;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyTableInheritanceChild;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6041\NumericValidated;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\JsonSchemaResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\JsonSchemaResourceRelated;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NoCollectionDummy;
@@ -99,6 +100,7 @@ class OpenApiTest extends ApiTestCase
             OverrideOpenApiResponses::class,
             DummyAddress::class,
             RamseyUuidDummy::class,
+            NumericValidated::class,
             JsonSchemaResource::class,
             JsonSchemaResourceRelated::class,
             WrappedResponseEntity::class,
@@ -599,6 +601,31 @@ class OpenApiTest extends ApiTestCase
             ['type' => 'null'],
         ], $json['components']['schemas']['DummyBoolean']['properties']['isDummyBoolean']['anyOf']);
         $this->assertArrayNotHasKey('owl:maxCardinality', $json['components']['schemas']['DummyBoolean']['properties']['isDummyBoolean']);
+    }
+
+    public function testOpenApi30EmitsBooleanExclusiveBoundsForNumericConstraints(): void
+    {
+        $kernel = self::bootKernel();
+        if ('mongodb' === $kernel->getEnvironment()) {
+            $this->markTestSkipped('Resource not loaded with MongoDB.');
+        }
+
+        $response = self::createClient()->request('GET', '/docs.jsonopenapi?spec_version=3.0.0', ['headers' => ['Accept' => 'application/vnd.openapi+json']]);
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray();
+
+        $this->assertSame('3.0.0', $json['openapi']);
+        $this->assertArrayHasKey('NumericValidated', $json['components']['schemas']);
+        $properties = $json['components']['schemas']['NumericValidated']['properties'];
+
+        $this->assertSame(10, $properties['greaterThanMe']['minimum']);
+        $this->assertTrue($properties['greaterThanMe']['exclusiveMinimum']);
+
+        $this->assertSame(99, $properties['lessThanMe']['maximum']);
+        $this->assertTrue($properties['lessThanMe']['exclusiveMaximum']);
+
+        $this->assertSame(0, $properties['positive']['minimum']);
+        $this->assertTrue($properties['positive']['exclusiveMinimum']);
     }
 
     public function testRetrieveTheOpenApiDocumentationInJson(): void

--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -164,6 +164,7 @@ YAML;
         $this->addToAssertionCount(1);
     }
 
+    #[Group('orm')]
     public function testSpecVersion30EmitsDraft4BooleanExclusiveBounds(): void
     {
         $this->tester->run(['command' => 'api:openapi:export', '--spec-version' => '3.0.0']);

--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\OpenApi\OpenApi;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Crud;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6317\Issue6317;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue5625\Currency;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue6041\NumericValidated;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -55,6 +56,7 @@ class OpenApiCommandTest extends KernelTestCase
             Issue6317::class,
             Currency::class,
             Crud::class,
+            NumericValidated::class,
         ];
     }
 
@@ -160,6 +162,26 @@ YAML;
             $this->fail('Is not valid YAML: '.$exception->getMessage());
         }
         $this->addToAssertionCount(1);
+    }
+
+    public function testSpecVersion30EmitsDraft4BooleanExclusiveBounds(): void
+    {
+        $this->tester->run(['command' => 'api:openapi:export', '--spec-version' => '3.0.0']);
+        $result = $this->tester->getDisplay();
+        $json = json_decode($result, true, 512, \JSON_THROW_ON_ERROR);
+
+        $this->assertSame('3.0.0', $json['openapi']);
+        $this->assertArrayHasKey('NumericValidated', $json['components']['schemas']);
+        $properties = $json['components']['schemas']['NumericValidated']['properties'];
+
+        $this->assertSame(10, $properties['greaterThanMe']['minimum']);
+        $this->assertTrue($properties['greaterThanMe']['exclusiveMinimum']);
+
+        $this->assertSame(99, $properties['lessThanMe']['maximum']);
+        $this->assertTrue($properties['lessThanMe']['exclusiveMaximum']);
+
+        $this->assertSame(0, $properties['positive']['minimum']);
+        $this->assertTrue($properties['positive']['exclusiveMinimum']);
     }
 
     public function testFilterXApiPlatformTag(): void

--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -164,9 +164,12 @@ YAML;
         $this->addToAssertionCount(1);
     }
 
-    #[Group('orm')]
     public function testSpecVersion30EmitsDraft4BooleanExclusiveBounds(): void
     {
+        if ('mongodb' === static::$kernel->getEnvironment()) {
+            $this->markTestSkipped('Resource not loaded with MongoDB.');
+        }
+
         $this->tester->run(['command' => 'api:openapi:export', '--spec-version' => '3.0.0']);
         $result = $this->tester->getDisplay();
         $json = json_decode($result, true, 512, \JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Summary

OpenAPI 3.0 inherits JSON Schema Draft 4 semantics where `exclusiveMinimum` / `exclusiveMaximum` MUST be **booleans** qualifying `minimum` / `maximum`. The runtime SchemaFactory emits the JSON Schema 2020-12 form (these keywords as numbers), so `api:openapi:export --spec-version=3.0.0` and `GET /docs.jsonopenapi?spec_version=3.0.0` produced invalid 3.0 documents for any property with `Assert\Positive`, `Assert\GreaterThan`, `Assert\LessThan`, or `Assert\Range` with strict bounds.

`BackwardCompatibleSchemaFactory` (introduced in #6098 closing #6041) was supposed to handle the conversion but only fires when the serializer context contains `draft_4 => true` — a flag set today only by `ApiTestAssertionsTrait`. `OpenApiFactory`'s `buildSchema` call sites passed `serializerContext: null`, so the BC conversion never activated in the export / HTTP paths.

### Changes

1. **`OpenApiFactory`** — derive a schema serializer context from `$context['spec_version']` once per `collectPaths()` call and thread it through every `buildSchema()` invocation (output, input, error responses). `addOperationErrors()` gains an optional `$serializerContext` parameter for the error schemas.

2. **`BackwardCompatibleSchemaFactory`** — guard the swap against schemas where `exclusiveMinimum` / `exclusiveMaximum` is already boolean. The same property `ArrayObject` instance is reachable through multiple definitions (one per supported format), and the previous unconditional rewrite turned `{minimum: 10, exclusiveMinimum: true}` into `{minimum: true, exclusiveMinimum: true}` on the second pass.

3. **`OpenApiCommand`** — thread `--spec-version` into the `OpenApiFactory::__invoke` context, not only into the normalizer. Before this, `collectPaths()` never saw the requested spec version on the CLI path, so the Draft 4 conversion above never activated for `api:openapi:export --spec-version=3.0.0`. The HTTP path was unaffected because `SerializerContextBuilder` already injects `spec_version` into the `OpenApiProvider` context.

### Observed vs expected

Before:
```json
"positive": { "minimum": 0, "exclusiveMinimum": 0, "type": "integer" }
```
After:
```json
"positive": { "minimum": 0, "exclusiveMinimum": true, "type": "integer" }
```

Closes #7936
Closes #8176

## Test plan

- [x] New functional test `OpenApiTest::testOpenApi30EmitsBooleanExclusiveBoundsForNumericConstraints` exercises `/docs.jsonopenapi?spec_version=3.0.0` against the existing `NumericValidated` fixture (`Assert\GreaterThan`, `Assert\LessThan`, `Assert\Positive`); fails on the base branch (`exclusiveMinimum: 10` number / corruption to `minimum: true`), green after the fix.
- [x] New `OpenApiCommandTest::testSpecVersion30EmitsDraft4BooleanExclusiveBounds` exercises `api:openapi:export --spec-version=3.0.0` against the same fixture; fails without the `OpenApiCommand` plumb (`exclusiveMinimum: 10`), green after the fix.
- [x] `BackwardCompatibleSchemaFactoryTest` (existing) — still 4/4 green.
- [x] `tests/Functional/OpenApiTest` — 21/21 green.
- [x] `tests/OpenApi/Command/OpenApiCommandTest` — 6/6 green.
- [x] `ApiTestCaseTest::testAssertMatchesResourceItemAndCollectionJsonSchemaOutputWithRangeAssertions` — still green; idempotency guard does not affect the existing draft-4 test trait path.
- [x] `OpenApiFactoryTest::testInvoke` failure is pre-existing on `upstream/4.3` (`'Unprocessable entity'` vs `'An error occurred'` — unrelated 422 description drift).