### PR TITLE
fix(state): only emit Content-Type charset for media types that define it

### DIFF
--- a/src/Laravel/Tests/AuthTest.php
+++ b/src/Laravel/Tests/AuthTest.php
@@ -47,7 +47,7 @@ class AuthTest extends TestCase
     {
         $response = $this->get('/api/vaults', ['accept' => ['application/ld+json']]);
         $this->assertArraySubset(['detail' => 'Unauthenticated.'], $response->json());
-        $response->assertHeader('content-type', 'application/problem+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/problem+json');
         $response->assertStatus(401);
     }
 

--- a/src/Laravel/Tests/DocsTest.php
+++ b/src/Laravel/Tests/DocsTest.php
@@ -26,28 +26,28 @@ class DocsTest extends TestCase
     {
         $res = $this->get('/api/docs.jsonopenapi');
         $this->assertArrayHasKey('openapi', $res->json());
-        $this->assertSame('application/vnd.openapi+json; charset=utf-8', $res->headers->get('content-type'));
+        $this->assertSame('application/vnd.openapi+json', $res->headers->get('content-type'));
     }
 
     public function testOpenApiAccept(): void
     {
         $res = $this->get('/api/docs', headers: ['accept' => 'application/vnd.openapi+json']);
         $this->assertArrayHasKey('openapi', $res->json());
-        $this->assertSame('application/vnd.openapi+json; charset=utf-8', $res->headers->get('content-type'));
+        $this->assertSame('application/vnd.openapi+json', $res->headers->get('content-type'));
     }
 
     public function testJsonLd(): void
     {
         $res = $this->get('/api/docs.jsonld');
         $this->assertArrayHasKey('@context', $res->json());
-        $this->assertSame('application/ld+json; charset=utf-8', $res->headers->get('content-type'));
+        $this->assertSame('application/ld+json', $res->headers->get('content-type'));
     }
 
     public function testJsonLdAccept(): void
     {
         $res = $this->get('/api/docs', headers: ['accept' => 'application/ld+json']);
         $this->assertArrayHasKey('@context', $res->json());
-        $this->assertSame('application/ld+json; charset=utf-8', $res->headers->get('content-type'));
+        $this->assertSame('application/ld+json', $res->headers->get('content-type'));
     }
 
     public function testHtmlDocsRendersSwaggerUiByDefault(): void

