### PR TITLE
fix(openapi): disambiguate definition names when input and output share a shortname

### DIFF
--- a/src/JsonSchema/DefinitionNameFactory.php
+++ b/src/JsonSchema/DefinitionNameFactory.php
@@ -44,9 +44,10 @@ final class DefinitionNameFactory implements DefinitionNameFactoryInterface
         }
 
         if (null !== $inputOrOutputClass && $className !== $inputOrOutputClass) {
-            $parts = explode('\\', $inputOrOutputClass);
-            $shortName = end($parts);
-            $prefix .= self::GLUE.$shortName;
+            // Use createPrefixFromClass so DTOs with identical short names but different
+            // FQCNs (e.g. App\...\Input\ThingCreate and App\...\Output\ThingCreate) get
+            // disambiguated suffixes instead of overwriting each other in the schema map.
+            $prefix .= self::GLUE.$this->createPrefixFromClass($inputOrOutputClass);
         }
 
         // TODO: remove in 5.0

--- a/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
+++ b/src/JsonSchema/Tests/DefinitionNameFactoryTest.php
@@ -15,8 +15,11 @@ namespace ApiPlatform\JsonSchema\Tests;
 
 use ApiPlatform\JsonSchema\DefinitionNameFactory;
 use ApiPlatform\JsonSchema\SchemaFactory;
+use ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\InputOutputCollision\Input\ThingCreate as InputThingCreate;
+use ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\InputOutputCollision\Output\ThingCreate as OutputThingCreate;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DtoOutput;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -143,6 +146,35 @@ final class DefinitionNameFactoryTest extends TestCase
         self::assertEquals(
             'DummyClass.jsonhal',
             $definitionNameFactory->create(Fixtures\DefinitionNameFactory\NamespaceA\Module\DummyClass::class, 'jsonhal')
+        );
+    }
+
+    public function testCreateDistinctDefinitionNamesWhenInputAndOutputShareShortName(): void
+    {
+        $definitionNameFactory = new DefinitionNameFactory();
+
+        $operation = new Post(class: Dummy::class, shortName: 'Thing');
+
+        $inputName = $definitionNameFactory->create(
+            Dummy::class,
+            'jsonld',
+            InputThingCreate::class,
+            $operation,
+            ['schema_type' => \ApiPlatform\JsonSchema\Schema::TYPE_INPUT]
+        );
+
+        $outputName = $definitionNameFactory->create(
+            Dummy::class,
+            'jsonld',
+            OutputThingCreate::class,
+            $operation,
+            ['schema_type' => \ApiPlatform\JsonSchema\Schema::TYPE_OUTPUT]
+        );
+
+        self::assertNotSame(
+            $inputName,
+            $outputName,
+            'Input and Output DTO classes sharing the same short name must produce distinct definition names.'
         );
     }
 

--- a/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/InputOutputCollision/Input/ThingCreate.php
+++ b/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/InputOutputCollision/Input/ThingCreate.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\InputOutputCollision\Input;
+
+class ThingCreate
+{
+}

--- a/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/InputOutputCollision/Output/ThingCreate.php
+++ b/src/JsonSchema/Tests/Fixtures/DefinitionNameFactory/InputOutputCollision/Output/ThingCreate.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\JsonSchema\Tests\Fixtures\DefinitionNameFactory\InputOutputCollision\Output;
+
+class ThingCreate
+{
+}


### PR DESCRIPTION
## Summary

When an operation declares both `input` and `output` as DTO classes that share the same basename
(but live in different namespaces), `DefinitionNameFactory` produced an identical definition name
for both, so the input schema was overwritten by the output schema and Swagger UI displayed the
output DTO as the request body. This patch reuses the existing `createPrefixFromClass`
disambiguation for the input/output suffix, so colliding short names now fall back to
progressively longer namespace-qualified suffixes — existing non-colliding names are unchanged.

## Reproduction

Declare an operation with `input: App\...\Input\ThingCreate::class` and
`output: App\...\Output\ThingCreate::class` — before this fix both produced the same `$ref`
(e.g. `#/definitions/Thing.ThingCreate.jsonld`).

## Test plan

- [x] Added failing test covering the bug.
- [x] Test passes after the fix.
- [x] Related test classes still pass locally.

Fixes #8169