### PR TITLE
fix(graphql): dispatch item Query through its own provider

### DIFF
--- a/src/Doctrine/Common/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Common/State/LinksHandlerTrait.php
@@ -35,6 +35,13 @@ trait LinksHandlerTrait
         $links = $this->getOperationLinks($operation);
 
         if (!($linkClass = $context['linkClass'] ?? false)) {
+            // Root item lookup: GraphQl Query.links carries relation links (for nested traversal)
+            // and the identifier-self link. Keep only the identifier-self / self-references so
+            // handleLinks applies WHERE id=X without consuming identifiers via relation joins.
+            if ($operation instanceof GraphQlOperation) {
+                return array_values(array_filter($links, static fn ($l) => null === $l->getToClass() || $l->getToClass() === $resourceClass));
+            }
+
             return $links;
         }
 

--- a/src/GraphQl/State/Provider/ReadProvider.php
+++ b/src/GraphQl/State/Provider/ReadProvider.php
@@ -21,6 +21,7 @@ use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\GraphQl\Mutation;
 use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
+use ApiPlatform\Metadata\GraphQl\Query;
 use ApiPlatform\Metadata\GraphQl\QueryCollection;
 use ApiPlatform\Metadata\GraphQl\Subscription;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -63,7 +64,11 @@ final class ReadProvider implements ProviderInterface
             }
 
             try {
-                $item = $this->iriConverter->getResourceFromIri($identifier, $context);
+                // For item Query carrying its own provider, dispatch through that provider.
+                // Mutation/Subscription keep the route-matched HTTP op so ReadProvider's class-mismatch
+                // diagnostics below stay accurate.
+                $dispatchOperation = ($operation instanceof Query && null !== $operation->getProvider()) ? $operation : null;
+                $item = $this->iriConverter->getResourceFromIri($identifier, $context, $dispatchOperation);
             } catch (ItemNotFoundException) {
                 $item = null;
             }

--- a/src/Laravel/Eloquent/State/LinksHandler.php
+++ b/src/Laravel/Eloquent/State/LinksHandler.php
@@ -56,6 +56,22 @@ final class LinksHandler implements LinksHandlerInterface
         }
 
         if (!($linkClass = $context['linkClass'] ?? false)) {
+            // GraphQl root item: walk the identifier-self link to apply WHERE id=X.
+            // Mirror of Doctrine\Common\State\LinksHandlerTrait::getLinks root-mode filter.
+            $resourceClass = $builder->getModel()::class;
+            foreach ($operation->getLinks() ?? [] as $link) {
+                if ($link->getFromProperty() || $link->getToProperty()) {
+                    continue;
+                }
+                if (null !== $link->getToClass() && $resourceClass !== $link->getToClass()) {
+                    continue;
+                }
+                $parameterName = $link->getParameterName() ?? ($link->getIdentifiers()[0] ?? null);
+                if (null !== $parameterName && isset($uriVariables[$parameterName])) {
+                    $builder = $this->buildQuery($builder, $link, $uriVariables[$parameterName]);
+                }
+            }
+
             return $builder;
         }
 

--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -20,6 +20,7 @@ use ApiPlatform\Metadata\Exception\OperationNotFoundException;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -72,17 +73,21 @@ class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(\sprintf('No resource associated to "%s".', $iri));
         }
 
-        $operation = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
+        $routeOperation = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
 