--- a/src/Laravel/Tests/HalTest.php
+++ b/src/Laravel/Tests/HalTest.php
@@ -45,7 +45,7 @@ class HalTest extends TestCase
     {
         $response = $this->get('/api/', ['accept' => ['application/hal+json']]);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/hal+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/hal+json');
 
         $this->assertJsonContains(
             [
@@ -67,7 +67,7 @@ class HalTest extends TestCase
         BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => 'application/hal+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/hal+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/hal+json');
         $this->assertJsonContains(
             [
                 '_links' => [
@@ -88,7 +88,7 @@ class HalTest extends TestCase
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/hal+json']]);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/hal+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/hal+json');
         $this->assertJsonContains(
             [
                 'name' => $book->name, // @phpstan-ignore-line

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -61,7 +61,7 @@ class JsonApiTest extends TestCase
     {
         $response = $this->get('/api/', ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
         $this->assertJsonContains(
             [
                 'links' => [
@@ -78,7 +78,7 @@ class JsonApiTest extends TestCase
         BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
         $response->assertJsonFragment([
             'links' => [
                 'self' => '/api/books?page=1',
@@ -98,7 +98,7 @@ class JsonApiTest extends TestCase
         $iri = $this->getIriFromResource($book);
         $response = $this->get($iri, ['accept' => ['application/vnd.api+json']]);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
 
         $this->assertJsonContains([
             'data' => [
@@ -141,7 +141,7 @@ class JsonApiTest extends TestCase
         );
 
         $response->assertStatus(201);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'type' => 'Book',
@@ -243,7 +243,7 @@ class JsonApiTest extends TestCase
         );
 
         $response->assertStatus(422);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
         $json = $response->json();
         $this->assertJsonContains([
             'errors' => [
@@ -289,7 +289,7 @@ class JsonApiTest extends TestCase
     {
         $response = $this->get('/api/books/notfound', headers: ['accept' => 'application/vnd.api+json']);
         $response->assertStatus(404);
-        $response->assertHeader('content-type', 'application/vnd.api+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/vnd.api+json');
 
         $this->assertJsonContains([
             'links' => ['type' => '/errors/404'],

--- a/src/Laravel/Tests/JsonLdTest.php
+++ b/src/Laravel/Tests/JsonLdTest.php
@@ -50,7 +50,7 @@ class JsonLdTest extends TestCase
         BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Book',
             '@id' => '/api/books',
@@ -66,7 +66,7 @@ class JsonLdTest extends TestCase
         $book = Book::first();
         $response = $this->get($this->getIriFromResource($book), ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Book',
             '@id' => $this->getIriFromResource($book),
@@ -94,7 +94,7 @@ class JsonLdTest extends TestCase
         );
 
         $response->assertStatus(201);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Book',
             '@type' => 'Book',
@@ -184,7 +184,7 @@ class JsonLdTest extends TestCase
     {
         $response = $this->get('/api/outputs', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@type' => 'NotAResource',
             'name' => 'test',
@@ -198,7 +198,7 @@ class JsonLdTest extends TestCase
         PostFactory::new()->has(CommentFactory::new()->count(10))->count(10)->create();
         $response = $this->get('/api/posts', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
 
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Post',
@@ -244,7 +244,7 @@ class JsonLdTest extends TestCase
         );
 
         $response->assertStatus(422);
-        $response->assertHeader('content-type', 'application/problem+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/problem+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/ValidationError',
             '@type' => 'ValidationError',
@@ -269,7 +269,7 @@ class JsonLdTest extends TestCase
         );
 
         $response->assertStatus(422);
-        $response->assertHeader('content-type', 'application/problem+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/problem+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/ValidationError',
             '@type' => 'ValidationError',
@@ -286,7 +286,7 @@ class JsonLdTest extends TestCase
         SluggableFactory::new()->count(10)->create();
         $response = $this->get('/api/sluggables', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Sluggable',
             '@id' => '/api/sluggables',
@@ -308,7 +308,7 @@ class JsonLdTest extends TestCase
     {
         $response = $this->get('/api/contexts/Entrypoint', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $this->assertArrayHasKey('@context', $response->json());
     }
 
@@ -316,7 +316,7 @@ class JsonLdTest extends TestCase
     {
         $response = $this->get('/api/contexts/Book', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $this->assertArrayHasKey('@context', $response->json());
     }
 
@@ -324,7 +324,7 @@ class JsonLdTest extends TestCase
     {
         $response = $this->get('/api/contexts/', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $this->assertArrayHasKey('@context', $response->json());
     }
 
@@ -333,7 +333,7 @@ class JsonLdTest extends TestCase
         PostFactory::new()->has(CommentFactory::new()->count(10))->count(10)->create();
         $response = $this->get('/api/posts/1/comments/1', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonMissingPath('internalNote');
     }
 
@@ -342,7 +342,7 @@ class JsonLdTest extends TestCase
         BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $response = $this->get('/api/books', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $this->assertStringNotContainsString('internalNote', (string) $response->getContent());
     }
 
@@ -386,7 +386,7 @@ class JsonLdTest extends TestCase
     {
         $response = $this->get('/api/resource_with_models?page=1', ['accept' => 'application/ld+json']);
         $response->assertStatus(200);
-        $response->assertHeader('content-type', 'application/ld+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/ld+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/ResourceWithModel',
             '@id' => '/api/resource_with_models',

--- a/src/Laravel/Tests/JsonProblemTest.php
+++ b/src/Laravel/Tests/JsonProblemTest.php
@@ -29,7 +29,7 @@ class JsonProblemTest extends TestCase
     {
         $response = $this->get('/api/books/notfound', headers: ['accept' => 'application/ld+json']);
         $response->assertStatus(404);
-        $response->assertHeader('content-type', 'application/problem+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/problem+json');
         $response->assertJsonFragment([
             '@context' => '/api/contexts/Error',
             '@id' => '/api/errors/404',
@@ -89,7 +89,7 @@ class JsonProblemTest extends TestCase
     {
         $response = $this->get('/api/teapot', headers: ['accept' => 'application/json']);
         $response->assertStatus(418);
-        $response->assertHeader('content-type', 'application/problem+json; charset=utf-8');
+        $response->assertHeader('content-type', 'application/problem+json');
         $response->assertJsonFragment([
             'type' => '/problem/teapot',
             'title' => 'I\'m a teapot',

--- a/src/State/Util/HttpResponseHeadersTrait.php
+++ b/src/State/Util/HttpResponseHeadersTrait.php
@@ -69,7 +69,7 @@ trait HttpResponseHeadersTrait
         ];
 
         if ($hasBody) {
-            $headers['Content-Type'] = \sprintf('%s; charset=utf-8', $request->getMimeType($request->getRequestFormat()));
+            $headers['Content-Type'] = $this->formatContentType($request->getMimeType($request->getRequestFormat()));
         }
 
         $exception = $request->attributes->get('exception');
@@ -146,6 +146,29 @@ trait HttpResponseHeadersTrait
         }
 
         return $headers;
+    }
+
+    /**
+     * Appends `; charset=utf-8` only for media types whose IANA registration defines a charset parameter.
+     *
+     * JSON-based media types (RFC 8259, RFC 6839 `+json` suffix) do not define charset and MUST always be UTF-8;
+     * sending the parameter can break strict clients.
+     */
+    private function formatContentType(?string $mimeType): string
+    {
+        if (null === $mimeType || '' === $mimeType) {
+            return '';
+        }
+
+        if (str_starts_with($mimeType, 'text/')) {
+            return $mimeType.'; charset=utf-8';
+        }
+
+        if ('application/xml' === $mimeType) {
+            return $mimeType.'; charset=utf-8';
+        }
+
+        return $mimeType;
     }
 
     private function addLinkedDataPlatformHeaders(array &$headers, HttpOperation $operation): void

--- a/tests/Fixtures/TestBundle/Controller/CustomController.php
+++ b/tests/Fixtures/TestBundle/Controller/CustomController.php
@@ -25,6 +25,6 @@ class CustomController extends AbstractController
 {
     public function customAction(int $id): JsonResponse
     {
-        return new JsonResponse(\sprintf('This is a custom action for %d.', $id), 200, ['Content-Type' => 'application/ld+json; charset=utf-8']);
+        return new JsonResponse(\sprintf('This is a custom action for %d.', $id), 200, ['Content-Type' => 'application/ld+json']);
     }
 }

--- a/tests/Functional/AttributeResourceTest.php
+++ b/tests/Functional/AttributeResourceTest.php
@@ -51,7 +51,7 @@ final class AttributeResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/AttributeResources',
             '@id' => '/attribute_resources',
@@ -87,7 +87,7 @@ final class AttributeResourceTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(301);
         $this->assertResponseHeaderSame('Location', '/attribute_resources/2');
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/AttributeResource',
             '@id' => '/attribute_resources/2',
@@ -107,7 +107,7 @@ final class AttributeResourceTest extends ApiTestCase
 
         $this->assertResponseStatusCodeSame(301);
         $this->assertResponseHeaderSame('Location', '/attribute_resources/2');
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/AttributeResource',
             '@id' => '/attribute_resources/2',
@@ -123,7 +123,7 @@ final class AttributeResourceTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/photos/1/resize/300/100');
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $linkHeader = $response->getHeaders(false)['link'][0] ?? '';
         $this->assertStringContainsString('<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"', $linkHeader);
         $this->assertJsonContains(['detail' => 'Unable to generate an IRI for the item of type "ApiPlatform\\Tests\\Fixtures\\TestBundle\\Entity\\IncompleteUriVariableConfigured"']);

--- a/tests/Functional/Authorization/DenyTest.php
+++ b/tests/Functional/Authorization/DenyTest.php
@@ -56,7 +56,7 @@ final class DenyTest extends ApiTestCase
             'headers' => ['Accept' => 'application/ld+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testCustomDataProviderGeneratorReturns200(): void

--- a/tests/Functional/Authorization/LegacyDenyTest.php
+++ b/tests/Functional/Authorization/LegacyDenyTest.php
@@ -48,7 +48,7 @@ final class LegacyDenyTest extends ApiTestCase
             'headers' => ['Accept' => 'application/ld+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testStandardUserCannotCreate(): void

--- a/tests/Functional/CircularReferenceTest.php
+++ b/tests/Functional/CircularReferenceTest.php
@@ -50,7 +50,7 @@ final class CircularReferenceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CircularReference',
             '@id' => '/circular_references/1',

--- a/tests/Functional/CompositeIdentifierTest.php
+++ b/tests/Functional/CompositeIdentifierTest.php
@@ -75,7 +75,7 @@ final class CompositeIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/composite_items');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CompositeItem',
             '@id' => '/composite_items',
@@ -103,7 +103,7 @@ final class CompositeIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/composite_relations');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/CompositeRelation',
             '@id' => '/composite_relations',
@@ -124,7 +124,7 @@ final class CompositeIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/composite_relations/compositeItem=1;compositeLabel=1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CompositeRelation',
             '@id' => '/composite_relations/compositeItem=1;compositeLabel=1',
@@ -158,7 +158,7 @@ final class CompositeIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/composite_items/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testCompositeIdentifierWithDifferentTypes(): void

--- a/tests/Functional/ConfigurableTest.php
+++ b/tests/Functional/ConfigurableTest.php
@@ -58,7 +58,7 @@ final class ConfigurableTest extends ApiTestCase
         self::createClient()->request('GET', '/fileconfigdummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/fileconfigdummy',
             '@id' => '/fileconfigdummies',
@@ -83,7 +83,7 @@ final class ConfigurableTest extends ApiTestCase
         self::createClient()->request('GET', '/single_file_configs');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/single_file_config',
             '@id' => '/single_file_configs',
@@ -100,7 +100,7 @@ final class ConfigurableTest extends ApiTestCase
         self::createClient()->request('GET', '/fileconfigdummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/fileconfigdummy',
             '@id' => '/fileconfigdummies/1',

--- a/tests/Functional/ContentNegotiationTest.php
+++ b/tests/Functional/ContentNegotiationTest.php
@@ -97,7 +97,7 @@ final class ContentNegotiationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $data = $response->toArray();
         $this->assertIsArray($data);
         $this->assertCount(1, $data);
@@ -141,7 +141,7 @@ final class ContentNegotiationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testWildcardAcceptDefaultsToUrlFormat(): void
@@ -165,7 +165,7 @@ final class ContentNegotiationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(406);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testHtmlAcceptReturnsHtmlError(): void
@@ -186,7 +186,7 @@ final class ContentNegotiationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(406);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testPostCsvBodyOnCustomFormatResource(): void

--- a/tests/Functional/CrudAbstractTest.php
+++ b/tests/Functional/CrudAbstractTest.php
@@ -52,7 +52,7 @@ final class CrudAbstractTest extends ApiTestCase
         $this->createConcrete();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/concrete_dummies/1.jsonld');
         $this->assertResponseHeaderSame('Location', '/concrete_dummies/1');
         $this->assertJsonEquals([
@@ -72,7 +72,7 @@ final class CrudAbstractTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/abstract_dummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertArrayNotHasKey('content-location', array_change_key_case($response->getHeaders()));
         $this->assertJsonEquals([
             '@context' => '/contexts/ConcreteDummy',
@@ -91,7 +91,7 @@ final class CrudAbstractTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/abstract_dummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertGreaterThanOrEqual(1, \count($data['hydra:member']));
         $this->assertSame('ConcreteDummy', $data['hydra:member'][0]['@type']);

--- a/tests/Functional/CrudTest.php
+++ b/tests/Functional/CrudTest.php
@@ -78,7 +78,7 @@ final class CrudTest extends ApiTestCase
         $this->createDummy();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/dummies/1.jsonld');
         $this->assertResponseHeaderSame('Location', '/dummies/1');
         $this->assertJsonContains(self::DUMMY);
@@ -91,7 +91,7 @@ final class CrudTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertArrayNotHasKey('content-location', array_change_key_case($response->getHeaders()));
         $this->assertJsonContains(self::DUMMY);
     }
@@ -121,7 +121,7 @@ final class CrudTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/Dummy', $data['@context']);
         $this->assertSame('/dummies', $data['@id']);

--- a/tests/Functional/CrudUriVariablesTest.php
+++ b/tests/Functional/CrudUriVariablesTest.php
@@ -110,7 +110,7 @@ final class CrudUriVariablesTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Employee',
             '@id' => '/companies/2/employees',

--- a/tests/Functional/CustomControllerTest.php
+++ b/tests/Functional/CustomControllerTest.php
@@ -144,7 +144,7 @@ final class CustomControllerTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Payment',
             '@id' => '/payments/1',
@@ -164,7 +164,7 @@ final class CustomControllerTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/VoidPayment',
             '@id' => '/void_payments/1',
@@ -186,7 +186,7 @@ final class CustomControllerTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/VoidPayment',
             '@id' => '/void_payments/1',

--- a/tests/Functional/CustomIdentifierTest.php
+++ b/tests/Functional/CustomIdentifierTest.php
@@ -52,7 +52,7 @@ final class CustomIdentifierTest extends ApiTestCase
         $this->createDummy();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CustomIdentifierDummy',
             '@id' => '/custom_identifier_dummies/1',
@@ -69,7 +69,7 @@ final class CustomIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/custom_identifier_dummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CustomIdentifierDummy',
             '@id' => '/custom_identifier_dummies/1',
@@ -86,7 +86,7 @@ final class CustomIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/custom_identifier_dummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CustomIdentifierDummy',
             '@id' => '/custom_identifier_dummies',
@@ -111,7 +111,7 @@ final class CustomIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CustomIdentifierDummy',
             '@id' => '/custom_identifier_dummies/1',

--- a/tests/Functional/CustomIdentifierWithSubresourceTest.php
+++ b/tests/Functional/CustomIdentifierWithSubresourceTest.php
@@ -58,7 +58,7 @@ final class CustomIdentifierWithSubresourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/SlugParentDummy',
             '@id' => '/slug_parent_dummies/parent-dummy',
@@ -81,7 +81,7 @@ final class CustomIdentifierWithSubresourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/SlugChildDummy',
             '@id' => '/slug_child_dummies/child-dummy',
@@ -99,7 +99,7 @@ final class CustomIdentifierWithSubresourceTest extends ApiTestCase
         self::createClient()->request('GET', '/slug_parent_dummies/parent-dummy/child_dummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/SlugChildDummy',
             '@id' => '/slug_parent_dummies/parent-dummy/child_dummies',
@@ -124,7 +124,7 @@ final class CustomIdentifierWithSubresourceTest extends ApiTestCase
         self::createClient()->request('GET', '/slug_child_dummies/child-dummy/parent_dummy');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/SlugParentDummy',
             '@id' => '/slug_child_dummies/child-dummy/parent_dummy',

--- a/tests/Functional/CustomNormalizedTest.php
+++ b/tests/Functional/CustomNormalizedTest.php
@@ -52,7 +52,7 @@ final class CustomNormalizedTest extends ApiTestCase
         $this->createCustom();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/custom_normalized_dummies/1.jsonld');
         $this->assertResponseHeaderSame('Location', '/custom_normalized_dummies/1');
         $this->assertJsonEquals([
@@ -73,7 +73,7 @@ final class CustomNormalizedTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $this->assertResponseHeaderSame('Content-Location', '/related_normalized_dummies/1.json');
         $this->assertResponseHeaderSame('Location', '/related_normalized_dummies/1');
         $this->assertJsonEquals(['id' => 1, 'name' => 'My Dummy', 'customNormalizedDummy' => []]);
@@ -102,7 +102,7 @@ final class CustomNormalizedTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $this->assertResponseHeaderSame('Content-Location', '/related_normalized_dummies/1.json');
         $this->assertJsonEquals([
             'id' => 1,
@@ -118,7 +118,7 @@ final class CustomNormalizedTest extends ApiTestCase
         self::createClient()->request('GET', '/custom_normalized_dummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/CustomNormalizedDummy',
             '@id' => '/custom_normalized_dummies/1',

--- a/tests/Functional/CustomWritableIdentifierTest.php
+++ b/tests/Functional/CustomWritableIdentifierTest.php
@@ -51,7 +51,7 @@ final class CustomWritableIdentifierTest extends ApiTestCase
         $this->createWithSlug('My Dummy', 'my_slug');
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/custom_writable_identifier_dummies/my_slug.jsonld');
         $this->assertResponseHeaderSame('Location', '/custom_writable_identifier_dummies/my_slug');
         $this->assertJsonEquals([

--- a/tests/Functional/DefaultOrderTest.php
+++ b/tests/Functional/DefaultOrderTest.php
@@ -67,7 +67,7 @@ final class DefaultOrderTest extends ApiTestCase
         self::createClient()->request('GET', '/foos?itemsPerPage=10');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Foo',
             '@id' => '/foos',
@@ -112,7 +112,7 @@ final class DefaultOrderTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/foo_dummies?itemsPerPage=10');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $names = array_column($data['hydra:member'], 'name');
         $this->assertSame(['Balbo', 'Sthenelus', 'Ephesian', 'Hawsepipe', 'Separativeness'], $names);

--- a/tests/Functional/Doctrine/BooleanFilterTest.php
+++ b/tests/Functional/Doctrine/BooleanFilterTest.php
@@ -64,7 +64,7 @@ final class BooleanFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/Dummy', $data['@context']);
         $this->assertSame('/dummies', $data['@id']);
@@ -92,7 +92,7 @@ final class BooleanFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/EmbeddedDummy', $data['@context']);
         $this->assertSame('/embedded_dummies', $data['@id']);

--- a/tests/Functional/Doctrine/ExistsFilterTest.php
+++ b/tests/Functional/Doctrine/ExistsFilterTest.php
@@ -53,7 +53,7 @@ final class ExistsFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame(0, $data['hydra:totalItems']);
         $this->assertSame([], $data['hydra:member']);

--- a/tests/Functional/Doctrine/MultipleFilterTest.php
+++ b/tests/Functional/Doctrine/MultipleFilterTest.php
@@ -46,7 +46,7 @@ final class MultipleFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
 
         $data = $response->toArray();
         $this->assertSame('/contexts/Dummy', $data['@context']);

--- a/tests/Functional/Doctrine/RangeFilterTest.php
+++ b/tests/Functional/Doctrine/RangeFilterTest.php
@@ -61,7 +61,7 @@ final class RangeFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame($expectedTotal, $data['hydra:totalItems']);
     }

--- a/tests/Functional/Doctrine/SeparatedResourceTest.php
+++ b/tests/Functional/Doctrine/SeparatedResourceTest.php
@@ -55,7 +55,7 @@ final class SeparatedResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/'.$shortName, $data['@context']);
         $this->assertStringStartsWith($uri, $data['@id']);
@@ -78,7 +78,7 @@ final class SeparatedResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertSame('5', $response->toArray()['hydra:member'][0]['value']);
     }
 
@@ -95,7 +95,7 @@ final class SeparatedResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testGetAllEntityClassAndCustomProviderResources(): void

--- a/tests/Functional/Elasticsearch/MatchFilterTest.php
+++ b/tests/Functional/Elasticsearch/MatchFilterTest.php
@@ -41,7 +41,7 @@ final class MatchFilterTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/tweets?message=Good%20job', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -95,7 +95,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?message%5B%5D=Good%20job&message%5B%5D=run', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -162,7 +162,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?author.firstName=Caroline', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -216,7 +216,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?message%5B%5D=Good%20job&message%5B%5D=run&author.firstName=Caroline', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -270,7 +270,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?message=Good%20job', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -324,7 +324,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?message%5B%5D=Good%20job&message%5B%5D=run', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -391,7 +391,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?library.firstName=Caroline', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -445,7 +445,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?message%5B%5D=Good%20job&message%5B%5D=run&library.firstName=Caroline', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -499,7 +499,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?library.relatedGenres.name=Fiction', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",

--- a/tests/Functional/Elasticsearch/OrderFilterTest.php
+++ b/tests/Functional/Elasticsearch/OrderFilterTest.php
@@ -41,7 +41,7 @@ final class OrderFilterTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/tweets?order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -104,7 +104,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -167,7 +167,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?order%5Bauthor.id%5D=asc&order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -230,7 +230,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?order%5Bauthor.id%5D=asc&order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -293,7 +293,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?order%5Bauthor.id%5D=desc&order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -356,7 +356,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?order%5Bauthor.id%5D=desc&order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -419,7 +419,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -482,7 +482,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -545,7 +545,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Blibrary.id%5D=asc&order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -608,7 +608,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Blibrary.id%5D=asc&order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -671,7 +671,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Blibrary.id%5D=desc&order%5Bid%5D=asc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -734,7 +734,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?order%5Blibrary.id%5D=desc&order%5Bid%5D=desc', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",

--- a/tests/Functional/Elasticsearch/ReadTest.php
+++ b/tests/Functional/Elasticsearch/ReadTest.php
@@ -41,7 +41,7 @@ final class ReadTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/users/116b83f8-6c32-48d8-8e28-c5c247532d3f', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/User",
@@ -98,7 +98,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Tweet",
@@ -217,7 +217,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?page=3', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Tweet",
@@ -337,7 +337,7 @@ JSON);
         $response = self::createClient()->request('GET', '/tweets?page=7', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Tweet",
@@ -440,7 +440,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries/116b83f8-6c32-48d8-8e28-c5c247532d3f', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Library",
@@ -497,7 +497,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Book",
@@ -628,7 +628,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?page=3', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Book",
@@ -760,7 +760,7 @@ JSON);
         $response = self::createClient()->request('GET', '/books?page=7', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/Book",

--- a/tests/Functional/Elasticsearch/TermFilterTest.php
+++ b/tests/Functional/Elasticsearch/TermFilterTest.php
@@ -41,7 +41,7 @@ final class TermFilterTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/users?id=%2Fusers%2Fcf875c95-41ab-48df-af66-38c74db18f72', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -80,7 +80,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?gender=female', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -126,7 +126,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?age=42&gender=female', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -175,7 +175,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?age=42&gender=male', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -208,7 +208,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?firstName=xavier', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -248,7 +248,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?tweets.id=%2Ftweets%2Fdcaef1db-225d-442b-960e-5de6984a44be', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -287,7 +287,7 @@ JSON);
         $response = self::createClient()->request('GET', '/users?tweets.date=2018-02-02%2014%3A14%3A14', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -326,7 +326,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?id=%2Flibraries%2Fcf875c95-41ab-48df-af66-38c74db18f72', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -365,7 +365,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?gender=female', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -411,7 +411,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?age=42&gender=female', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -460,7 +460,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?age=42&gender=male', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -493,7 +493,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?firstName=xavier', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -533,7 +533,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?books.id=%2Fbooks%2Fdcaef1db-225d-442b-960e-5de6984a44be', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -572,7 +572,7 @@ JSON);
         $response = self::createClient()->request('GET', '/libraries?books.date=2018-02-02%2014%3A14%3A14', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",

--- a/tests/Functional/EnumDenormalizationValidationTest.php
+++ b/tests/Functional/EnumDenormalizationValidationTest.php
@@ -57,7 +57,7 @@ final class EnumDenormalizationValidationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
 
         $content = $response->toArray(false);
         $this->assertArrayHasKey('violations', $content);

--- a/tests/Functional/ErrorTest.php
+++ b/tests/Functional/ErrorTest.php
@@ -130,7 +130,7 @@ final class ErrorTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
 
         $responseData = $response->toArray(false);
 

--- a/tests/Functional/ExceptionToStatusTest.php
+++ b/tests/Functional/ExceptionToStatusTest.php
@@ -51,7 +51,7 @@ final class ExceptionToStatusTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testResourceExceptionToStatusMaps400(): void
@@ -62,7 +62,7 @@ final class ExceptionToStatusTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testFilterValidationExceptionMaps400(): void
@@ -72,7 +72,7 @@ final class ExceptionToStatusTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testOverrideValidationExceptionStatusOnDelete(): void

--- a/tests/Functional/Hal/CollectionTest.php
+++ b/tests/Functional/Hal/CollectionTest.php
@@ -34,7 +34,7 @@ final class CollectionTest extends ApiTestCase
             'headers' => ['Accept' => 'application/hal+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
 
         $this->assertSame('/hal_collection_paged?page=1', $body['_links']['self']['href']);

--- a/tests/Functional/Hal/HalTest.php
+++ b/tests/Functional/Hal/HalTest.php
@@ -36,7 +36,7 @@ final class HalTest extends ApiTestCase
             'headers' => ['Accept' => 'application/hal+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertSame('/', $body['_links']['self']['href']);
         $hrefs = array_column($body['_links'], 'href');
@@ -49,7 +49,7 @@ final class HalTest extends ApiTestCase
             'headers' => ['Accept' => 'application/hal+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
 
         $this->assertSame('/hal_relation_embedders/1', $body['_links']['self']['href']);
@@ -92,7 +92,7 @@ final class HalTest extends ApiTestCase
             'json' => ['krondstadt' => 'Updated'],
         ]);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertSame('/hal_relation_embedders/1', $body['_links']['self']['href']);
         $this->assertSame('/hal_related_resources/1', $body['_links']['related']['href']);
@@ -110,7 +110,7 @@ final class HalTest extends ApiTestCase
             'json' => ['krondstadt' => 'Patched'],
         ]);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertSame('/hal_relation_embedders/1', $body['_links']['self']['href']);
         $this->assertSame('/hal_related_resources/1', $body['_links']['related']['href']);

--- a/tests/Functional/Hal/InputOutputDtoTest.php
+++ b/tests/Functional/Hal/InputOutputDtoTest.php
@@ -34,7 +34,7 @@ final class InputOutputDtoTest extends ApiTestCase
             'headers' => ['Accept' => 'application/hal+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertSame('test', $body['foo']);
         $this->assertSame(1, $body['bar']);

--- a/tests/Functional/Hal/MaxDepthTest.php
+++ b/tests/Functional/Hal/MaxDepthTest.php
@@ -85,7 +85,7 @@ final class MaxDepthTest extends ApiTestCase
             ],
         ]);
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertArrayHasKey('_embedded', $body);
         $this->assertArrayHasKey('child', $body['_embedded']);

--- a/tests/Functional/Hal/NonResourceTest.php
+++ b/tests/Functional/Hal/NonResourceTest.php
@@ -34,7 +34,7 @@ final class NonResourceTest extends ApiTestCase
             'headers' => ['Accept' => 'application/hal+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
 
         $this->assertSame('/hal_non_resource_containers/1', $body['_links']['self']['href']);

--- a/tests/Functional/Hal/ProblemTest.php
+++ b/tests/Functional/Hal/ProblemTest.php
@@ -39,7 +39,7 @@ final class ProblemTest extends ApiTestCase
             'json' => [],
         ]);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $body = $response->toArray(false);
         $this->assertSame('/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3', $body['type']);
         $this->assertSame('An error occurred', $body['title']);
@@ -67,7 +67,7 @@ final class ProblemTest extends ApiTestCase
             ],
         ]);
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $body = $response->toArray(false);
         $this->assertSame('/errors/400', $body['type']);
         $this->assertSame('An error occurred', $body['title']);

--- a/tests/Functional/Hal/TableInheritanceTest.php
+++ b/tests/Functional/Hal/TableInheritanceTest.php
@@ -61,7 +61,7 @@ final class TableInheritanceTest extends ApiTestCase
             'json' => ['name' => 'foo', 'nickname' => 'bar'],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/hal+json');
         $body = $response->toArray();
         $this->assertSame([
             '_links' => ['self' => ['href' => '/dummy_table_inheritance_children/1']],

--- a/tests/Functional/Issue5926Test.php
+++ b/tests/Functional/Issue5926Test.php
@@ -34,10 +34,10 @@ final class Issue5926Test extends ApiTestCase
 
     public static function formats(): iterable
     {
-        yield ['application/json', 'application/json; charset=utf-8'];
-        yield ['application/vnd.api+json', 'application/vnd.api+json; charset=utf-8'];
-        yield ['application/ld+json', 'application/ld+json; charset=utf-8'];
-        yield ['application/hal+json', 'application/hal+json; charset=utf-8'];
+        yield ['application/json', 'application/json'];
+        yield ['application/vnd.api+json', 'application/vnd.api+json'];
+        yield ['application/ld+json', 'application/ld+json'];
+        yield ['application/hal+json', 'application/hal+json'];
     }
 
     #[DataProvider('formats')]

--- a/tests/Functional/Json/InputOutputTest.php
+++ b/tests/Functional/Json/InputOutputTest.php
@@ -46,7 +46,7 @@ final class InputOutputTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
         $this->assertJsonEquals(['emailSentAt' => '2019-07-05T15:44:00+00:00']);
     }
 
@@ -61,7 +61,7 @@ final class InputOutputTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonContains(['detail' => 'User does not exist.']);
     }
 }

--- a/tests/Functional/Json/RelationTest.php
+++ b/tests/Functional/Json/RelationTest.php
@@ -61,7 +61,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/ThirdLevel',
             '@id' => '/third_levels/1',
@@ -83,7 +83,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/RelationEmbedder',
             '@id' => '/relation_embedders/1',
@@ -113,7 +113,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@id' => '/relation_embedders/1',
             'anotherRelated' => [

--- a/tests/Functional/JsonApi/AbsoluteUrlTest.php
+++ b/tests/Functional/JsonApi/AbsoluteUrlTest.php
@@ -37,7 +37,7 @@ final class AbsoluteUrlTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertSame('http://example.com/jsonapi_absolute_url_dummies', $body['links']['self']);
         $this->assertSame('http://example.com/jsonapi_absolute_url_dummies/1', $body['data'][0]['id']);

--- a/tests/Functional/JsonApi/CollectionAttributesTest.php
+++ b/tests/Functional/JsonApi/CollectionAttributesTest.php
@@ -35,7 +35,7 @@ final class CollectionAttributesTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertSame('/jsonapi_circular_references/1', $body['data']['id']);
         $this->assertSame('/jsonapi_circular_references/1', $body['data']['relationships']['parent']['data']['id']);

--- a/tests/Functional/JsonApi/CollectionUriTemplateTest.php
+++ b/tests/Functional/JsonApi/CollectionUriTemplateTest.php
@@ -73,7 +73,7 @@ final class CollectionUriTemplateTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'links' => [
                 'propertyCollectionIriOnlyRelation' => '/property-collection-relations',

--- a/tests/Functional/JsonApi/CrudTest.php
+++ b/tests/Functional/JsonApi/CrudTest.php
@@ -75,7 +75,7 @@ final class CrudTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.api+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertCount(1, $body['data']);
     }

--- a/tests/Functional/JsonApi/EntrypointTest.php
+++ b/tests/Functional/JsonApi/EntrypointTest.php
@@ -36,7 +36,7 @@ final class EntrypointTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertSame('http://example.com/', $body['links']['self']);
         $this->assertSame('http://example.com/jsonapi_entrypoint_dummies', $body['links']['jsonApiEntrypointDummy']);
@@ -49,7 +49,7 @@ final class EntrypointTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertSame([], $body['data']);
     }

--- a/tests/Functional/JsonApi/ErrorTest.php
+++ b/tests/Functional/JsonApi/ErrorTest.php
@@ -39,7 +39,7 @@ class ErrorTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'errors' => [
                 [
@@ -88,7 +88,7 @@ class ErrorTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray(false);
         $this->assertSame('An error occurred', $body['errors'][0]['title']);
         $this->assertSame(400, $body['errors'][0]['status']);
@@ -107,7 +107,7 @@ class ErrorTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray(false);
         $this->assertSame('An error occurred', $body['errors'][0]['title']);
         $this->assertSame(404, $body['errors'][0]['status']);

--- a/tests/Functional/JsonApi/IdentifierModeTest.php
+++ b/tests/Functional/JsonApi/IdentifierModeTest.php
@@ -45,7 +45,7 @@ class IdentifierModeTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'id' => '10',
@@ -68,7 +68,7 @@ class IdentifierModeTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 [

--- a/tests/Functional/JsonApi/InputDtoTest.php
+++ b/tests/Functional/JsonApi/InputDtoTest.php
@@ -56,7 +56,7 @@ class InputDtoTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'attributes' => [

--- a/tests/Functional/JsonApi/InputOutputTest.php
+++ b/tests/Functional/JsonApi/InputOutputTest.php
@@ -35,7 +35,7 @@ final class InputOutputTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'type' => 'CustomOutputDto',
@@ -54,7 +54,7 @@ final class InputOutputTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 ['type' => 'CustomOutputDto', 'attributes' => ['foo' => 'test', 'bar' => 1]],

--- a/tests/Functional/JsonApi/ItemUriTemplateTest.php
+++ b/tests/Functional/JsonApi/ItemUriTemplateTest.php
@@ -34,7 +34,7 @@ final class ItemUriTemplateTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.api+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $body = $response->toArray();
         $this->assertSame('/jsonapi_uri_template_cars', $body['links']['self']);
         $this->assertCount(2, $body['data']);

--- a/tests/Functional/JsonApi/NonResourceTest.php
+++ b/tests/Functional/JsonApi/NonResourceTest.php
@@ -36,7 +36,7 @@ final class NonResourceTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.api+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'id' => '/jsonapi_non_resource_containers/1',
@@ -82,7 +82,7 @@ final class NonResourceTest extends ApiTestCase
             ],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonContains([
             'data' => [
                 'id' => '/jsonapi_non_relation_resources/1',

--- a/tests/Functional/JsonApi/RelatedResourcesInclusionTest.php
+++ b/tests/Functional/JsonApi/RelatedResourcesInclusionTest.php
@@ -64,7 +64,7 @@ final class RelatedResourcesInclusionTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
         $this->assertJsonEquals([
             'data' => [
                 'id' => '/dummy_properties/1',

--- a/tests/Functional/JsonApiFlatPaginationTest.php
+++ b/tests/Functional/JsonApiFlatPaginationTest.php
@@ -62,7 +62,7 @@ final class JsonApiFlatPaginationTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
 
         $data = $response->toArray();
 
@@ -82,7 +82,7 @@ final class JsonApiFlatPaginationTest extends ApiTestCase
         ]);
 
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json');
 
         $data = $response->toArray();
 

--- a/tests/Functional/JsonLd/ContextTest.php
+++ b/tests/Functional/JsonLd/ContextTest.php
@@ -33,7 +33,7 @@ final class ContextTest extends ApiTestCase
     {
         $response = self::createClient()->request('GET', '/contexts/Entrypoint');
         $this->assertResponseIsSuccessful();
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
         $this->assertSame('http://localhost/docs.jsonld#', $body['@context']['@vocab']);
         $this->assertSame('http://www.w3.org/ns/hydra/core#', $body['@context']['hydra']);

--- a/tests/Functional/JsonLd/EntityClassWithDateTimeTest.php
+++ b/tests/Functional/JsonLd/EntityClassWithDateTimeTest.php
@@ -49,7 +49,7 @@ final class EntityClassWithDateTimeTest extends ApiTestCase
             'headers' => ['Accept' => 'application/ld+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
         $this->assertSame('/EntityClassWithDateTime/1', $body['@id']);
         $this->assertSame('EntityClassWithDateTime', $body['@type']);

--- a/tests/Functional/JsonLd/EntrypointTest.php
+++ b/tests/Functional/JsonLd/EntrypointTest.php
@@ -35,7 +35,7 @@ final class EntrypointTest extends ApiTestCase
             'headers' => ['Accept' => 'application/ld+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
         $this->assertSame('/contexts/Entrypoint', $body['@context']);
         $this->assertSame('/', $body['@id']);

--- a/tests/Functional/JsonLd/HydraDocsTest.php
+++ b/tests/Functional/JsonLd/HydraDocsTest.php
@@ -41,7 +41,7 @@ final class HydraDocsTest extends ApiTestCase
     {
         $response = self::createClient()->request('GET', '/docs.jsonld');
         $this->assertResponseIsSuccessful();
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
 
         $this->assertIsArray($body['@context']);

--- a/tests/Functional/JsonLd/HydraErrorTest.php
+++ b/tests/Functional/JsonLd/HydraErrorTest.php
@@ -39,7 +39,7 @@ final class HydraErrorTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(400);
         $headers = $response->getHeaders(false);
-        $this->assertSame('application/problem+json; charset=utf-8', $headers['content-type'][0]);
+        $this->assertSame('application/problem+json', $headers['content-type'][0]);
         $this->assertStringContainsString(
             '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"',
             implode(',', $headers['link']),
@@ -66,7 +66,7 @@ final class HydraErrorTest extends ApiTestCase
             'json' => new \stdClass(),
         ]);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('application/problem+json; charset=utf-8', $response->getHeaders(false)['content-type'][0]);
+        $this->assertSame('application/problem+json', $response->getHeaders(false)['content-type'][0]);
         $this->assertJsonContains([
             '@context' => '/contexts/ConstraintViolation',
             '@id' => '/validation_errors/c1051bb4-d103-4f74-8988-acbcafc7fdc3',
@@ -93,7 +93,7 @@ final class HydraErrorTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(404);
         $headers = $response->getHeaders(false);
-        $this->assertSame('application/problem+json; charset=utf-8', $headers['content-type'][0]);
+        $this->assertSame('application/problem+json', $headers['content-type'][0]);
         $this->assertStringContainsString(
             '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"',
             implode(',', $headers['link']),
@@ -117,7 +117,7 @@ final class HydraErrorTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(405);
         $headers = $response->getHeaders(false);
-        $this->assertSame('application/problem+json; charset=utf-8', $headers['content-type'][0]);
+        $this->assertSame('application/problem+json', $headers['content-type'][0]);
         $this->assertStringContainsString(
             '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"',
             implode(',', $headers['link']),
@@ -141,7 +141,7 @@ final class HydraErrorTest extends ApiTestCase
         ]);
         $this->assertResponseStatusCodeSame(400);
         $headers = $response->getHeaders(false);
-        $this->assertSame('application/problem+json; charset=utf-8', $headers['content-type'][0]);
+        $this->assertSame('application/problem+json', $headers['content-type'][0]);
         $this->assertStringContainsString(
             '<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"',
             implode(',', $headers['link']),

--- a/tests/Functional/JsonLd/InputOutputDtoTest.php
+++ b/tests/Functional/JsonLd/InputOutputDtoTest.php
@@ -58,7 +58,7 @@ final class InputOutputDtoTest extends ApiTestCase
             'json' => ['foo' => 'test', 'bar' => 1],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $this->assertJsonContains([
             '@context' => '/contexts/JsonLdCustomInput',
             '@id' => '/jsonld_custom_inputs/1',
@@ -166,7 +166,7 @@ final class InputOutputDtoTest extends ApiTestCase
             'headers' => ['Accept' => 'application/ld+json'],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
         $this->assertSame('JsonLdNoInput', $body['@type']);
         $this->assertSame(1, $body['id']);
@@ -254,7 +254,7 @@ final class InputOutputDtoTest extends ApiTestCase
             'json' => ['email' => 'user@example.com'],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $body = $response->toArray();
         $this->assertSame('user@example.com', $body['email']);
     }

--- a/tests/Functional/JsonLd/IriOnlyTest.php
+++ b/tests/Functional/JsonLd/IriOnlyTest.php
@@ -34,7 +34,7 @@ final class IriOnlyTest extends ApiTestCase
     {
         $response = self::createClient()->request('GET', $uri);
         $this->assertResponseIsSuccessful();
-        $this->assertSame('application/ld+json; charset=utf-8', $response->getHeaders()['content-type'][0]);
+        $this->assertSame('application/ld+json', $response->getHeaders()['content-type'][0]);
         $this->assertSame([
             '@context' => [
                 '@vocab' => 'http://localhost/docs.jsonld#',

--- a/tests/Functional/JsonLd/MessengerTest.php
+++ b/tests/Functional/JsonLd/MessengerTest.php
@@ -39,7 +39,7 @@ final class MessengerTest extends ApiTestCase
             'json' => ['var' => 'test'],
         ]);
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $body = $response->toArray();
         $this->assertSame('/contexts/MessengerWithInput', $body['@context']);
         $this->assertSame('/messenger_with_inputs/1', $body['@id']);

--- a/tests/Functional/Mercure/MercureTest.php
+++ b/tests/Functional/Mercure/MercureTest.php
@@ -81,7 +81,7 @@ final class MercureTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
 
         $updates = $hub->getUpdates();
         $this->assertCount(1, $updates);
@@ -114,7 +114,7 @@ final class MercureTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
 
         $updates = $hub->getUpdates();
         $this->assertCount(1, $updates);

--- a/tests/Functional/MongoDb/EmbedManyWithoutTargetDocumentTest.php
+++ b/tests/Functional/MongoDb/EmbedManyWithoutTargetDocumentTest.php
@@ -55,7 +55,7 @@ final class EmbedManyWithoutTargetDocumentTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/DummyWithEmbedManyOmittingTargetDocument',
             '@id' => '/dummy_with_embed_many_omitting_target_documents/1',

--- a/tests/Functional/MongoDb/NestedReferenceFilterErrorTest.php
+++ b/tests/Functional/MongoDb/NestedReferenceFilterErrorTest.php
@@ -76,7 +76,7 @@ final class NestedReferenceFilterErrorTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummies?relatedDummy.thirdLevel.badFourthLevel.level=4', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(500);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $body = $response->toArray(false);
         $this->assertSame('/contexts/Error', $body['@context']);
         $this->assertSame('hydra:Error', $body['@type']);
@@ -89,7 +89,7 @@ final class NestedReferenceFilterErrorTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummies?relatedDummy.thirdLevel.fourthLevel.badThirdLevel.level=3', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(500);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $body = $response->toArray(false);
         $this->assertSame('/contexts/Error', $body['@context']);
         $this->assertSame('hydra:Error', $body['@type']);

--- a/tests/Functional/NotExposedTest.php
+++ b/tests/Functional/NotExposedTest.php
@@ -42,7 +42,7 @@ final class NotExposedTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/Chair', $data['@context']);
         $this->assertSame('/chairs', $data['@id']);
@@ -153,7 +153,7 @@ final class NotExposedTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Spoon',
             '@id' => '/cuillers/12345',

--- a/tests/Functional/NullOnNonNullablePropertyTest.php
+++ b/tests/Functional/NullOnNonNullablePropertyTest.php
@@ -43,7 +43,7 @@ final class NullOnNonNullablePropertyTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $body = $response->toArray(false);
         $this->assertStringContainsString('Expected argument of type "string", "null" given at property path "name"', $body['hydra:description'] ?? $body['detail'] ?? '');
     }
@@ -61,7 +61,7 @@ final class NullOnNonNullablePropertyTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
 
         $content = $response->toArray(false);
         $this->assertArrayHasKey('violations', $content);

--- a/tests/Functional/ObjectMapperValidationTest.php
+++ b/tests/Functional/ObjectMapperValidationTest.php
@@ -87,7 +87,7 @@ class ObjectMapperValidationTest extends ApiTestCase
 
         // Should return 422 validation error, NOT 500 database error
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
 
         // Verify we got the UniqueEntity validation error
         $this->assertJsonContains([

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -285,7 +285,7 @@ class OpenApiTest extends ApiTestCase
     {
         $response = self::createClient()->request('GET', '/docs', ['headers' => ['accept' => 'application/vnd.openapi+json']]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
         $json = $response->toArray();
 
         // Context
@@ -477,7 +477,7 @@ class OpenApiTest extends ApiTestCase
 
         $response = self::createClient()->request('GET', '/docs?api_gateway=true', ['headers' => ['accept' => 'application/vnd.openapi+json']]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
         $json = $response->toArray();
 
         $this->assertSame('/', $json['basePath']);
@@ -518,7 +518,7 @@ class OpenApiTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.openapi+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
         $json = $response->toArray();
 
         // Context
@@ -554,7 +554,7 @@ class OpenApiTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.openapi+yaml'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+yaml; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+yaml');
     }
 
     public function testRetrieveTheOpenApiDocumentationHtml(): void
@@ -630,7 +630,7 @@ class OpenApiTest extends ApiTestCase
             'headers' => ['Accept' => 'text/html,*/*;q=0.8'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
     }
 
     public function testOpenApiUiIsEnabledForDocsEndpointWithDummyObject(): void
@@ -649,7 +649,7 @@ class OpenApiTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.openapi+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
         $this->assertJson($response->getContent());
     }
 
@@ -659,7 +659,7 @@ class OpenApiTest extends ApiTestCase
             'headers' => ['Accept' => 'application/vnd.openapi+json'],
         ]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/vnd.openapi+json');
         $this->assertJson($response->getContent());
     }
 

--- a/tests/Functional/OperationResourceTest.php
+++ b/tests/Functional/OperationResourceTest.php
@@ -70,7 +70,7 @@ final class OperationResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/OperationResource',
             '@id' => '/operation_resources/1',
@@ -90,7 +90,7 @@ final class OperationResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/operation_resources/1.jsonld');
         $this->assertJsonEquals([
             '@context' => '/contexts/OperationResource',

--- a/tests/Functional/OperationTest.php
+++ b/tests/Functional/OperationTest.php
@@ -51,7 +51,7 @@ final class OperationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/ReadableOnlyProperty',
             '@id' => '/readable_only_properties/1',
@@ -66,7 +66,7 @@ final class OperationTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/relation_embedders/42/custom');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertSame('"This is a custom action for 42."', $response->getContent());
     }
 
@@ -88,7 +88,7 @@ final class OperationTest extends ApiTestCase
         self::createClient()->request('GET', '/embedded_dummies_groups/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/EmbeddedDummy',
             '@id' => '/embedded_dummies_groups/1',
@@ -131,7 +131,7 @@ final class OperationTest extends ApiTestCase
         self::createClient()->request('GET', '/books/by_isbn/9780451524935');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Book',
             '@id' => '/books/by_isbn/9780451524935',

--- a/tests/Functional/OverriddenOperationTest.php
+++ b/tests/Functional/OverriddenOperationTest.php
@@ -56,7 +56,7 @@ final class OverriddenOperationTest extends ApiTestCase
         $this->createDummy();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/OverriddenOperationDummy',
             '@id' => '/overridden_operation_dummies/1',
@@ -74,7 +74,7 @@ final class OverriddenOperationTest extends ApiTestCase
         self::createClient()->request('GET', '/overridden_operation_dummies/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/OverriddenOperationDummy',
             '@id' => '/overridden_operation_dummies/1',

--- a/tests/Functional/PatchTest.php
+++ b/tests/Functional/PatchTest.php
@@ -116,7 +116,7 @@ final class PatchTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/PatchDummyRelation',
             '@id' => '/patch_dummy_relations/1',
@@ -138,7 +138,7 @@ final class PatchTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Beta',
             '@id' => '/betas/1',

--- a/tests/Functional/ProviderProcessorEntityTest.php
+++ b/tests/Functional/ProviderProcessorEntityTest.php
@@ -51,7 +51,7 @@ final class ProviderProcessorEntityTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/processor_entities/1.jsonld');
         $this->assertResponseHeaderSame('Location', '/processor_entities/1');
         $this->assertJsonEquals([
@@ -71,7 +71,7 @@ final class ProviderProcessorEntityTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/provider_entities/1.jsonld');
         $this->assertResponseHeaderSame('Location', '/provider_entities/1');
         $this->assertJsonEquals([
@@ -93,7 +93,7 @@ final class ProviderProcessorEntityTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/provider_entities');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertArrayNotHasKey('content-location', array_change_key_case($response->getHeaders()));
         $this->assertJsonEquals([
             '@context' => '/contexts/ProviderEntity',
@@ -119,7 +119,7 @@ final class ProviderProcessorEntityTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/provider_entities/1');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertArrayNotHasKey('content-location', array_change_key_case($response->getHeaders()));
         $this->assertJsonEquals([
             '@context' => '/contexts/ProviderEntity',

--- a/tests/Functional/RelationTest.php
+++ b/tests/Functional/RelationTest.php
@@ -313,7 +313,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testPostRelationWithNotExistingIriReturns400(): void
@@ -326,7 +326,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testInvalidIriReturns400(): void
@@ -339,7 +339,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonContains(['detail' => 'Invalid IRI "certainly not an IRI".']);
     }
 
@@ -353,7 +353,7 @@ final class RelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $linkHeader = $response->getHeaders(false)['link'][0] ?? '';
         $this->assertStringContainsString('<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"', $linkHeader);
         $data = $response->toArray(false);

--- a/tests/Functional/Security/ContentNegotiationErrorsTest.php
+++ b/tests/Functional/Security/ContentNegotiationErrorsTest.php
@@ -47,7 +47,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(415);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'The content-type "text/plain" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/vnd.api+json", "application/xml", "text/xml", "application/json", "text/html", "application/graphql", "multipart/form-data".',
         ]);
@@ -58,7 +58,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies', ['headers' => ['Accept' => 'text/plain']]);
 
         $this->assertResponseStatusCodeSame(406);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Requested format "text/plain" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/vnd.api+json", "application/xml", "text/xml", "application/json", "text/html", "application/graphql", "multipart/form-data".',
         ]);
@@ -69,7 +69,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies/1.json', ['headers' => ['Accept' => 'text/xml']]);
 
         $this->assertResponseStatusCodeSame(406);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Requested format "text/xml" is not supported. Supported MIME types are "application/json".',
         ]);
@@ -80,7 +80,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies/1', ['headers' => ['Accept' => 'invalid']]);
 
         $this->assertResponseStatusCodeSame(406);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Requested format "invalid" is not supported. Supported MIME types are "application/ld+json", "application/hal+json", "application/vnd.api+json", "application/xml", "text/xml", "application/json", "text/html", "application/graphql", "multipart/form-data".',
         ]);
@@ -91,7 +91,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies/1.invalid');
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Format "invalid" is not supported',
         ]);
@@ -102,7 +102,7 @@ final class ContentNegotiationErrorsTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies/1.invalid', ['headers' => ['Accept' => 'text/invalid']]);
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Format "invalid" is not supported',
         ]);

--- a/tests/Functional/Security/SecurityHeadersTest.php
+++ b/tests/Functional/Security/SecurityHeadersTest.php
@@ -39,7 +39,7 @@ final class SecurityHeadersTest extends ApiTestCase
     {
         self::createClient()->request('GET', '/dummies', ['headers' => ['Accept' => 'application/ld+json']]);
 
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertResponseHeaderSame('x-content-type-options', 'nosniff');
         $this->assertResponseHeaderSame('x-frame-options', 'deny');
     }
@@ -72,7 +72,7 @@ final class SecurityHeadersTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertResponseHeaderSame('x-content-type-options', 'nosniff');
         $this->assertResponseHeaderSame('x-frame-options', 'deny');
     }

--- a/tests/Functional/Security/StrongTypingTest.php
+++ b/tests/Functional/Security/StrongTypingTest.php
@@ -50,7 +50,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Dummy',
             '@id' => '/dummies/1',
@@ -87,7 +87,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
@@ -107,7 +107,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
@@ -128,7 +128,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
     }
 
     public function testDateWithUnexpectedFormatIsRejected(): void
@@ -143,7 +143,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
     }
 
     public function testStringInsteadOfArrayOnCollectionRelationTriggersTypeError(): void
@@ -158,7 +158,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
@@ -179,7 +179,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
@@ -199,7 +199,7 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/Error',
             '@type' => 'hydra:Error',
@@ -219,6 +219,6 @@ final class StrongTypingTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
     }
 }

--- a/tests/Functional/Serializer/ConstructorDeserializationTest.php
+++ b/tests/Functional/Serializer/ConstructorDeserializationTest.php
@@ -50,7 +50,7 @@ final class ConstructorDeserializationTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/DummyEntityWithConstructor',
             '@id' => '/dummy_entity_with_constructors/1',

--- a/tests/Functional/Serializer/EmptyArrayAsObjectTest.php
+++ b/tests/Functional/Serializer/EmptyArrayAsObjectTest.php
@@ -33,7 +33,7 @@ final class EmptyArrayAsObjectTest extends ApiTestCase
         self::createClient()->request('GET', '/empty_array_as_objects/5', ['headers' => ['Accept' => 'application/ld+json']]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
     "@context": "/contexts/EmptyArrayAsObject",

--- a/tests/Functional/Serializer/GroupFilterTest.php
+++ b/tests/Functional/Serializer/GroupFilterTest.php
@@ -76,7 +76,7 @@ final class GroupFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -154,7 +154,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -223,7 +223,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -304,7 +304,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -376,7 +376,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -454,7 +454,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -523,7 +523,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -601,7 +601,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -667,7 +667,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -697,7 +697,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -724,7 +724,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -755,7 +755,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -783,7 +783,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -813,7 +813,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -840,7 +840,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -870,7 +870,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -903,7 +903,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -935,7 +935,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -964,7 +964,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -997,7 +997,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1028,7 +1028,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1061,7 +1061,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1094,7 +1094,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1126,7 +1126,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1154,7 +1154,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",
@@ -1186,7 +1186,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyGroup",

--- a/tests/Functional/Serializer/PropertyFilterTest.php
+++ b/tests/Functional/Serializer/PropertyFilterTest.php
@@ -83,7 +83,7 @@ final class PropertyFilterTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -133,7 +133,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -190,7 +190,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -237,7 +237,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -293,7 +293,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -338,7 +338,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -392,7 +392,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -421,7 +421,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -459,7 +459,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
       "type": "object",
@@ -499,7 +499,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyProperty",
@@ -532,7 +532,7 @@ JSON);
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
       "@context": "/contexts/DummyProperty",

--- a/tests/Functional/Serializer/ValueObjectRelationsTest.php
+++ b/tests/Functional/Serializer/ValueObjectRelationsTest.php
@@ -60,7 +60,7 @@ final class ValueObjectRelationsTest extends ApiTestCase
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
     "@context": "/contexts/VoDummyCar",
@@ -182,7 +182,7 @@ JSON);
         );
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
         $this->assertStringContainsString('<http://www.w3.org/ns/hydra/error>; rel="http://www.w3.org/ns/json-ld#error"', self::getClient()->getResponse()->headers->get('link') ?? '');
         $this->assertMatchesJsonSchema(<<<'JSON'
 {
@@ -213,7 +213,7 @@ JSON);
         );
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
         $this->assertJsonEquals(<<<'JSON'
 {
     "@context": "/contexts/VoDummyCar",

--- a/tests/Functional/SubResource/MultipleRelationTest.php
+++ b/tests/Functional/SubResource/MultipleRelationTest.php
@@ -40,7 +40,7 @@ final class MultipleRelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/RelationMultiple',
             '@id' => '/dummy/1/relations/2',
@@ -62,7 +62,7 @@ final class MultipleRelationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/RelationMultiple',
             '@id' => '/dummy/1/relations',

--- a/tests/Functional/SubResource/SubResourceTest.php
+++ b/tests/Functional/SubResource/SubResourceTest.php
@@ -162,7 +162,7 @@ final class SubResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/Answer',
             '@id' => '/questions/1/answer',
@@ -186,7 +186,7 @@ final class SubResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/OneToOneSubresourceAnswer',
             '@id' => '/one_to_one_subresource_questions/1/answer',
@@ -237,7 +237,7 @@ final class SubResourceTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummies/1/related_dummies');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/dummies/1/related_dummies', $data['@id']);
         $this->assertSame(2, $data['hydra:totalItems']);
@@ -266,7 +266,7 @@ final class SubResourceTest extends ApiTestCase
         self::createClient()->request('GET', '/dummies/1/related_dummies/2');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonContains([
             '@context' => '/contexts/RelatedDummy',
             '@id' => '/dummies/1/related_dummies/2',
@@ -286,7 +286,7 @@ final class SubResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testGetEmbeddedRelationAtThirdLevel(): void
@@ -315,7 +315,7 @@ final class SubResourceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/FourthLevel',
             '@id' => '/dummies/1/related_dummies/1/third_level/fourth_level',
@@ -446,7 +446,7 @@ final class SubResourceTest extends ApiTestCase
         self::createClient()->request('GET', '/people/1/sent_greetings');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertJsonEquals([
             '@context' => '/contexts/GreetingBySender',
             '@id' => '/people/1/sent_greetings',

--- a/tests/Functional/TableInheritanceTest.php
+++ b/tests/Functional/TableInheritanceTest.php
@@ -84,7 +84,7 @@ final class TableInheritanceTest extends ApiTestCase
         $data = $this->createChild();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertSame('DummyTableInheritanceChild', $data['@type']);
         $this->assertSame('/contexts/DummyTableInheritanceChild', $data['@context']);
         $this->assertSame('/dummy_table_inheritance_children/1', $data['@id']);
@@ -99,7 +99,7 @@ final class TableInheritanceTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/dummy_table_inheritances');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertCount(1, $data['hydra:member']);
         $this->assertSame('DummyTableInheritanceChild', $data['hydra:member'][0]['@type']);
@@ -134,7 +134,7 @@ final class TableInheritanceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('DummyTableInheritanceDifferentChild', $data['@type']);
         $this->assertSame('/contexts/DummyTableInheritanceDifferentChild', $data['@context']);
@@ -156,7 +156,7 @@ final class TableInheritanceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('DummyTableInheritanceRelated', $data['@type']);
         $this->assertSame('/dummy_table_inheritance_relateds/1', $data['@id']);
@@ -197,7 +197,7 @@ final class TableInheritanceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $members = $data['hydra:member'];
         $this->assertCount(2, $members);
@@ -218,7 +218,7 @@ final class TableInheritanceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('/contexts/ResourceInterface', $data['@context']);
         $this->assertSame('/resource_interfaces/single%20item', $data['@id']);
@@ -253,7 +253,7 @@ final class TableInheritanceTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertCount(3, $data['hydra:member']);
         foreach ($data['hydra:member'] as $i => $member) {

--- a/tests/Functional/UnionIntersectTypesTest.php
+++ b/tests/Functional/UnionIntersectTypesTest.php
@@ -41,7 +41,7 @@ final class UnionIntersectTypesTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('Book', $data['@type']);
         $this->assertSame('/contexts/Book', $data['@context']);
@@ -75,7 +75,7 @@ final class UnionIntersectTypesTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $data = $response->toArray();
         $this->assertSame('Book', $data['@type']);
         $this->assertSame(1, $data['number']);
@@ -95,7 +95,7 @@ final class UnionIntersectTypesTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'Could not denormalize object of type "ApiPlatform\\Tests\\Fixtures\\TestBundle\\ApiResource\\Issue5452\\ActivableInterface", no supporting normalizer found.',
         ]);

--- a/tests/Functional/Uuid/UuidIdentifierTest.php
+++ b/tests/Functional/Uuid/UuidIdentifierTest.php
@@ -56,7 +56,7 @@ final class UuidIdentifierTest extends ApiTestCase
         $this->createUuidDummy();
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
         $this->assertResponseHeaderSame('Content-Location', '/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78.jsonld');
         $this->assertResponseHeaderSame('Location', '/uuid_identifier_dummies/41b29566-144b-11e6-a148-3e1d05defe78');
     }
@@ -160,7 +160,7 @@ final class UuidIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/ramsey_uuid_dummies/41B29566-144B-11E6-A148-3E1D05DEFE78');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testDeleteRamseyUuidDummy(): void
@@ -189,7 +189,7 @@ final class UuidIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/ramsey_uuid_dummies/41B29566-144B-E1D05DEFE78');
 
         $this->assertResponseStatusCodeSame(404);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testCreateRamseyUuidDummy(): void
@@ -205,7 +205,7 @@ final class UuidIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testCreateRamseyUuidDummyWithNonIdField(): void
@@ -221,7 +221,7 @@ final class UuidIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testUpdateRamseyUuidNonIdField(): void
@@ -242,7 +242,7 @@ final class UuidIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testCreateBadRamseyUuidReturns400(): void
@@ -258,7 +258,7 @@ final class UuidIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testUpdateBadRamseyUuidReturns400(): void
@@ -279,7 +279,7 @@ final class UuidIdentifierTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(400);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
     }
 
     public function testGetSymfonyUuidDummy(): void
@@ -297,6 +297,6 @@ final class UuidIdentifierTest extends ApiTestCase
         self::createClient()->request('GET', '/symfony_uuid_dummies/cdf8f706-ebe3-4fb6-b0bd-ae7b48028f24');
 
         $this->assertResponseStatusCodeSame(200);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 }

--- a/tests/Functional/ValidationGroupsTest.php
+++ b/tests/Functional/ValidationGroupsTest.php
@@ -45,7 +45,7 @@ final class ValidationGroupsTest extends \ApiPlatform\Symfony\Bundle\Test\ApiTes
         ]);
 
         $this->assertResponseStatusCodeSame(201);
-        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/ld+json');
     }
 
     public function testValidationGroupsTriggerFailure(): void
@@ -56,7 +56,7 @@ final class ValidationGroupsTest extends \ApiPlatform\Symfony\Bundle\Test\ApiTes
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonContains([
             '@context' => '/contexts/ConstraintViolation',
             '@type' => 'ConstraintViolation',
@@ -77,7 +77,7 @@ final class ValidationGroupsTest extends \ApiPlatform\Symfony\Bundle\Test\ApiTes
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonContains([
             'detail' => 'title: This value should not be null.',
             'violations' => [[
@@ -96,7 +96,7 @@ final class ValidationGroupsTest extends \ApiPlatform\Symfony\Bundle\Test\ApiTes
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $data = $response->toArray(false);
         $this->assertSame('test: This value should not be null.', $data['detail']);
         $this->assertSame('test', $data['violations'][0]['propertyPath']);
@@ -115,7 +115,7 @@ final class ValidationGroupsTest extends \ApiPlatform\Symfony\Bundle\Test\ApiTes
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('Content-Type', 'application/problem+json');
         $this->assertJsonEquals([
             'status' => 422,
             'violations' => [[

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -59,7 +59,7 @@ final class ValidationTest extends ApiTestCase
         ]);
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertResponseHeaderSame('content-type', 'application/problem+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/problem+json');
 
         $this->assertJsonContains([
             '@context' => '/contexts/ConstraintViolation',

--- a/tests/Symfony/Bundle/Test/ClientTest.php
+++ b/tests/Symfony/Bundle/Test/ClientTest.php
@@ -122,7 +122,7 @@ class ClientTest extends ApiTestCase
         $this->recreateSchema([SecuredDummy::class, RelatedDummy::class]);
         self::createClient()->request('GET', '/secured_dummies', ['auth_basic' => ['dunglas', 'kevin']]);
         $this->assertResponseIsSuccessful();
-        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json');
 
         $this->assertJsonEquals([
             '@context' => '/contexts/SecuredDummy',


### PR DESCRIPTION
## Summary

Per [#8218 review feedback](https://github.com/api-platform/core/pull/8218#discussion_r3344757561), API Platform was unconditionally appending `; charset=utf-8` to every response `Content-Type`. JSON-based media types (`application/json` and the RFC 6839 `+json` structured syntax suffix family: `ld+json`, `hal+json`, `vnd.api+json`, `problem+json`, `merge-patch+json`, `vnd.openapi+json`…) do **not** define a `charset` parameter in their IANA registrations, and including one can be rejected by strict clients.

### RFC references

- RFC 8259 §11 (JSON media type registration): *"No `charset` parameter is defined for this registration."*
- RFC 8259 §8.1: JSON exchanged between systems MUST be encoded in UTF-8 — the parameter is redundant.
- RFC 6839: `+json` / `+yaml` structured syntax suffixes inherit the base type's parameter rules; neither defines `charset`.
- RFC 2046 §4.1: `text/*` types define `charset`.
- RFC 7303: `application/xml` and `application/xml-external-parsed-entity` define `charset`.

### Change

New `formatContentType()` helper in `HttpResponseHeadersTrait` that appends `; charset=utf-8` only for `text/*`, `application/xml`, and `application/xml-external-parsed-entity`. Everything else (JSON family, YAML, binary, etc.) returns the bare media type.

Functional tests asserting on `Content-Type` for JSON / YAML responses were updated accordingly.

## Test plan

- [x] `tests/Functional/` full suite green (1562 tests, 16351 assertions)
- [x] `tests/Symfony/Bundle/Test/ClientTest.php` green
- [x] Sample Laravel tests updated
- [ ] CI green on PR

Refs #8218