### PR TITLE
fix(test): capture streamedresponse body in test client response

### DIFF
--- a/src/Symfony/Bundle/Test/Response.php
+++ b/src/Symfony/Bundle/Test/Response.php
@@ -51,9 +51,6 @@ final class Response implements ResponseInterface
             }
         }
 
-        // StreamedResponse::getContent() returns false because the body is streamed via a callback.
-        // BrowserKit's HttpKernelBrowser::filterResponse already buffered the streamed output into
-        // the BrowserKit response, so use it as the source of truth to avoid re-streaming.
         $this->content = $httpFoundationResponse instanceof StreamedResponse
             ? $browserKitResponse->getContent()
             : (string) $httpFoundationResponse->getContent();

--- a/src/Symfony/Bundle/Test/Response.php
+++ b/src/Symfony/Bundle/Test/Response.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -50,7 +51,12 @@ final class Response implements ResponseInterface
             }
         }
 
-        $this->content = (string) $httpFoundationResponse->getContent();
+        // StreamedResponse::getContent() returns false because the body is streamed via a callback.
+        // BrowserKit's HttpKernelBrowser::filterResponse already buffered the streamed output into
+        // the BrowserKit response, so use it as the source of truth to avoid re-streaming.
+        $this->content = $httpFoundationResponse instanceof StreamedResponse
+            ? $browserKitResponse->getContent()
+            : (string) $httpFoundationResponse->getContent();
         $this->info = [
             'http_code' => $httpFoundationResponse->getStatusCode(),
             'error' => null,

--- a/tests/Symfony/Bundle/Test/ResponseTest.php
+++ b/tests/Symfony/Bundle/Test/ResponseTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
+use Symfony\Component\HttpFoundation\StreamedJsonResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ResponseTest extends TestCase
 {
@@ -121,5 +123,37 @@ class ResponseTest extends TestCase
         $response->cancel();
 
         $this->assertSame('Response has been canceled.', $response->getInfo('error'));
+    }
+
+    public function testStreamedResponseContentIsCapturedFromBrowserKitResponse(): void
+    {
+        $streamedBody = '{"foo":"bar"}';
+        // BrowserKit's HttpKernelBrowser::filterResponse already buffered the streamed body
+        // into the BrowserKit Response, but the HttpFoundation StreamedResponse::getContent()
+        // still returns false. The Response wrapper must read from the BrowserKit response.
+        $browserKitResponse = new BrowserKitResponse($streamedBody, 200, ['content-type' => 'application/json']);
+        $httpFoundationResponse = new StreamedResponse(static function () use ($streamedBody): void {
+            echo $streamedBody;
+        }, 200, ['content-type' => 'application/json']);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+
+        $this->assertSame($streamedBody, $response->getContent());
+        $this->assertSame(['foo' => 'bar'], $response->toArray());
+    }
+
+    public function testStreamedJsonResponseContentIsCapturedFromBrowserKitResponse(): void
+    {
+        if (!class_exists(StreamedJsonResponse::class)) {
+            $this->markTestSkipped('StreamedJsonResponse is not available.');
+        }
+
+        $streamedBody = '{"items":[1,2,3]}';
+        $browserKitResponse = new BrowserKitResponse($streamedBody, 200, ['content-type' => 'application/json']);
+        $httpFoundationResponse = new StreamedJsonResponse(['items' => [1, 2, 3]]);
+
+        $response = new Response($httpFoundationResponse, $browserKitResponse, []);
+
+        $this->assertSame($streamedBody, $response->getContent());
     }
 }


### PR DESCRIPTION
## Summary

Since Symfony 6.1 ([symfony/symfony#46445](https://github.com/symfony/symfony/issues/46445)), `HttpFoundation\StreamedResponse::getContent()` returns `false` because the body is streamed via a callback. The test client wrapper (`ApiPlatform\Symfony\Bundle\Test\Response`) cast that to string in its constructor, yielding an empty body so functional tests reading `$response->getContent()` against streamed endpoints saw `""` instead of the actual response.

`BrowserKit\HttpKernelBrowser::filterResponse` already buffers the streamed output via `ob_start()` and stores it on the BrowserKit `Response`. The fix reads from the BrowserKit response when the kernel response is a `StreamedResponse` (covers `StreamedJsonResponse` too), avoiding both the empty-body case and any re-streaming.

## Reproduction

A state provider (or controller) returning `StreamedResponse` invoked through `ApiTestCase::createClient()` produced an empty `$response->getContent()`.

## Test plan

- [x] Added failing test covering `StreamedResponse` and `StreamedJsonResponse` cases (`tests/Symfony/Bundle/Test/ResponseTest.php`).
- [x] Test passes after the fix.
- [x] `vendor/bin/phpunit tests/Symfony/Bundle/Test` — 66 tests, 108 assertions, all green.

Fixes #5780