-        if ($operation instanceof CollectionOperationInterface) {
+        if ($routeOperation instanceof CollectionOperationInterface) {
             throw new InvalidArgumentException(\sprintf('The iri "%s" references a collection not an item.', $iri));
         }
 
-        if (!$operation instanceof HttpOperation) {
+        if (!$routeOperation instanceof HttpOperation) {
             throw new RuntimeException(\sprintf('The iri "%s" does not reference an HTTP operation.', $iri));
         }
 
-        if ($item = $this->provider->provide($operation, $parameters['uri_variables'], $context)) {
+        $dispatchOperation = ($operation instanceof GraphQlOperation && null !== $operation->getProvider())
+            ? $operation
+            : $routeOperation;
+
+        if ($item = $this->provider->provide($dispatchOperation, $parameters['uri_variables'], $context)) {
             return $item; // @phpstan-ignore-line
         }
 

--- a/src/Metadata/Resource/Factory/LinkResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/LinkResourceMetadataCollectionFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Resource\Factory;
 
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Link;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 
@@ -51,6 +52,13 @@ final class LinkResourceMetadataCollectionFactory implements ResourceMetadataCol
                     $links[] = $this->linkFactory->completeLink($link);
                 }
                 $links = $this->mergeLinks($relationLinks, $links);
+
+                // Item Query/Mutation/Subscription need the identifier-self link so Doctrine
+                // LinksHandler can apply `WHERE id = X` when dispatched through the GraphQl op
+                // (see Doctrine\Common\State\LinksHandlerTrait::getLinks root-mode filter).
+                if (!$graphQlOperation instanceof CollectionOperationInterface) {
+                    $links = $this->mergeLinks($this->linkFactory->createLinksFromIdentifiers($graphQlOperation), $links);
+                }
 
                 $graphQlOperations[$graphQlOperation->getName()] = $graphQlOperation->withLinks($links);
             }

--- a/src/Metadata/Tests/Resource/Factory/LinkResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/LinkResourceMetadataCollectionFactoryTest.php
@@ -84,6 +84,7 @@ class LinkResourceMetadataCollectionFactoryTest extends TestCase
                     class: AttributeResource::class,
                     graphQlOperations: [
                         'item_query' => (new Query(shortName: 'AttributeResource', class: AttributeResource::class))->withLinks([
+                            (new Link())->withFromClass(AttributeResource::class)->withIdentifiers(['id'])->withParameterName('id'),
                             (new Link())->withFromProperty('foo')->withFromClass(AttributeResource::class)->withToClass(Dummy::class)->withIdentifiers(['id']),
                             (new Link())->withFromProperty('foo2')->withFromClass(AttributeResource::class)->withToClass(Dummy::class)->withIdentifiers(['id']),
                             (new Link())->withFromProperty('bar')->withFromClass(AttributeResource::class)->withToClass(RelatedDummy::class)->withIdentifiers(['id']),
@@ -132,6 +133,7 @@ class LinkResourceMetadataCollectionFactoryTest extends TestCase
                     class: AttributeResource::class,
                     graphQlOperations: [
                         'item_query' => (new Query(shortName: 'AttributeResource', class: AttributeResource::class))->withLinks([
+                            (new Link())->withFromClass(AttributeResource::class)->withIdentifiers(['identifier'])->withParameterName('identifier'),
                             (new Link())->withParameterName('dummyId')->withFromProperty('dummy')->withFromClass(AttributeResource::class)->withToClass(Dummy::class)->withIdentifiers(['identifier']),
                         ]),
                     ]

--- a/src/Symfony/Routing/IriConverter.php
+++ b/src/Symfony/Routing/IriConverter.php
@@ -22,6 +22,7 @@ use ApiPlatform\Metadata\Exception\OperationNotFoundException;
 use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\GraphQl\Operation as GraphQlOperation;
 use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -87,24 +88,30 @@ final class IriConverter implements IriConverterInterface
             throw new InvalidArgumentException(\sprintf('The iri "%s" does not reference the correct resource.', $iri));
         }
 
-        $operation = $parameters['_api_operation'] = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
+        $routeOperation = $parameters['_api_operation'] = $this->resourceMetadataCollectionFactory->create($parameters['_api_resource_class'])->getOperation($parameters['_api_operation_name']);
 
-        if ($operation instanceof CollectionOperationInterface) {
+        if ($routeOperation instanceof CollectionOperationInterface) {
             throw new InvalidArgumentException(\sprintf('The iri "%s" references a collection not an item.', $iri));
         }
 
-        if (!$operation instanceof HttpOperation) {
+        if (!$routeOperation instanceof HttpOperation) {
             throw new RuntimeException(\sprintf('The iri "%s" does not reference an HTTP operation.', $iri));
         }
         $attributes = AttributesExtractor::extractAttributes($parameters);
 
         try {
-            $uriVariables = $this->getOperationUriVariables($operation, $parameters, $attributes['resource_class']);
+            $uriVariables = $this->getOperationUriVariables($routeOperation, $parameters, $attributes['resource_class']);
         } catch (InvalidIdentifierException|InvalidUriVariableException $e) {
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
 
-        if ($item = $this->provider->provide($operation, $uriVariables, $context)) {
+        // If a caller-provided GraphQl operation carries its own provider, dispatch through it
+        // so the user-defined Query(provider: X) wins over the route-matched HTTP operation.
+        $dispatchOperation = ($operation instanceof GraphQlOperation && null !== $operation->getProvider())
+            ? $operation
+            : $routeOperation;
+
+        if ($item = $this->provider->provide($dispatchOperation, $uriVariables, $context)) {
             return $item;
         }
 

--- a/tests/Fixtures/TestBundle/ApiResource/GraphQlCustomQueryProvider/Account.php
+++ b/tests/Fixtures/TestBundle/ApiResource/GraphQlCustomQueryProvider/Account.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\GraphQlCustomQueryProvider;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Operation;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    operations: [],
+    graphQlOperations: [
+        new Query(provider: [Account::class, 'provide']),
+    ],
+    normalizationContext: ['groups' => ['account:read']],
+)]
+final class Account
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        #[Groups(['account:read'])]
+        public string $id = '1',
+        /**
+         * @var list<array{key: string}>
+         */
+        #[Groups(['account:read'])]
+        public array $credentials = [],
+    ) {
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self(id: (string) ($uriVariables['id'] ?? '1'), credentials: [['key' => 'static-value']]);
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/GraphQlCustomQueryProvider/AccountWithGet.php
+++ b/tests/Fixtures/TestBundle/ApiResource/GraphQlCustomQueryProvider/AccountWithGet.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\GraphQlCustomQueryProvider;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Operation;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    operations: [
+        new Get(provider: [AccountWithGet::class, 'provideForGet']),
+    ],
+    graphQlOperations: [
+        new Query(provider: [AccountWithGet::class, 'provideForQuery']),
+    ],
+    normalizationContext: ['groups' => ['account_with_get:read']],
+)]
+final class AccountWithGet
+{
+    public function __construct(
+        #[ApiProperty(identifier: true)]
+        #[Groups(['account_with_get:read'])]
+        public string $id = '1',
+        #[Groups(['account_with_get:read'])]
+        public string $source = '',
+    ) {
+    }
+
+    public static function provideForGet(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self(id: (string) ($uriVariables['id'] ?? '1'), source: 'http-get');
+    }
+
+    public static function provideForQuery(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self(id: (string) ($uriVariables['id'] ?? '1'), source: 'graphql-query');
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue6264/Availability.php
@@ -25,7 +25,7 @@ use ApiPlatform\Metadata\GraphQl\Query;
         new Get(provider: Availability::class.'::getCase'),
     ],
     graphQlOperations: [
-        new Query(provider: Availability::class.'getCase'),
+        new Query(provider: Availability::class.'::getCase'),
     ]
 )]
 enum Availability: int

--- a/tests/Functional/GraphQl/GraphQlCustomQueryProviderTest.php
+++ b/tests/Functional/GraphQl/GraphQlCustomQueryProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\GraphQlCustomQueryProvider\Account;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\GraphQlCustomQueryProvider\AccountWithGet;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * A resource declaring a GraphQl Query with a custom `provider:` must invoke that
+ * provider on the root item query — independently of any HTTP item operation.
+ *
+ * @see https://github.com/api-platform/core/issues/5805
+ */
+final class GraphQlCustomQueryProviderTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Account::class, AccountWithGet::class];
+    }
+
+    public function testGraphQlQueryUsesCustomProviderWhenNoHttpGetIsDeclared(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+{
+  account(id: "/accounts/1") {
+    id
+    credentials
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame('/accounts/1', $json['data']['account']['id']);
+        $this->assertSame([['key' => 'static-value']], $json['data']['account']['credentials']);
+    }
+
+    public function testGraphQlQueryUsesItsOwnProviderWhenHttpGetHasDifferentOne(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+{
+  accountWithGet(id: "/account_with_gets/1") {
+    id
+    source
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame('/account_with_gets/1', $json['data']['accountWithGet']['id']);
+        $this->assertSame('graphql-query', $json['data']['accountWithGet']['source']);
+    }
+
+    public function testHttpGetStillUsesItsOwnProvider(): void
+    {
+        $response = self::createClient()->request('GET', '/account_with_gets/1');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertJsonContains(['source' => 'http-get']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#5805](https://github.com/api-platform/core/issues/5805) — GraphQl item `Query(provider: X)` was silently ignored: `GraphQl\State\Provider\ReadProvider` routed item lookups through `IriConverter::getResourceFromIri`, which dispatched to the route-matched HTTP item op (NotExposed/Get) — bypassing the user-declared Query provider.

The first iteration of this PR copied `Query.provider` onto the synthesised `NotExposed` (band-aid scoped to the no-HTTP-Get case). After exploring three alternatives, this PR moves the fix to the dispatch layer so it covers all combinations of HTTP/GraphQl operations.

## Implementation (Path A — metadata-time)

### 1. ReadProvider passes the GraphQl Query to IriConverter when it carries a provider

`src/GraphQl/State/Provider/ReadProvider.php` — for item Query with `provider:`, pass the operation as the 3rd argument to `iriConverter->getResourceFromIri`. Mutation/Subscription keep the route-matched HTTP op so the class-mismatch diagnostic (`Item ... did not match expected type ...`) stays accurate.

### 2. IriConverter dispatches via the caller's GraphQl op when it has a provider

`src/Symfony/Routing/IriConverter.php` + `src/Laravel/Routing/IriConverter.php` — `uri_variables` still extracted via the HTTP `routeOperation`. The final dispatch chooses `$operation` (GraphQl with provider) over `$routeOperation` (HTTP).

### 3. GraphQl Query.links gets the identifier-self link

`src/Metadata/Resource/Factory/LinkResourceMetadataCollectionFactory.php` — non-collection GraphQl ops get `LinkFactory::createLinksFromIdentifiers($op)` merged into `links`. Mirrors what `UriTemplateResourceMetadataCollectionFactory` already does for HTTP `uri_variables`.

### 4. Doctrine LinksHandler filters root-mode walks

`src/Doctrine/Common/State/LinksHandlerTrait::getLinks` — when no `$context['linkClass']` and the op is a `GraphQlOperation`, keep only links with `toClass === null || toClass === $resourceClass`. Drops relation links (which target other classes) so handleLinks applies `WHERE id = X` cleanly. HTTP path unchanged — `uri_variables` carry no relation-to-other-class links. Doctrine ODM picks the fix up via the shared trait.

`src/Laravel/Eloquent/State/LinksHandler` — standalone impl, mirror branch added for GraphQl root items.

### 5. Reverted

`NotExposedOperationResourceMetadataCollectionFactory` — band-aid no longer needed.

## Why this approach

Considered:

- **Original PR**: metadata-time `NotExposed.provider` inheritance. Works for `operations: []` only. Misses `#[Get, Query(provider: X)]`.
- **Path B**: runtime injection at dispatch site (clone Query op with HTTP `uri_variables` copied into `links`). Local, lower BC blast radius — but implicit transient mutation.
- **Path A (this PR)**: GraphQl Query.links permanently carries the identifier-self link. Symmetric with HTTP `uri_variables`. Consumer-side filter (4) keeps existing nested-traversal and HTTP behaviour intact.

Path A picked for architectural symmetry — `Query.links` becomes the single source of truth, mirroring HTTP `uri_variables`. The LinksHandler filter is a localised change with HTTP unaffected (verified via Subresource tests).

## BC

Targets `4.3`. Three risk vectors audited:

- `IdentifiersExtractor::getIdentifiersFromOperation` GraphQl branch reads `$op->getLinks()` — gets an extra identifier entry. Tests pass.
- `ReadLinkParameterProvider::getUriVariables` same — tests pass.
- Custom Doctrine `LinksHandlerInterface` impls walking `Query.getLinks()` directly would see one extra entry. Documented as a fix.

## Test plan

- [x] `tests/Functional/GraphQl/GraphQlCustomQueryProviderTest.php` — 3 cases: no-HTTP-Get + `Query(provider:X)`, `#[Get(provider:Y), Query(provider:X)]` (Query wins on GraphQl), HTTP Get keeps own provider.
- [x] Fixtures use static-method providers — no DI, no service registration.
- [x] `vendor/bin/phpunit tests/Functional/GraphQl` — 150 pass, 0 failures.
- [x] `vendor/bin/phpunit tests/Symfony/Routing src/Laravel/Tests/Unit/Routing` — 31 pass (IriConverter).
- [x] `vendor/bin/phpunit tests/Functional/SubResource tests/Functional/CustomIdentifierWithSubresourceTest.php` — 26 pass (HTTP sub-resource unchanged).
- [x] `vendor/bin/phpunit src/GraphQl/Tests src/Metadata/Tests` — only preexisting baseline failures unrelated to this PR.
- [x] Renamed `tests/Fixtures/.../Issue5805/` → `GraphQlCustomQueryProvider/` per CLAUDE.md naming rule.