### PR TITLE
fix(serializer): clarify nested-document error with actionable hints

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -756,7 +756,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute must be "array" (nested document) or "string" (IRI), "%s" given.', $attributeName, \gettype($value)), $value, ['array', 'string'], $context['deserialization_path'] ?? null, true);
         }
 
-        throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Nested documents for attribute "%s" are not allowed. Use IRIs instead.', $attributeName), $value, ['array', 'string'], $context['deserialization_path'] ?? null, true);
+        throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Nested documents for attribute "%s" are not allowed. Provide an IRI, or enable nested writes by adding matching denormalization groups on the related resource (and, for to-many relations, define adder/remover methods on the parent class).', $attributeName), $value, ['array', 'string'], $context['deserialization_path'] ?? null, true);
     }
 
     private function getResourceFromIri(string $data, array $context, string $resourceClass): ?object

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1422,7 +1422,7 @@ class AbstractItemNormalizerTest extends TestCase
     public function testInnerDocumentNotAllowed(): void
     {
         $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage('Nested documents for attribute "relatedDummy" are not allowed. Use IRIs instead.');
+        $this->expectExceptionMessage('Nested documents for attribute "relatedDummy" are not allowed. Provide an IRI, or enable nested writes by adding matching denormalization groups on the related resource (and, for to-many relations, define adder/remover methods on the parent class).');
 
         $data = [
             'relatedDummy' => [

--- a/tests/Functional/Hal/ProblemTest.php
+++ b/tests/Functional/Hal/ProblemTest.php
@@ -71,7 +71,7 @@ final class ProblemTest extends ApiTestCase
         $body = $response->toArray(false);
         $this->assertSame('/errors/400', $body['type']);
         $this->assertSame('An error occurred', $body['title']);
-        $this->assertSame('Nested documents for attribute "relatedDummy" are not allowed. Use IRIs instead.', $body['detail']);
+        $this->assertSame('Nested documents for attribute "relatedDummy" are not allowed. Provide an IRI, or enable nested writes by adding matching denormalization groups on the related resource (and, for to-many relations, define adder/remover methods on the parent class).', $body['detail']);
         $this->assertArrayHasKey('trace', $body);
     }
 }


### PR DESCRIPTION
## Summary

The denormalizer error "Nested documents for attribute X are not allowed. Use IRIs instead." only mentioned one of two possible remedies. When a developer intends nested embedding, switching to IRIs is the wrong fix — the right one is to add matching denormalization groups (and, for to-many relations, adder/remover methods on the parent class).

Updated the exception message to surface both options so the failure is self-diagnosing.

## Reproduction

POST a parent resource with a nested OneToMany collection without `@id`s and without `addX`/`removeX` accessors on the parent. The old message wrongly nudged users toward IRIs.

## Test plan

- [x] Updated `testInnerDocumentNotAllowed` in `AbstractItemNormalizerTest` to assert the new message.
- [x] Updated `testNestedRelationDocumentReturns400Problem` in `tests/Functional/Hal/ProblemTest`.
- [x] PHPStan + php-cs-fixer clean on changed files.

Fixes #8077