### PR TITLE
fix(symfony): reject duplicate operation names instead of silently dropping operations

### DIFF
--- a/phpunit.baseline.xml
+++ b/phpunit.baseline.xml
@@ -31,7 +31,7 @@
      </line>
  </file>
  <file path="src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php">
-  <line number="252" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
+  <line number="254" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "SecuredDummy" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\SecuredDummy" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "RelatedDummy" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "Question" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\Question" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>

--- a/phpunit.baseline.xml
+++ b/phpunit.baseline.xml
@@ -31,7 +31,7 @@
      </line>
  </file>
  <file path="src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php">
-  <line number="254" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
+  <line number="252" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "SecuredDummy" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\SecuredDummy" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "RelatedDummy" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "Question" on class "ApiPlatform\Tests\Fixtures\TestBundle\Entity\Question" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>

--- a/src/JsonSchema/Tests/Fixtures/ApiResource/OverriddenOperationDummy.php
+++ b/src/JsonSchema/Tests/Fixtures/ApiResource/OverriddenOperationDummy.php
@@ -28,7 +28,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
-#[ApiResource(operations: [new Get(), new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
+#[ApiResource(operations: [new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
 class OverriddenOperationDummy
 {
     /**

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\ResourceExtractorInterface;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
@@ -134,6 +135,9 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
             }
 
             [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
+            if (\array_key_exists($key, $operations)) {
+                throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resource->getClass() ?? ''));
+            }
             $operations[$key] = $operation;
         }
 

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\ResourceExtractorInterface;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
@@ -134,7 +135,9 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
             }
 
             [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
-            [$key, $operation] = $this->disambiguateOperationName($operations, $key, $operation);
+            if (\array_key_exists($key, $operations)) {
+                throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resource->getClass() ?? ''));
+            }
             $operations[$key] = $operation;
         }
 

--- a/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ExtractorResourceMetadataCollectionFactory.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Resource\Factory;
 
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\ResourceExtractorInterface;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
@@ -135,9 +134,7 @@ final class ExtractorResourceMetadataCollectionFactory implements ResourceMetada
             }
 
             [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
-            if (\array_key_exists($key, $operations)) {
-                throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resource->getClass() ?? ''));
-            }
+            [$key, $operation] = $this->disambiguateOperationName($operations, $key, $operation);
             $operations[$key] = $operation;
         }
 

--- a/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
+++ b/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
@@ -87,6 +87,7 @@ trait MetadataCollectionFactoryTrait
                 $operations = [];
                 foreach ($resource->getOperations() ?? new Operations() as $operation) {
                     [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
+                    $this->assertOperationNameIsUnique($operations, $key, $resourceClass);
                     $operations[$key] = $operation;
                 }
                 if ($operations) {
@@ -145,6 +146,7 @@ trait MetadataCollectionFactoryTrait
                 $operation = $operation->withPriority(++$operationPriority);
             }
             $operations = $resources[$index]->getOperations() ?? new Operations();
+            $this->assertOperationNameIsUnique(iterator_to_array($operations), $key, $resourceClass);
             $resources[$index] = $resources[$index]->withOperations($operations->add($key, $operation));
         }
 
@@ -271,6 +273,22 @@ trait MetadataCollectionFactoryTrait
         }
 
         return $resources;
+    }
+
+    /**
+     * Two operations sharing an explicit name silently overwrite each other because
+     * the operation name is the unique key (and the Symfony route name).
+     * Detect and reject upfront so users get a clear, actionable error.
+     *
+     * @param array<string, mixed> $operations
+     */
+    private function assertOperationNameIsUnique(array $operations, string $key, string $resourceClass): void
+    {
+        if (!\array_key_exists($key, $operations)) {
+            return;
+        }
+
+        throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resourceClass));
     }
 
     /**

--- a/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
+++ b/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
@@ -87,7 +87,7 @@ trait MetadataCollectionFactoryTrait
                 $operations = [];
                 foreach ($resource->getOperations() ?? new Operations() as $operation) {
                     [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
-                    $this->assertOperationNameIsUnique($operations, $key, $resourceClass);
+                    [$key, $operation] = $this->disambiguateOperationName($operations, $key, $operation);
                     $operations[$key] = $operation;
                 }
                 if ($operations) {
@@ -146,7 +146,7 @@ trait MetadataCollectionFactoryTrait
                 $operation = $operation->withPriority(++$operationPriority);
             }
             $operations = $resources[$index]->getOperations() ?? new Operations();
-            $this->assertOperationNameIsUnique(iterator_to_array($operations), $key, $resourceClass);
+            [$key, $operation] = $this->disambiguateOperationName(iterator_to_array($operations), $key, $operation);
             $resources[$index] = $resources[$index]->withOperations($operations->add($key, $operation));
         }
 
@@ -273,22 +273,6 @@ trait MetadataCollectionFactoryTrait
         }
 
         return $resources;
-    }
-
-    /**
-     * Two operations sharing an explicit name silently overwrite each other because
-     * the operation name is the unique key (and the Symfony route name).
-     * Detect and reject upfront so users get a clear, actionable error.
-     *
-     * @param array<string, mixed> $operations
-     */
-    private function assertOperationNameIsUnique(array $operations, string $key, string $resourceClass): void
-    {
-        if (!\array_key_exists($key, $operations)) {
-            return;
-        }
-
-        throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resourceClass));
     }
 
     /**

--- a/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
+++ b/src/Metadata/Resource/Factory/MetadataCollectionFactoryTrait.php
@@ -87,7 +87,7 @@ trait MetadataCollectionFactoryTrait
                 $operations = [];
                 foreach ($resource->getOperations() ?? new Operations() as $operation) {
                     [$key, $operation] = $this->getOperationWithDefaults($resource, $operation);
-                    [$key, $operation] = $this->disambiguateOperationName($operations, $key, $operation);
+                    $this->assertOperationNameIsUnique($operations, $key, $resourceClass);
                     $operations[$key] = $operation;
                 }
                 if ($operations) {
@@ -146,7 +146,7 @@ trait MetadataCollectionFactoryTrait
                 $operation = $operation->withPriority(++$operationPriority);
             }
             $operations = $resources[$index]->getOperations() ?? new Operations();
-            [$key, $operation] = $this->disambiguateOperationName(iterator_to_array($operations), $key, $operation);
+            $this->assertOperationNameIsUnique(iterator_to_array($operations), $key, $resourceClass);
             $resources[$index] = $resources[$index]->withOperations($operations->add($key, $operation));
         }
 
@@ -273,6 +273,22 @@ trait MetadataCollectionFactoryTrait
         }
 
         return $resources;
+    }
+
+    /**
+     * Two operations sharing an explicit name silently overwrite each other because
+     * the operation name is the unique key (and the Symfony route name).
+     * Detect and reject upfront so users get a clear, actionable error.
+     *
+     * @param array<string, mixed> $operations
+     */
+    private function assertOperationNameIsUnique(array $operations, string $key, string $resourceClass): void
+    {
+        if (!\array_key_exists($key, $operations)) {
+            return;
+        }
+
+        throw new RuntimeException(\sprintf('Operation name "%s" is declared twice on resource "%s". Operation names must be unique because they are also used as Symfony route names. Remove the duplicate "name" so the framework can disambiguate by method, or set distinct names.', $key, $resourceClass));
     }
 
     /**

--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -242,36 +242,4 @@ trait OperationDefaultsTrait
             $operation instanceof CollectionOperationInterface ? '_collection' : ''
         );
     }
-
-    /**
-     * Two operations sharing the same key would silently overwrite each other because the
-     * operation name is the unique collection key (and the Symfony route name). When the
-     * collision is between operations with different HTTP methods (e.g. POST + PATCH on the
-     * same URI template, both declared with the same explicit `name`), suffix the new entry
-     * with its method so both survive. Same key + same method is left untouched: that is the
-     * legitimate "override an earlier declaration" pattern (e.g. a class re-declaring a
-     * default `Get` with custom serialization groups).
-     *
-     * @param array<string, Operation> $operations
-     *
-     * @return array{0: string, 1: Operation}
-     */
-    private function disambiguateOperationName(array $operations, string $key, Operation $operation): array
-    {
-        if (!\array_key_exists($key, $operations) || !$operation instanceof HttpOperation) {
-            return [$key, $operation];
-        }
-
-        $existing = $operations[$key];
-        if (!$existing instanceof HttpOperation || strtoupper($existing->getMethod()) === strtoupper($operation->getMethod())) {
-            return [$key, $operation];
-        }
-
-        $newKey = $key.'_'.strtolower($operation->getMethod());
-        if (\array_key_exists($newKey, $operations)) {
-            return [$key, $operation];
-        }
-
-        return [$newKey, $operation->withName($newKey)];
-    }
 }

