### PR TITLE
fix(symfony): filter nested constraint groups in Sequentially/Compound

### DIFF
--- a/src/Symfony/Tests/Fixtures/DummySequentiallyValidatedEntityWithNestedGroups.php
+++ b/src/Symfony/Tests/Fixtures/DummySequentiallyValidatedEntityWithNestedGroups.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Symfony\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class DummySequentiallyValidatedEntityWithNestedGroups
+{
+    #[Assert\Sequentially([
+        new Assert\NotBlank(groups: ['some group']),
+        new Assert\Range(min: '0.01'),
+    ])]
+    public ?string $dummy = null;
+}

--- a/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
+++ b/src/Symfony/Tests/Validator/Metadata/Property/ValidatorPropertyMetadataFactoryTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\Symfony\Tests\Fixtures\DummyIriWithValidationEntity;
 use ApiPlatform\Symfony\Tests\Fixtures\DummyNumericValidatedEntity;
 use ApiPlatform\Symfony\Tests\Fixtures\DummyRangeValidatedEntity;
 use ApiPlatform\Symfony\Tests\Fixtures\DummySequentiallyValidatedEntity;
+use ApiPlatform\Symfony\Tests\Fixtures\DummySequentiallyValidatedEntityWithNestedGroups;
 use ApiPlatform\Symfony\Tests\Fixtures\DummyUniqueValidatedEntity;
 use ApiPlatform\Symfony\Tests\Fixtures\DummyValidatedChoiceEntity;
 use ApiPlatform\Symfony\Tests\Fixtures\DummyValidatedEntity;
@@ -448,6 +449,32 @@ class ValidatorPropertyMetadataFactoryTest extends TestCase
         $this->assertArrayHasKey('minLength', $schema);
         $this->assertArrayHasKey('maxLength', $schema);
         $this->assertArrayHasKey('pattern', $schema);
+    }
+
+    public function testSequentiallyConstraintDoesNotMarkRequiredFromNestedConstraintWithDifferentGroup(): void
+    {
+        $validatorClassMetadata = new ClassMetadata(DummySequentiallyValidatedEntityWithNestedGroups::class);
+        (new AttributeLoader())->loadClassMetadata($validatorClassMetadata);
+
+        $validatorMetadataFactory = $this->prophesize(MetadataFactoryInterface::class);
+        $validatorMetadataFactory->getMetadataFor(DummySequentiallyValidatedEntityWithNestedGroups::class)
+            ->willReturn($validatorClassMetadata)
+            ->shouldBeCalled();
+
+        $decoratedPropertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $decoratedPropertyMetadataFactory->create(DummySequentiallyValidatedEntityWithNestedGroups::class, 'dummy', [])->willReturn(
+            (new ApiProperty())->withNativeType(Type::string())
+        )->shouldBeCalled();
+
+        $validationPropertyMetadataFactory = new ValidatorPropertyMetadataFactory(
+            $validatorMetadataFactory->reveal(),
+            $decoratedPropertyMetadataFactory->reveal(),
+            []
+        );
+
+        $propertyMetadata = $validationPropertyMetadataFactory->create(DummySequentiallyValidatedEntityWithNestedGroups::class, 'dummy');
+
+        $this->assertFalse($propertyMetadata->isRequired());
     }
 
     public function testCreateWithCompoundConstraint(): void

--- a/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
+++ b/src/Symfony/Validator/Metadata/Property/ValidatorPropertyMetadataFactory.php
@@ -212,7 +212,11 @@ final class ValidatorPropertyMetadataFactory implements PropertyMetadataFactoryI
 
             foreach ($validatorPropertyMetadata->findConstraints($validationGroup) as $propertyConstraint) {
                 if ($propertyConstraint instanceof Sequentially || $propertyConstraint instanceof Compound) {
-                    $constraints[] = $propertyConstraint->getNestedConstraints();
+                    foreach ($propertyConstraint->getNestedConstraints() as $nestedConstraint) {
+                        if (\in_array($validationGroup, $nestedConstraint->groups, true)) {
+                            $constraints[] = [$nestedConstraint];
+                        }
+                    }
                 } else {
                     $constraints[] = [$propertyConstraint];
                 }


### PR DESCRIPTION
## Summary

Fixes #7777.

`ValidatorPropertyMetadataFactory::getPropertyConstraints()` expanded `Composite::getNestedConstraints()` for `Sequentially`/`Compound` without filtering by the active validation group. Because Symfony's `Composite` constructor merges nested groups into the parent (union), a parent in `Default` could carry a nested constraint that only lives in another group.

Reporter case:

```php
#[Assert\Sequentially([
    new Assert\NotBlank(groups: ['some group']),
    new Assert\Range(min: '0.01'),
])]
private ?string \$someField = null;
```

`Sequentially.groups` becomes `['some group', 'Default']` (union from nested). For `Default` validation, `findConstraints('Default')` returned `Sequentially`, then we yielded every nested constraint — including the `NotBlank` that only belongs to `'some group'` — and `isRequired()` flagged the field as required in the OpenAPI schema.

The fix filters each nested constraint by `\in_array(\$validationGroup, \$nestedConstraint->groups, true)`. Symfony's `Constraint::addImplicitGroupName()` already propagates the class default group only to constraints already in `Default`, so explicit non-Default nested groups remain excluded — semantics match validator runtime behavior.

## Test plan

- [x] New fixture `DummySequentiallyValidatedEntityWithNestedGroups` reproduces the reporter's constraint shape.
- [x] New unit test `testSequentiallyConstraintDoesNotMarkRequiredFromNestedConstraintWithDifferentGroup` fails before the fix (`required=true`), passes after (`required=false`).
- [x] Existing `testCreateWithSequentiallyConstraint` and `testCreateWithCompoundConstraint` still pass — restriction extraction is unaffected for groupless nested constraints.
- [x] Full `src/Symfony/Tests/Validator/` suite green.