### PR TITLE
fix(metadata): stop emitting withBuiltinTypes deprecation from internal callers

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -191,3 +191,28 @@ parameters:
 			identifier: function.alreadyNarrowedType
 			path: tests/Symfony/Bundle/Command/DebugResourceCommandTest.php
 			reportUnmatched: false
+
+		# Structural assertions that document the ApiProperty internal API surface
+		# (see #8173). PHPStan correctly sees the methods as defined on this branch,
+		# but the assertions guard against accidental removal in future releases.
+		-
+			identifier: function.alreadyNarrowedType
+			path: src/Metadata/Tests/Property/Factory/InternalBuiltinTypesDeprecationTest.php
+			reportUnmatched: false
+
+		# Split-package consumers of ApiPlatform\Metadata guard internal accessors with
+		# method_exists() so the "lowest" dependency builds (api-platform/metadata <= 4.3.7,
+		# which lacks internalGetBuiltinTypes()) still install. PHPStan sees the method
+		# as always-defined when analysing the monorepo, hence the narrowed-type notice.
+		-
+			identifier: function.alreadyNarrowedType
+			paths:
+				- src/Elasticsearch
+				- src/GraphQl
+				- src/Hal
+				- src/Hydra
+				- src/JsonApi
+				- src/JsonSchema
+				- src/Serializer
+				- src/Symfony/Validator
+			reportUnmatched: false

--- a/src/Elasticsearch/Filter/AbstractFilter.php
+++ b/src/Elasticsearch/Filter/AbstractFilter.php
@@ -201,7 +201,7 @@ abstract class AbstractFilter implements FilterInterface
                 return $noop;
             }
 
-            $types = $propertyMetadata->internalGetBuiltinTypes();
+            $types = method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes();
 
             if (null === $types) {
                 return $noop;

--- a/src/Elasticsearch/Filter/AbstractFilter.php
+++ b/src/Elasticsearch/Filter/AbstractFilter.php
@@ -201,7 +201,7 @@ abstract class AbstractFilter implements FilterInterface
                 return $noop;
             }
 