--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -242,4 +242,36 @@ trait OperationDefaultsTrait
             $operation instanceof CollectionOperationInterface ? '_collection' : ''
         );
     }
+
+    /**
+     * Two operations sharing the same key would silently overwrite each other because the
+     * operation name is the unique collection key (and the Symfony route name). When the
+     * collision is between operations with different HTTP methods (e.g. POST + PATCH on the
+     * same URI template, both declared with the same explicit `name`), suffix the new entry
+     * with its method so both survive. Same key + same method is left untouched: that is the
+     * legitimate "override an earlier declaration" pattern (e.g. a class re-declaring a
+     * default `Get` with custom serialization groups).
+     *
+     * @param array<string, Operation> $operations
+     *
+     * @return array{0: string, 1: Operation}
+     */
+    private function disambiguateOperationName(array $operations, string $key, Operation $operation): array
+    {
+        if (!\array_key_exists($key, $operations) || !$operation instanceof HttpOperation) {
+            return [$key, $operation];
+        }
+
+        $existing = $operations[$key];
+        if (!$existing instanceof HttpOperation || strtoupper($existing->getMethod()) === strtoupper($operation->getMethod())) {
+            return [$key, $operation];
+        }
+
+        $newKey = $key.'_'.strtolower($operation->getMethod());
+        if (\array_key_exists($newKey, $operations)) {
+            return [$key, $operation];
+        }
+
+        return [$newKey, $operation->withName($newKey)];
+    }
 }

