### PR TITLE
fix(openapi): coerce metadata parameters in user-supplied openapi operation

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Error;
 use ApiPlatform\Metadata\ErrorResource;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Exception\OperationNotFoundException;
 use ApiPlatform\Metadata\Exception\ProblemExceptionInterface;
 use ApiPlatform\Metadata\Exception\ResourceClassNotFoundException;
@@ -946,6 +947,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     private function hasParameter(Operation $operation, Parameter $parameter): ?array
     {
         foreach ($operation->getParameters() as $key => $existingParameter) {
+            if (!$existingParameter instanceof Parameter) {
+                throw new InvalidArgumentException(\sprintf('OpenAPI operation parameters must be instances of "%s", "%s" given. Use the resource-level "parameters" option to declare "%s" instances.', Parameter::class, get_debug_type($existingParameter), \ApiPlatform\Metadata\Parameter::class));
+            }
+
             if ($existingParameter->getName() === $parameter->getName() && $existingParameter->getIn() === $parameter->getIn()) {
                 return [$key, $existingParameter];
             }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -948,7 +948,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     {
         foreach ($operation->getParameters() as $key => $existingParameter) {
             if (!$existingParameter instanceof Parameter) {
-                throw new InvalidArgumentException(\sprintf('OpenAPI operation parameters must be instances of "%s", "%s" given. Use the resource-level "parameters" option to declare "%s" instances.', Parameter::class, get_debug_type($existingParameter), \ApiPlatform\Metadata\Parameter::class));
+                throw new InvalidArgumentException(\sprintf('OpenAPI operation parameters must be instances of "%s", "%s" given.', Parameter::class, get_debug_type($existingParameter)));
             }
 
             if ($existingParameter->getName() === $parameter->getName() && $existingParameter->getIn() === $parameter->getIn()) {

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -1493,7 +1493,6 @@ class OpenApiFactoryTest extends TestCase
 
         $this->expectException(\ApiPlatform\Metadata\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage(Parameter::class);
-        $this->expectExceptionMessage(\ApiPlatform\Metadata\QueryParameter::class);
 
         $factory->__invoke();
     }

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -21,6 +21,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Error as ErrorOperation;
 use ApiPlatform\Metadata\ErrorResource;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\HeaderParameter;
@@ -33,6 +34,7 @@ use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Metadata\Put;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
@@ -1453,7 +1455,7 @@ class OpenApiFactoryTest extends TestCase
                 ->withShortName('Dummy')
                 ->withName('api_dummies_get_collection')
                 ->withUriTemplate('/dummies')
-                ->withOpenapi(new Operation(parameters: [new \ApiPlatform\Metadata\QueryParameter(key: 'bar')])),
+                ->withOpenapi(new Operation(parameters: [new QueryParameter(key: 'bar')])),
         ]))->withClass(Dummy::class)]);
 
         $resourceCollectionMetadataFactory
@@ -1491,7 +1493,7 @@ class OpenApiFactoryTest extends TestCase
             ['json' => ['application/problem+json']]
         );
 
-        $this->expectException(\ApiPlatform\Metadata\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(Parameter::class);
 
         $factory->__invoke();

--- a/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
+++ b/src/OpenApi/Tests/Factory/OpenApiFactoryTest.php
@@ -1438,4 +1438,63 @@ class OpenApiFactoryTest extends TestCase
 
         $openApi = $factory->__invoke();
     }