-            $types = $propertyMetadata->getBuiltinTypes();
+            $types = $propertyMetadata->internalGetBuiltinTypes();
 
             if (null === $types) {
                 return $noop;

--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -69,7 +69,7 @@ trait FieldDatatypeTrait
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+            $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
             foreach ($types as $type) {
                 if (

--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -69,7 +69,7 @@ trait FieldDatatypeTrait
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->getBuiltinTypes() ?? [];
+            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
             foreach ($types as $type) {
                 if (

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -69,7 +69,7 @@ class ResolverFactory implements ResolverFactoryInterface
                         return $body;
                     }
                 } else {
-                    $type = $propertyMetadata?->getBuiltinTypes()[0] ?? null;
+                    $type = $propertyMetadata?->internalGetBuiltinTypes()[0] ?? null;
 
                     // Data already fetched and normalized (field or nested resource)
                     if ($body || null === $resourceClass || ($type && !$type->isCollection())) {

--- a/src/GraphQl/Resolver/Factory/ResolverFactory.php
+++ b/src/GraphQl/Resolver/Factory/ResolverFactory.php
@@ -69,7 +69,7 @@ class ResolverFactory implements ResolverFactoryInterface
                         return $body;
                     }
                 } else {
-                    $type = $propertyMetadata?->internalGetBuiltinTypes()[0] ?? null;
+                    $type = ($propertyMetadata && method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata?->getBuiltinTypes())[0] ?? null;
 
                     // Data already fetched and normalized (field or nested resource)
                     if ($body || null === $resourceClass || ($type && !$type->isCollection())) {

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -222,7 +222,7 @@ final class FieldsBuilder implements FieldsBuilderEnumInterface
                 $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, $context);
 
                 if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-                    $propertyTypes = $propertyMetadata->internalGetBuiltinTypes();
+                    $propertyTypes = method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes();
 
                     if (
                         !$propertyTypes

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -222,7 +222,7 @@ final class FieldsBuilder implements FieldsBuilderEnumInterface
                 $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, $context);
 
                 if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-                    $propertyTypes = $propertyMetadata->getBuiltinTypes();
+                    $propertyTypes = $propertyMetadata->internalGetBuiltinTypes();
 
                     if (
                         !$propertyTypes

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -192,7 +192,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 /** @var class-string|null $className */
                 $className = null;
             } else {
-                $types = $propertyMetadata->getBuiltinTypes() ?? [];
+                $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
             }
 
             // prevent declaring $attribute as attribute if it's already declared as relationship

--- a/src/Hal/Serializer/ItemNormalizer.php
+++ b/src/Hal/Serializer/ItemNormalizer.php
@@ -192,7 +192,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
                 /** @var class-string|null $className */
                 $className = null;
             } else {
-                $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+                $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
             }
 
             // prevent declaring $attribute as attribute if it's already declared as relationship

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -419,7 +419,7 @@ final class DocumentationNormalizer implements NormalizerInterface
             }
         // TODO: remove in 5.x
         } else {
-            $builtInTypes = $propertyMetadata->getBuiltinTypes() ?? [];
+            $builtInTypes = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
             foreach ($builtInTypes as $type) {
                 if ($type->isCollection() && null !== $collectionType = $type->getCollectionValueTypes()[0] ?? null) {
@@ -501,7 +501,7 @@ final class DocumentationNormalizer implements NormalizerInterface
         }
 
         // TODO: remove in 5.x
-        $builtInTypes = $propertyMetadata->getBuiltinTypes() ?? [];
+        $builtInTypes = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
         foreach ($builtInTypes as $type) {
             $className = $type->getClassName();

--- a/src/Hydra/Serializer/DocumentationNormalizer.php
+++ b/src/Hydra/Serializer/DocumentationNormalizer.php
@@ -419,7 +419,7 @@ final class DocumentationNormalizer implements NormalizerInterface
             }
         // TODO: remove in 5.x
         } else {
-            $builtInTypes = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+            $builtInTypes = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
             foreach ($builtInTypes as $type) {
                 if ($type->isCollection() && null !== $collectionType = $type->getCollectionValueTypes()[0] ?? null) {
@@ -501,7 +501,7 @@ final class DocumentationNormalizer implements NormalizerInterface
         }
 
         // TODO: remove in 5.x
-        $builtInTypes = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+        $builtInTypes = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
         foreach ($builtInTypes as $type) {
             $className = $type->getClassName();

--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -383,7 +383,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, $serializerContext ?? []);
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+            $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
             $isRelationship = false;
             $isOne = $isMany = false;
             $relatedClasses = [];

--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -383,7 +383,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         $propertyMetadata = $this->propertyMetadataFactory->create($resourceClass, $property, $serializerContext ?? []);
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->getBuiltinTypes() ?? [];
+            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
             $isRelationship = false;
             $isOne = $isMany = false;
             $relatedClasses = [];

--- a/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
@@ -95,7 +95,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $type = $propertyMetadata->getBuiltinTypes()[0] ?? null;
+            $type = $propertyMetadata->internalGetBuiltinTypes()[0] ?? null;
             if ($type && null !== $type->getClassName()) {
                 return "data/relationships/$fieldName";
             }

--- a/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
+++ b/src/JsonApi/Serializer/ConstraintViolationListNormalizer.php
@@ -95,7 +95,7 @@ final class ConstraintViolationListNormalizer implements NormalizerInterface
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $type = $propertyMetadata->internalGetBuiltinTypes()[0] ?? null;
+            $type = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes())[0] ?? null;
             if ($type && null !== $type->getClassName()) {
                 return "data/relationships/$fieldName";
             }

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -396,7 +396,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $isRelationship = false;
 
             if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-                $types = $propertyMetadata->getBuiltinTypes() ?? [];
+                $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
                 foreach ($types as $type) {
                     $isOne = $isMany = false;

--- a/src/JsonApi/Serializer/ItemNormalizer.php
+++ b/src/JsonApi/Serializer/ItemNormalizer.php
@@ -396,7 +396,7 @@ final class ItemNormalizer extends AbstractItemNormalizer
             $isRelationship = false;
 
             if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-                $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+                $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
                 foreach ($types as $type) {
                     $isOne = $isMany = false;

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -344,7 +344,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
 
     private function getLegacyTypeSchema(ApiProperty $propertyMetadata, array $propertySchema, string $resourceClass, string $property, ?bool $link): array
     {
-        $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+        $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
         $className = ($types[0] ?? null)?->getClassName() ?? null;
 
         if (null !== $propertyMetadata->getUriTemplate() || (!\array_key_exists('readOnly', $propertySchema) && false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable()) && !$className) {

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -344,7 +344,7 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
 
     private function getLegacyTypeSchema(ApiProperty $propertyMetadata, array $propertySchema, string $resourceClass, string $property, ?bool $link): array
     {
-        $types = $propertyMetadata->getBuiltinTypes() ?? [];
+        $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
         $className = ($types[0] ?? null)?->getClassName() ?? null;
 
         if (null !== $propertyMetadata->getUriTemplate() || (!\array_key_exists('readOnly', $propertySchema) && false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable()) && !$className) {

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -194,7 +194,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return;
         }
 
-        $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+        $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
         // never override the following keys if at least one is already set
         // or if property has no type(s) defined

--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -194,7 +194,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             return;
         }
 
-        $types = $propertyMetadata->getBuiltinTypes() ?? [];
+        $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
         // never override the following keys if at least one is already set
         // or if property has no type(s) defined

--- a/src/Metadata/ApiProperty.php
+++ b/src/Metadata/ApiProperty.php
@@ -534,11 +534,7 @@ final class ApiProperty
     {
         trigger_deprecation('api-platform/metadata', '4.2', 'The "%s()" method is deprecated, use "%s::getNativeType()" instead.', __METHOD__, self::class);
 
-        if (null === $this->builtinTypes && null !== $this->nativeType) {
-            $this->builtinTypes = PropertyInfoToTypeInfoHelper::convertTypeToLegacyTypes($this->nativeType) ?? [];
-        }
-
-        return $this->builtinTypes;
+        return $this->internalGetBuiltinTypes();
     }
 
     /**
@@ -550,6 +546,32 @@ final class ApiProperty
     {
         trigger_deprecation('api-platform/metadata', '4.2', 'The "%s()" method is deprecated, use "%s::withNativeType()" instead.', __METHOD__, self::class);
 
+        return $this->internalWithBuiltinTypes($builtinTypes);
+    }
+
+    /**
+     * @internal Same as {@see getBuiltinTypes()} but without the deprecation; used by API Platform's
+     *           own factories that still need the legacy representation on symfony/property-info < 7.1.
+     *
+     * @return LegacyType[]|null
+     */
+    public function internalGetBuiltinTypes(): ?array
+    {
+        if (null === $this->builtinTypes && null !== $this->nativeType) {
+            $this->builtinTypes = PropertyInfoToTypeInfoHelper::convertTypeToLegacyTypes($this->nativeType) ?? [];
+        }
+
+        return $this->builtinTypes;
+    }
+
+    /**
+     * @internal Same as {@see withBuiltinTypes()} but without the deprecation; used by API Platform's
+     *           own factories that still produce legacy types on symfony/property-info < 7.1.
+     *
+     * @param LegacyType[] $builtinTypes
+     */
+    public function internalWithBuiltinTypes(array $builtinTypes = []): static
+    {
         $self = clone $this;
         $self->builtinTypes = $builtinTypes;
         $self->nativeType = PropertyInfoToTypeInfoHelper::convertLegacyTypesToType($builtinTypes);

--- a/src/Metadata/IdentifiersExtractor.php
+++ b/src/Metadata/IdentifiersExtractor.php
@@ -133,7 +133,7 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
 
             // TODO: remove in 5.x
             if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-                $types = $propertyMetadata->getBuiltinTypes();
+                $types = $propertyMetadata->internalGetBuiltinTypes();
                 if (null === ($type = $types[0] ?? null)) {
                     continue;
                 }

--- a/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
@@ -132,8 +132,8 @@ final class AttributePropertyMetadataFactory implements PropertyMetadataFactoryI
                         continue;
                     }
 
-                    if ($builtinTypes = $attribute->getBuiltinTypes()) {
-                        $propertyMetadata = $propertyMetadata->withBuiltinTypes($builtinTypes);
+                    if ($builtinTypes = $attribute->internalGetBuiltinTypes()) {
+                        $propertyMetadata = $propertyMetadata->internalWithBuiltinTypes($builtinTypes);
                     }
 
                     continue;

--- a/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/ExtractorPropertyMetadataFactory.php
@@ -66,7 +66,7 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
                     continue;
                 }
 
-                $apiProperty = $apiProperty->withBuiltinTypes(array_map(static fn (string $builtinType): LegacyType => new LegacyType($builtinType), $value));
+                $apiProperty = $apiProperty->internalWithBuiltinTypes(array_map(static fn (string $builtinType): LegacyType => new LegacyType($builtinType), $value));
 
                 continue;
             }
@@ -118,6 +118,13 @@ final class ExtractorPropertyMetadataFactory implements PropertyMetadataFactoryI
     {
         foreach (get_class_methods(ApiProperty::class) as $method) {
             if (preg_match('/^(?:get|is)(.*)/', (string) $method, $matches) && null !== ($val = $metadata[lcfirst($matches[1])] ?? null) && method_exists($propertyMetadata, "with{$matches[1]}")) {
+                // BC layer, to remove in 5.0: route the deprecated builtinTypes setter to the internal one.
+                if ('BuiltinTypes' === $matches[1]) {
+                    $propertyMetadata = $propertyMetadata->internalWithBuiltinTypes($val);
+
+                    continue;
+                }
+
                 $propertyMetadata = $propertyMetadata->{"with{$matches[1]}"}($val);
             }
         }

--- a/src/Metadata/Property/Factory/PropertyInfoPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/PropertyInfoPropertyMetadataFactory.php
@@ -48,7 +48,7 @@ final class PropertyInfoPropertyMetadataFactory implements PropertyMetadataFacto
 
         // TODO: remove in 5.x
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            if (!$propertyMetadata->getBuiltinTypes()) {
+            if (!$propertyMetadata->internalGetBuiltinTypes()) {
                 $types = $this->propertyInfo->getTypes($resourceClass, $property, $options) ?? []; // @phpstan-ignore-line
 
                 foreach ($types as $i => $type) {
@@ -58,7 +58,7 @@ final class PropertyInfoPropertyMetadataFactory implements PropertyMetadataFacto
                     }
                 }
 
-                $propertyMetadata = $propertyMetadata->withBuiltinTypes($types);
+                $propertyMetadata = $propertyMetadata->internalWithBuiltinTypes($types);
             }
         } else {
             if (!$propertyMetadata->getNativeType()) {

--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -76,7 +76,7 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
 
         // TODO: remove in 5.x
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->getBuiltinTypes() ?? [];
+            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
             if (!$this->isResourceClass($resourceClass) && $types) {
                 foreach ($types as $builtinType) {

--- a/src/Metadata/Tests/Property/Factory/InternalBuiltinTypesDeprecationTest.php
+++ b/src/Metadata/Tests/Property/Factory/InternalBuiltinTypesDeprecationTest.php
@@ -17,10 +17,8 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\AttributePropertyMetadataFactory;
 use ApiPlatform\Metadata\Property\Factory\ExtractorPropertyMetadataFactory;
 use ApiPlatform\Metadata\Property\Factory\PropertyInfoPropertyMetadataFactory;
-use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\DummyWithApiPropertyAttributes;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 
 /**
@@ -44,8 +42,13 @@ final class InternalBuiltinTypesDeprecationTest extends TestCase
     protected function setUp(): void
     {
         $this->deprecations = [];
+        // Only record deprecations that target ApiProperty's legacy builtin types accessors:
+        // the surrounding code (e.g. instantiating Symfony's LegacyType on property-info 7.3+)
+        // also emits unrelated deprecations that must not influence this test.
         set_error_handler(function (int $errno, string $errstr): bool {
-            $this->deprecations[] = $errstr;
+            if (str_contains($errstr, 'ApiPlatform\Metadata\ApiProperty::')) {
+                $this->deprecations[] = $errstr;
+            }
 
             return true;
         }, \E_USER_DEPRECATED);
@@ -64,10 +67,6 @@ final class InternalBuiltinTypesDeprecationTest extends TestCase
 
     public function testInternalBuiltinTypesAccessorsDoNotEmitDeprecation(): void
     {
-        if (!method_exists(ApiProperty::class, 'internalWithBuiltinTypes') || !method_exists(ApiProperty::class, 'internalGetBuiltinTypes')) {
-            $this->markTestSkipped('Internal builtin types accessors are not available; covered by the structural test.');
-        }
-
         $types = class_exists(LegacyType::class) ? [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)] : [];
 
         $property = (new ApiProperty())->internalWithBuiltinTypes($types);

--- a/src/Metadata/Tests/Property/Factory/InternalBuiltinTypesDeprecationTest.php
+++ b/src/Metadata/Tests/Property/Factory/InternalBuiltinTypesDeprecationTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Property\Factory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Property\Factory\AttributePropertyMetadataFactory;
+use ApiPlatform\Metadata\Property\Factory\ExtractorPropertyMetadataFactory;
+use ApiPlatform\Metadata\Property\Factory\PropertyInfoPropertyMetadataFactory;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\DummyWithApiPropertyAttributes;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
+
+/**
+ * Regression test for #8173: internal factories must not emit
+ * "ApiProperty::withBuiltinTypes()" / "getBuiltinTypes()" deprecations
+ * when building property metadata.
+ *
+ * The public deprecated methods must keep emitting the deprecation for
+ * userland callers, but ApiPlatform's own factories must use an internal
+ * code path that does not trigger it.
+ */
+final class InternalBuiltinTypesDeprecationTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @var list<string>
+     */
+    private array $deprecations = [];
+
+    protected function setUp(): void
+    {
+        $this->deprecations = [];
+        set_error_handler(function (int $errno, string $errstr): bool {
+            $this->deprecations[] = $errstr;
+
+            return true;
+        }, \E_USER_DEPRECATED);
+    }
+
+    protected function tearDown(): void
+    {
+        restore_error_handler();
+    }
+
+    public function testApiPropertyExposesInternalBuiltinTypesAccessors(): void
+    {
+        $this->assertTrue(method_exists(ApiProperty::class, 'internalGetBuiltinTypes'), 'ApiProperty must expose an internal getter to read builtin types without triggering the deprecation.');
+        $this->assertTrue(method_exists(ApiProperty::class, 'internalWithBuiltinTypes'), 'ApiProperty must expose an internal setter to store builtin types without triggering the deprecation.');
+    }
+
+    public function testInternalBuiltinTypesAccessorsDoNotEmitDeprecation(): void
+    {
+        if (!method_exists(ApiProperty::class, 'internalWithBuiltinTypes') || !method_exists(ApiProperty::class, 'internalGetBuiltinTypes')) {
+            $this->markTestSkipped('Internal builtin types accessors are not available; covered by the structural test.');
+        }
+
+        $types = class_exists(LegacyType::class) ? [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)] : [];
+
+        $property = (new ApiProperty())->internalWithBuiltinTypes($types);
+        $property->internalGetBuiltinTypes();
+        $this->assertEmpty($this->deprecations, 'The internal builtin types accessors must not emit any deprecation. Got: '.implode("\n", $this->deprecations));
+    }
+
+    public function testPublicWithBuiltinTypesStillEmitsDeprecation(): void
+    {
+        $types = class_exists(LegacyType::class) ? [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)] : [];
+
+        (new ApiProperty())->withBuiltinTypes($types);
+
+        $found = false;
+        foreach ($this->deprecations as $message) {
+            if (str_contains($message, 'ApiPlatform\Metadata\ApiProperty::withBuiltinTypes()')) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'The public withBuiltinTypes() method must still emit a deprecation for external callers.');
+    }
+
+    public function testPublicGetBuiltinTypesStillEmitsDeprecation(): void
+    {
+        $property = new ApiProperty();
+        $property->getBuiltinTypes();
+
+        $found = false;
+        foreach ($this->deprecations as $message) {
+            if (str_contains($message, 'ApiPlatform\Metadata\ApiProperty::getBuiltinTypes()')) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, 'The public getBuiltinTypes() method must still emit a deprecation for external callers.');
+    }
+
+    public function testAttributePropertyMetadataFactorySourceUsesInternalAccessors(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(AttributePropertyMetadataFactory::class))->getFileName());
+
+        $this->assertStringNotContainsString('->withBuiltinTypes(', $source, 'AttributePropertyMetadataFactory must not call the deprecated public withBuiltinTypes() on ApiProperty.');
+        $this->assertStringNotContainsString('->getBuiltinTypes(', $source, 'AttributePropertyMetadataFactory must not call the deprecated public getBuiltinTypes() on ApiProperty.');
+    }
+
+    public function testExtractorPropertyMetadataFactorySourceUsesInternalAccessors(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(ExtractorPropertyMetadataFactory::class))->getFileName());
+
+        $this->assertStringNotContainsString('->withBuiltinTypes(', $source, 'ExtractorPropertyMetadataFactory must not call the deprecated public withBuiltinTypes() on ApiProperty.');
+        $this->assertStringNotContainsString('->getBuiltinTypes(', $source, 'ExtractorPropertyMetadataFactory must not call the deprecated public getBuiltinTypes() on ApiProperty.');
+    }
+
+    public function testPropertyInfoPropertyMetadataFactorySourceUsesInternalAccessors(): void
+    {
+        $source = file_get_contents((new \ReflectionClass(PropertyInfoPropertyMetadataFactory::class))->getFileName());
+
+        $this->assertStringNotContainsString('->withBuiltinTypes(', $source, 'PropertyInfoPropertyMetadataFactory must not call the deprecated public withBuiltinTypes() on ApiProperty.');
+        $this->assertStringNotContainsString('->getBuiltinTypes(', $source, 'PropertyInfoPropertyMetadataFactory must not call the deprecated public getBuiltinTypes() on ApiProperty.');
+    }
+}

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -791,7 +791,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+            $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
 
             foreach ($types as $type) {
                 if (
@@ -1126,7 +1126,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         $type = null;
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
+            $types = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
         } else {
             $type = $propertyMetadata->getNativeType();
             $types = $type instanceof CompositeTypeInterface ? $type->getTypes() : (null === $type ? [] : [$type]);

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -791,7 +791,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         }
 
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->getBuiltinTypes() ?? [];
+            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
 
             foreach ($types as $type) {
                 if (
@@ -1126,7 +1126,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         $type = null;
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $types = $propertyMetadata->getBuiltinTypes() ?? [];
+            $types = $propertyMetadata->internalGetBuiltinTypes() ?? [];
         } else {
             $type = $propertyMetadata->getNativeType();
             $types = $type instanceof CompositeTypeInterface ? $type->getTypes() : (null === $type ? [] : [$type]);

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -106,13 +106,13 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
             return false;
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_STRING];
         }
 
         if (
-            null !== ($builtinType = ($propertyMetadata->getBuiltinTypes()[0] ?? null))
+            null !== ($builtinType = ($propertyMetadata->internalGetBuiltinTypes()[0] ?? null))
             && $builtinType->isCollection()
             && \count($builtinType->getCollectionValueTypes()) > 0
         ) {

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaChoiceRestriction.php
@@ -106,13 +106,14 @@ final class PropertySchemaChoiceRestriction implements PropertySchemaRestriction
             return false;
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $legacyBuiltinTypes = (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? [];
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $legacyBuiltinTypes);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_STRING];
         }
 
         if (
-            null !== ($builtinType = ($propertyMetadata->internalGetBuiltinTypes()[0] ?? null))
+            null !== ($builtinType = ($legacyBuiltinTypes[0] ?? null))
             && $builtinType->isCollection()
             && \count($builtinType->getCollectionValueTypes()) > 0
         ) {

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
@@ -52,7 +52,7 @@ final class PropertySchemaGreaterThanOrEqualRestriction implements PropertySchem
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanOrEqualRestriction.php
@@ -52,7 +52,7 @@ final class PropertySchemaGreaterThanOrEqualRestriction implements PropertySchem
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
@@ -56,7 +56,7 @@ final class PropertySchemaGreaterThanRestriction implements PropertySchemaRestri
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaGreaterThanRestriction.php
@@ -56,7 +56,7 @@ final class PropertySchemaGreaterThanRestriction implements PropertySchemaRestri
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
@@ -59,7 +59,7 @@ class PropertySchemaLengthRestriction implements PropertySchemaRestrictionMetada
             return $constraint instanceof Length && $type?->isIdentifiedBy(TypeIdentifier::STRING);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_STRING];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLengthRestriction.php
@@ -59,7 +59,7 @@ class PropertySchemaLengthRestriction implements PropertySchemaRestrictionMetada
             return $constraint instanceof Length && $type?->isIdentifiedBy(TypeIdentifier::STRING);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_STRING];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
@@ -55,7 +55,7 @@ final class PropertySchemaLessThanOrEqualRestriction implements PropertySchemaRe
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanOrEqualRestriction.php
@@ -55,7 +55,7 @@ final class PropertySchemaLessThanOrEqualRestriction implements PropertySchemaRe
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
@@ -53,7 +53,7 @@ final class PropertySchemaLessThanRestriction implements PropertySchemaRestricti
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaLessThanRestriction.php
@@ -53,7 +53,7 @@ final class PropertySchemaLessThanRestriction implements PropertySchemaRestricti
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
@@ -63,7 +63,7 @@ final class PropertySchemaRangeRestriction implements PropertySchemaRestrictionM
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->getBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }

--- a/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
+++ b/src/Symfony/Validator/Metadata/Property/Restriction/PropertySchemaRangeRestriction.php
@@ -63,7 +63,7 @@ final class PropertySchemaRangeRestriction implements PropertySchemaRestrictionM
             return $type->isIdentifiedBy(TypeIdentifier::INT, TypeIdentifier::FLOAT);
         }
 