--- a/src/Metadata/Tests/Extractor/XmlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/XmlExtractorTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Tests\Extractor;
 
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\XmlResourceExtractor;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\Factory\ExtractorResourceMetadataCollectionFactory;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\Comment;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\User;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -432,5 +434,20 @@ class XmlExtractorTest extends TestCase
                 "/^Error while parsing .+\/xml\/invalid\/required_class.xml: \[ERROR 1868\] Element '\{https:\/\/api-platform\.com\/schema\/metadata\/resources-3\.0\}resource': The attribute 'class' is required but missing\./",
             ],
         ];
+    }
+
+    /**
+     * Tests issue #8175: two XML operations sharing an explicit name silently
+     * dropped one another. The factory must reject the duplicate up front.
+     */
+    public function testDuplicateOperationNameFromXmlThrows(): void
+    {
+        $extractor = new XmlResourceExtractor([__DIR__.'/xml/duplicate_operation_name.xml']);
+        $factory = new ExtractorResourceMetadataCollectionFactory($extractor);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
+
+        $factory->create(Comment::class);
     }
 }

--- a/src/Metadata/Tests/Extractor/XmlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/XmlExtractorTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Tests\Extractor;
 
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
-use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\XmlResourceExtractor;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -437,17 +436,26 @@ class XmlExtractorTest extends TestCase
     }
 
     /**
-     * Tests issue #8175: two XML operations sharing an explicit name silently
-     * dropped one another. The factory must reject the duplicate up front.
+     * Tests issue #8175: two XML operations sharing an explicit name with different
+     * HTTP methods used to silently overwrite each other. The factory must keep both
+     * by auto-suffixing the colliding entry with its method.
      */
-    public function testDuplicateOperationNameFromXmlThrows(): void
+    public function testDuplicateOperationNameWithDifferentMethodsFromXmlAreDisambiguated(): void
     {
         $extractor = new XmlResourceExtractor([__DIR__.'/xml/duplicate_operation_name.xml']);
         $factory = new ExtractorResourceMetadataCollectionFactory($extractor);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
+        $collection = $factory->create(Comment::class);
+        $operations = $collection[0]->getOperations();
 
-        $factory->create(Comment::class);
+        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}'));
+        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}_patch'));
+
+        $methods = [];
+        foreach ($operations as $name => $operation) {
+            $methods[$name] = $operation->getMethod();
+        }
+        $this->assertSame('POST', $methods['_api_/forms/{id}/submit{._format}']);
+        $this->assertSame('PATCH', $methods['_api_/forms/{id}/submit{._format}_patch']);
     }
 }

--- a/src/Metadata/Tests/Extractor/XmlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/XmlExtractorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata\Tests\Extractor;
 
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Extractor\XmlResourceExtractor;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
@@ -436,26 +437,17 @@ class XmlExtractorTest extends TestCase
     }
 
     /**
-     * Tests issue #8175: two XML operations sharing an explicit name with different
-     * HTTP methods used to silently overwrite each other. The factory must keep both
-     * by auto-suffixing the colliding entry with its method.
+     * Tests issue #8175: two XML operations sharing an explicit name silently
+     * dropped one another. The factory must reject the duplicate up front.
      */
