### PR TITLE
ci(commitlint): check PR commits against PR base ref

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Fetch PR head
         run: git fetch origin pull/${{ github.event.pull_request.number }}/head:pr_head
       - name: Run commitlint


### PR DESCRIPTION
## Summary

`.github/workflows/commitlint.yml` uses `actions/checkout@v6` with no `ref:` argument. For `pull_request_target` events, that defaults to the target repo's default branch (`main`), not the PR base.

The workflow then computes `merge-base HEAD pr_head` where HEAD=main and walks `rev-list` forward to pick the "first PR commit". Because main and 4.3 diverged long ago, that walk picks the oldest 4.3 commit since divergence — currently `fix(graphiql): migrate to v5 via esm.sh CDN (#8209)`. Scope `graphiql` is not in `.commitlintrc` → the check fails on every PR against 4.3.

## Fix

Set `ref: ${{ github.event.pull_request.base.ref }}` on the checkout step so HEAD becomes the PR's actual base (e.g. `4.3`). The existing shell logic for merge-base + rev-list is then correct.

## Reproduction

Any PR against `4.3` since the workflow landed has hit this — see commitlint runs on #8226, #8229–#8233.

## Test plan

- [ ] CI confirms commitlint passes on this PR (the first commit of which is itself a valid `ci(commitlint): ...` message).