-        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), $propertyMetadata->internalGetBuiltinTypes() ?? []);
+        $types = array_map(static fn (LegacyType $type) => $type->getBuiltinType(), (method_exists($propertyMetadata, 'internalGetBuiltinTypes') ? $propertyMetadata->internalGetBuiltinTypes() : $propertyMetadata->getBuiltinTypes()) ?? []);
         if ($propertyMetadata->getExtraProperties()['nested_schema'] ?? false) {
             $types = [LegacyType::BUILTIN_TYPE_INT];
         }


### PR DESCRIPTION
## Summary

`ApiProperty::withBuiltinTypes()` / `getBuiltinTypes()` were deprecated in 4.2 in favor of the native-type equivalents, but API Platform's own factories and normalizers still call them on the legacy `symfony/property-info` code path. On Symfony 6.4 this produced ~600 deprecation entries per request even though no userland code touches the deprecated API.

This PR adds two `@internal` methods on `ApiProperty` (`internalGetBuiltinTypes()` / `internalWithBuiltinTypes()`) that perform the same storage/conversion without emitting the deprecation, and routes every internal call site through them. The public methods keep emitting the deprecation for external callers, preserving the existing BC promise.

## Reproduction

On Symfony < 7.1 (or any property-info without `getType()`) `vendor/api-platform/metadata/ApiProperty.php:551` fires `withBuiltinTypes()` deprecations from `ExtractorPropertyMetadataFactory`, `AttributePropertyMetadataFactory`, `PropertyInfoPropertyMetadataFactory`, and several normalizers/restrictions during normal property metadata building.

## Test plan

- [x] Added failing test covering the bug.
- [x] Test passes after the fix.
- [x] Related test classes still pass locally (`src/Metadata/Tests/Property/`, `src/JsonSchema/Tests/`, `src/Hal/Tests/`, `src/JsonApi/Tests/`, `src/Hydra/Tests/`, `src/Serializer/Tests/`, `src/GraphQl/Tests/`, `src/Elasticsearch/Tests/`, `src/Symfony/Tests/Validator/Metadata/Property/Restriction/`). The two pre-existing failures in `ResourceMetadataCompatibilityTest` and three in `src/Hal/Tests/` reproduce on `upstream/4.3` and are unrelated to this change.

Fixes #8173