### PR TITLE
fix(laravel): wire jsonapi.use_iri_as_id in ApiPlatformProvider

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -977,6 +977,7 @@ class ApiPlatformProvider extends ServiceProvider
         $this->app->singleton(JsonApiItemNormalizer::class, static function (Application $app) {
             $config = $app['config'];
             $defaultContext = $config->get('api-platform.serializer', []);
+            $useIriAsId = (bool) $config->get('api-platform.jsonapi.use_iri_as_id', true);
 
             return new JsonApiItemNormalizer(
                 $app->make(PropertyNameCollectionFactoryInterface::class),
@@ -989,7 +990,10 @@ class ApiPlatformProvider extends ServiceProvider
                 $defaultContext,
                 $app->make(ResourceMetadataCollectionFactoryInterface::class),
                 $app->make(ResourceAccessCheckerInterface::class),
-                // $app->make(TagCollectorInterface::class),
+                tagCollector: null,
+                operationResourceResolver: $app->make(OperationResourceClassResolverInterface::class),
+                identifiersExtractor: $app->make(IdentifiersExtractorInterface::class),
+                useIriAsId: $useIriAsId,
             );
         });
 

--- a/src/Laravel/Tests/JsonApiUseIriAsIdTest.php
+++ b/src/Laravel/Tests/JsonApiUseIriAsIdTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\Book;
+use Workbench\Database\Factories\AuthorFactory;
+use Workbench\Database\Factories\BookFactory;
+
+class JsonApiUseIriAsIdTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config): void {
+            $config->set('api-platform.formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('api-platform.docs_formats', ['jsonapi' => ['application/vnd.api+json']]);
+            $config->set('api-platform.resources', [app_path('Models'), app_path('ApiResource')]);
+            $config->set('api-platform.jsonapi', ['use_iri_as_id' => false]);
+            $config->set('api-platform.defaults', [
+                'route_prefix' => '/api',
+            ]);
+
+            $config->set('app.debug', true);
+        });
+    }
+
+    public function testGetBookUsesScalarIdAndLinksSelf(): void
+    {
+        BookFactory::new()->has(AuthorFactory::new())->create();
+        $book = Book::first();
+        $iri = $this->getIriFromResource($book);
+        $response = $this->get($iri, ['accept' => ['application/vnd.api+json']]);
+        $response->assertStatus(200);
+        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+
+        $this->assertJsonContains([
+            'data' => [
+                'id' => $book->getKey(),
+                'type' => 'Book',
+                'links' => ['self' => $iri],
+                'attributes' => [
+                    'name' => $book->name, // @phpstan-ignore-line
+                ],
+            ],
+        ], $response->json());
+    }
+}

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -78,6 +78,13 @@ return [
         'partial_parameter_name' => 'partial',
     ],
 
+    'jsonapi' => [
+        // When false, the JSON:API `data.id` uses the resource scalar identifier
+        // and a `data.links.self` IRI is added. When true (default), `data.id`
+        // is the resource IRI.
+        'use_iri_as_id' => true,
+    ],
+
     'graphql' => [
         'enabled' => false,
         'nesting_separator' => '__',


### PR DESCRIPTION
## Summary

The Laravel `ApiPlatformProvider` instantiated `JsonApiItemNormalizer` without the `useIriAsId` flag, without an `IdentifiersExtractor`, and without an `OperationResourceClassResolver`. As a result, `api-platform.jsonapi.use_iri_as_id` (documented for the Symfony integration) was silently ignored: `data.id` always held the IRI and `data.links.self` was never emitted.

Symfony's `ApiPlatformExtension::registerJsonApiConfiguration` already wires the flag as a constructor argument. This PR ports the same wiring to Laravel and adds the config default.

- `src/Laravel/ApiPlatformProvider.php`: thread `operationResourceResolver`, `identifiersExtractor`, and `useIriAsId` into the `JsonApiItemNormalizer` singleton.
- `src/Laravel/config/api-platform.php`: document the `jsonapi.use_iri_as_id` default (`true`).
- `src/Laravel/Tests/JsonApiUseIriAsIdTest.php`: new functional test asserting `data.id` = scalar identifier and `data.links.self` = IRI when the flag is `false`.

Fixes #8199.

## Test plan

- [x] `vendor/bin/phpunit Tests/JsonApiTest.php Tests/JsonApiUseIriAsIdTest.php` from `src/Laravel/` (14 tests, 52 assertions — pass)
- [x] Default behaviour preserved (`data.id` = IRI when flag is `true` or unset)