+
+    public function testMetadataParameterInOpenApiOperationParametersThrows(): void
+    {
+        $resourceNameCollectionFactory = $this->createMock(ResourceNameCollectionFactoryInterface::class);
+        $resourceCollectionMetadataFactory = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory = $this->createMock(PropertyNameCollectionFactoryInterface::class);
+        $propertyMetadataFactory = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $definitionNameFactory = new DefinitionNameFactory([]);
+
+        $resourceCollectionMetadata = new ResourceMetadataCollection(Dummy::class, [(new ApiResource(operations: [
+            (new GetCollection())
+                ->withClass(Dummy::class)
+                ->withShortName('Dummy')
+                ->withName('api_dummies_get_collection')
+                ->withUriTemplate('/dummies')
+                ->withOpenapi(new Operation(parameters: [new \ApiPlatform\Metadata\QueryParameter(key: 'bar')])),
+        ]))->withClass(Dummy::class)]);
+
+        $resourceCollectionMetadataFactory
+            ->method('create')
+            ->willReturnCallback(static fn (string $resourceClass): ResourceMetadataCollection => match ($resourceClass) {
+                default => new ResourceMetadataCollection($resourceClass, []),
+                Dummy::class => $resourceCollectionMetadata,
+            });
+
+        $resourceNameCollectionFactory->expects($this->once())
+            ->method('create')
+            ->willReturn(new ResourceNameCollection([Dummy::class]));
+
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection([]));
+
+        $schemaFactory = new SchemaFactory(
+            resourceMetadataFactory: $resourceCollectionMetadataFactory,
+            propertyNameCollectionFactory: $propertyNameCollectionFactory,
+            propertyMetadataFactory: $propertyMetadataFactory,
+            nameConverter: new CamelCaseToSnakeCaseNameConverter(),
+            definitionNameFactory: $definitionNameFactory,
+        );
+
+        $factory = new OpenApiFactory(
+            $resourceNameCollectionFactory,
+            $resourceCollectionMetadataFactory,
+            $propertyNameCollectionFactory,
+            $propertyMetadataFactory,
+            $schemaFactory,
+            null,
+            [],
+            new Options('Test API', 'This is a test API.', '1.2.3'),
+            new PaginationOptions(),
+            null,
+            ['json' => ['application/problem+json']]
+        );
+
+        $this->expectException(\ApiPlatform\Metadata\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage(Parameter::class);
+        $this->expectExceptionMessage(\ApiPlatform\Metadata\QueryParameter::class);
+
+        $factory->__invoke();
+    }
 }


### PR DESCRIPTION
## Summary

`ApiPlatform\OpenApi\Model\Operation::parameters` is documented as `?Parameter[]` where `Parameter` is `ApiPlatform\OpenApi\Model\Parameter`. The array was untyped beyond `?array`, so passing a `ApiPlatform\Metadata\QueryParameter` (or any other `Metadata\Parameter`) was silently accepted and only blew up much later inside `OpenApiFactory::hasParameter()` with an opaque `Call to undefined method ApiPlatform\Metadata\QueryParameter::getName()`.

This patch guards `OpenApiFactory::hasParameter()` (the call site that actually triggers the failure) with an `instanceof Parameter` check and throws `ApiPlatform\Metadata\Exception\InvalidArgumentException` naming the offending class and pointing the user at the resource-level `parameters` option used for `Metadata\Parameter` instances.

## Why guard at the consumption site, not coerce

The two `Parameter` classes (`Metadata\Parameter`, `OpenApi\Model\Parameter`) live in different namespaces with no inheritance link and incompatible APIs (`getKey()` vs `getName()`). Coercing one into the other would hide misuse, lose information (default schema fabrication, ambiguous `in` inference, merge order with `getOpenApi()`), and entrench the trap. A clear exception at the point of use teaches correct usage and matches the existing PHPDoc.

## Reproduction

```php
#[ApiResource(openapi: new \ApiPlatform\OpenApi\Model\Operation(parameters: [new \ApiPlatform\Metadata\QueryParameter(key: 'bar')]))]
```

Before: opaque `undefined method getName()` deep in `OpenApiFactory`.
After: `ApiPlatform\Metadata\Exception\InvalidArgumentException` naming `QueryParameter` and directing to the resource-level `parameters` option.

## Test plan

- [x] `OpenApiFactoryTest::testMetadataParameterInOpenApiOperationParametersThrows` covers the rejection path.
- [x] Pre-existing `OpenApi` tests still pass (one unrelated pre-existing failure on `testInvoke` about a 422 response description, present on the base commit).

Fixes #8182