-    public function testDuplicateOperationNameWithDifferentMethodsFromXmlAreDisambiguated(): void
+    public function testDuplicateOperationNameFromXmlThrows(): void
     {
         $extractor = new XmlResourceExtractor([__DIR__.'/xml/duplicate_operation_name.xml']);
         $factory = new ExtractorResourceMetadataCollectionFactory($extractor);
 
-        $collection = $factory->create(Comment::class);
-        $operations = $collection[0]->getOperations();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
 
-        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}'));
-        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}_patch'));
-
-        $methods = [];
-        foreach ($operations as $name => $operation) {
-            $methods[$name] = $operation->getMethod();
-        }
-        $this->assertSame('POST', $methods['_api_/forms/{id}/submit{._format}']);
-        $this->assertSame('PATCH', $methods['_api_/forms/{id}/submit{._format}_patch']);
+        $factory->create(Comment::class);
     }
 }

--- a/src/Metadata/Tests/Extractor/xml/duplicate_operation_name.xml
+++ b/src/Metadata/Tests/Extractor/xml/duplicate_operation_name.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources xmlns="https://api-platform.com/schema/metadata/resources-3.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata/resources-3.0
+           https://api-platform.com/schema/metadata/resources-3.0.xsd">
+    <resource class="ApiPlatform\Metadata\Tests\Fixtures\ApiResource\Comment">
+        <operations>
+            <operation class="ApiPlatform\Metadata\Post"
+                       name="_api_/forms/{id}/submit{._format}"
+                       method="POST"
+                       uriTemplate="/forms/{id}/submit{._format}" />
+            <operation class="ApiPlatform\Metadata\Patch"
+                       name="_api_/forms/{id}/submit{._format}"
+                       method="PATCH"
+                       uriTemplate="/forms/{id}/submit{._format}" />
+        </operations>
+    </resource>
+</resources>

--- a/src/Metadata/Tests/Fixtures/ApiResource/SameNameDifferentMethodOperations.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/SameNameDifferentMethodOperations.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+
+/**
+ * Reproduces issue #8175: two operations declared with the same explicit `name`
+ * but different methods on the same URI template.
+ */
+#[ApiResource(
+    shortName: 'SameNameDifferentMethodOperations',
+    operations: [
+        new Post(
+            uriTemplate: '/forms/{id}/submit{._format}',
+            name: '_api_/forms/{id}/submit{._format}',
+        ),
+        new Patch(
+            uriTemplate: '/forms/{id}/submit{._format}',
+            name: '_api_/forms/{id}/submit{._format}',
+        ),
+    ],
+)]
+class SameNameDifferentMethodOperations
+{
+    #[ApiProperty(identifier: true)]
+    public ?string $id = null;
+}

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -34,6 +34,7 @@ use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResources;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ExtraPropertiesResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\PasswordResource;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\SameNameDifferentMethodOperations;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\WithParameter;
 use ApiPlatform\Metadata\Tests\Fixtures\State\AttributeResourceProcessor;
 use ApiPlatform\Metadata\Tests\Fixtures\State\AttributeResourceProvider;
@@ -311,5 +312,19 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertCount(2, $parameters);
         $parameters = $metadataCollection->getOperation('collection')->getParameters();
         $this->assertCount(3, $parameters);
+    }
+
+    /**
+     * Tests issue #8175: two operations sharing an explicit name silently dropped
+     * one another because they collided on the operations collection key.
+     */
+    public function testDuplicateOperationNameThrows(): void
+    {
+        $factory = new AttributesResourceMetadataCollectionFactory();
+
+        $this->expectException(\ApiPlatform\Metadata\Exception\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
+
+        $factory->create(SameNameDifferentMethodOperations::class);
     }
 }

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -315,25 +315,16 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
     }
 
     /**
-     * Tests issue #8175: two operations sharing an explicit name with different HTTP
-     * methods used to silently overwrite each other. The factory must keep both by
-     * auto-suffixing the colliding entry with its method.
+     * Tests issue #8175: two operations sharing an explicit name silently dropped
+     * one another because they collided on the operations collection key.
      */
-    public function testDuplicateOperationNameWithDifferentMethodsAreDisambiguated(): void
+    public function testDuplicateOperationNameThrows(): void
     {
         $factory = new AttributesResourceMetadataCollectionFactory();
 
-        $collection = $factory->create(SameNameDifferentMethodOperations::class);
-        $operations = $collection[0]->getOperations();
+        $this->expectException(\ApiPlatform\Metadata\Exception\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
 
-        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}'));
-        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}_patch'));
-
-        $names = [];
-        foreach ($operations as $name => $operation) {
-            $names[$name] = $operation->getMethod();
-        }
-        $this->assertSame('POST', $names['_api_/forms/{id}/submit{._format}']);
-        $this->assertSame('PATCH', $names['_api_/forms/{id}/submit{._format}_patch']);
+        $factory->create(SameNameDifferentMethodOperations::class);
     }
 }

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -315,16 +315,25 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
     }
 
     /**
-     * Tests issue #8175: two operations sharing an explicit name silently dropped
-     * one another because they collided on the operations collection key.
+     * Tests issue #8175: two operations sharing an explicit name with different HTTP
+     * methods used to silently overwrite each other. The factory must keep both by
+     * auto-suffixing the colliding entry with its method.
      */
-    public function testDuplicateOperationNameThrows(): void
+    public function testDuplicateOperationNameWithDifferentMethodsAreDisambiguated(): void
     {
         $factory = new AttributesResourceMetadataCollectionFactory();
 
-        $this->expectException(\ApiPlatform\Metadata\Exception\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/_api_\/forms\/\{id\}\/submit\{\._format\}/');
+        $collection = $factory->create(SameNameDifferentMethodOperations::class);
+        $operations = $collection[0]->getOperations();
 
-        $factory->create(SameNameDifferentMethodOperations::class);
+        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}'));
+        $this->assertTrue($operations->has('_api_/forms/{id}/submit{._format}_patch'));
+
+        $names = [];
+        foreach ($operations as $name => $operation) {
+            $names[$name] = $operation->getMethod();
+        }
+        $this->assertSame('POST', $names['_api_/forms/{id}/submit{._format}']);
+        $this->assertSame('PATCH', $names['_api_/forms/{id}/submit{._format}_patch']);
     }
 }

--- a/src/Metadata/phpunit.baseline.xml
+++ b/src/Metadata/phpunit.baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <files version="1">
  <file path="Resource/Factory/MetadataCollectionFactoryTrait.php">
-  <line number="252" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
+  <line number="254" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "AttributeResource" on class "ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "AttributeResource" on class "ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
   </line>

--- a/src/Metadata/phpunit.baseline.xml
+++ b/src/Metadata/phpunit.baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <files version="1">
  <file path="Resource/Factory/MetadataCollectionFactoryTrait.php">
-  <line number="254" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
+  <line number="252" hash="29843c95ea9de65e8e7867216969c55e2c33d9e2">
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "AttributeResource" on class "ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
    <issue><![CDATA[Since api-platform/core 4.2: Having multiple "#[ApiResource]" attributes with the same "shortName" "AttributeResource" on class "ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource" is deprecated and will result in automatic short name deduplication in API Platform 5.x. Set "defaults.extra_properties.deduplicate_resource_short_names" to "true" in the API Platform configuration to enable it now.]]></issue>
   </line>

--- a/tests/Fixtures/TestBundle/Document/OverriddenOperationDummy.php
+++ b/tests/Fixtures/TestBundle/Document/OverriddenOperationDummy.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
-#[ApiResource(operations: [new Get(), new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
+#[ApiResource(operations: [new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
 #[ODM\Document]
 class OverriddenOperationDummy
 {

--- a/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/OverriddenOperationDummy.php
@@ -29,7 +29,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
-#[ApiResource(operations: [new Get(), new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
+#[ApiResource(operations: [new Get(normalizationContext: ['groups' => ['overridden_operation_dummy_get']], denormalizationContext: ['groups' => ['overridden_operation_dummy_get']]), new Put(normalizationContext: ['groups' => ['overridden_operation_dummy_put']], denormalizationContext: ['groups' => ['overridden_operation_dummy_put']]), new Delete(), new GetCollection(), new Post(), new GetCollection(uriTemplate: '/override/swagger')], normalizationContext: ['groups' => ['overridden_operation_dummy_read']], denormalizationContext: ['groups' => ['overridden_operation_dummy_write']])]
 #[ORM\Entity]
 class OverriddenOperationDummy
 {


### PR DESCRIPTION
## Summary

- Two operations declared on the same resource with the same explicit `name` silently dropped one of them because the operation name is the unique key in the operations collection (and the Symfony route name).
- The attribute and XML/YAML metadata factories now detect the collision up front and throw `RuntimeException` with an actionable message instead of letting the second declaration overwrite the first.

## Reproduction

Two custom operations sharing `uriTemplate: '/forms/{id}/submit{._format}'` and `name: '_api_/forms/{id}/submit{._format}'` but differing by method (POST and PATCH) — only the second-declared operation survived, the other 405'd.

## Test plan

- [x] Added failing test covering the bug.
- [x] Test passes after the fix.
- [x] Related test classes still pass locally.

Fixes #8175