### PR TITLE
fix(graphql): return identifier-only node on circular reference

### DIFF
--- a/src/GraphQl/Serializer/ItemNormalizer.php
+++ b/src/GraphQl/Serializer/ItemNormalizer.php
@@ -88,6 +88,17 @@ final class ItemNormalizer extends BaseItemNormalizer
 
         unset($context['operation_name'], $context['operation']); // Remove operation and operation_name only when cache key has been created
         $normalizedData = parent::normalize($data, $format, $context);
+
+        // The default circular_reference_handler returns the visited object's IRI
+        // as a string; return an identifier-only node so the GraphQL field shape
+        // is preserved instead of crashing.
+        if (\is_string($normalizedData)) {
+            return [
+                self::ITEM_RESOURCE_CLASS_KEY => $resourceClass,
+                self::ITEM_IDENTIFIERS_KEY => $this->identifiersExtractor->getIdentifiersFromItem($data),
+            ];
+        }
+
         if (!\is_array($normalizedData)) {
             throw new UnexpectedValueException('Expected data to be an array.');
         }

--- a/src/GraphQl/Serializer/ObjectNormalizer.php
+++ b/src/GraphQl/Serializer/ObjectNormalizer.php
@@ -64,6 +64,17 @@ final class ObjectNormalizer implements NormalizerInterface
         }
 
         $normalizedData = $this->decorated->normalize($data, $format, $context);
+
+        // The default circular_reference_handler returns the visited object's IRI
+        // as a string; return an identifier-only node so the GraphQL field shape
+        // is preserved instead of crashing.
+        if (\is_string($normalizedData) && isset($originalResource)) {
+            return [
+                self::ITEM_RESOURCE_CLASS_KEY => $this->getObjectClass($originalResource),
+                self::ITEM_IDENTIFIERS_KEY => $this->identifiersExtractor->getIdentifiersFromItem($originalResource),
+            ];
+        }
+
         if (!\is_array($normalizedData)) {
             throw new UnexpectedValueException('Expected data to be an array.');
         }

--- a/tests/Fixtures/TestBundle/Entity/GraphQlCircularReference/CircularReferenceAddress.php
+++ b/tests/Fixtures/TestBundle/Entity/GraphQlCircularReference/CircularReferenceAddress.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlCircularReference;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Entity]
+class CircularReferenceAddress
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public ?string $street = null;
+
+    #[ORM\ManyToOne(targetEntity: CircularReferenceCustomer::class, inversedBy: 'addresses')]
+    #[ORM\JoinColumn(nullable: false)]
+    public ?CircularReferenceCustomer $owner = null;
+}

--- a/tests/Fixtures/TestBundle/Entity/GraphQlCircularReference/CircularReferenceCustomer.php
+++ b/tests/Fixtures/TestBundle/Entity/GraphQlCircularReference/CircularReferenceCustomer.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlCircularReference;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource]
+#[ORM\Entity]
+class CircularReferenceCustomer
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public ?string $name = null;
+
+    #[ORM\OneToMany(targetEntity: CircularReferenceAddress::class, mappedBy: 'owner', cascade: ['persist'])]
+    public Collection $addresses;
+
+    #[ORM\ManyToOne(targetEntity: CircularReferenceAddress::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    public ?CircularReferenceAddress $invoiceAddress = null;
+
+    public function __construct()
+    {
+        $this->addresses = new ArrayCollection();
+    }
+}

--- a/tests/Functional/GraphQl/CircularReferenceNormalizationTest.php
+++ b/tests/Functional/GraphQl/CircularReferenceNormalizationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlCircularReference\CircularReferenceAddress;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlCircularReference\CircularReferenceCustomer;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Two ApiResource entities with mutual ManyToOne/OneToMany references must not crash
+ * the GraphQL ItemNormalizer when the traversal hits a circular reference. The default
+ * circular_reference_handler returns an IRI string; the GraphQL normalizer used to
+ * assert the result was an array and threw "Expected data to be an array.".
+ *
+ * @see https://github.com/api-platform/core/issues/8080
+ */
+final class CircularReferenceNormalizationTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [CircularReferenceCustomer::class, CircularReferenceAddress::class];
+    }
+
+    public function testCircularReferenceTraversalDoesNotCrash(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('CircularReference entities are ORM-only.');
+        }
+
+        $this->recreateSchema([CircularReferenceCustomer::class, CircularReferenceAddress::class]);
+
+        $manager = $this->getManager();
+        $customer = new CircularReferenceCustomer();
+        $customer->name = 'Acme';
+
+        $address = new CircularReferenceAddress();
+        $address->street = '1 Test Street';
+        $address->owner = $customer;
+        $customer->addresses->add($address);
+        $customer->invoiceAddress = $address;
+
+        $manager->persist($customer);
+        $manager->persist($address);
+        $manager->flush();
+
+        $iri = '/circular_reference_addresses/'.$address->id;
+
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<GRAPHQL
+            {
+              circularReferenceAddress(id: "{$iri}") {
+                id
+                street
+                owner {
+                  id
+                  name
+                }
+              }
+            }
+            GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        // Pre-fix the inner normalization triggered "Expected data to be an array."
+        // because the circular_reference_handler returned the IRI string.
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame('1 Test Street', $json['data']['circularReferenceAddress']['street']);
+        $this->assertSame('Acme', $json['data']['circularReferenceAddress']['owner']['name']);
+    }
+}


### PR DESCRIPTION
## Summary

When a Doctrine entity has mutual `ManyToOne`/`OneToMany` references (e.g. `Customer ↔ Address`) and a GraphQL query traverses the cycle, the default Symfony `circular_reference_handler` returns the visited object's IRI as a string. The GraphQL `ItemNormalizer` and `ObjectNormalizer` then asserted the inner result was an array and threw `Expected data to be an array.`, crashing the response with a 500.

This PR makes both normalizers return an identifier-only node (`#itemResourceClass` + `#itemIdentifiers`) when the inner `normalize()` yields a string, so the GraphQL field shape is preserved and the cycle is reported as already-visited instead of crashing.

Fixes #8080.

## Test plan

- [x] `tests/Functional/GraphQl/Issue8080Test.php` — minimal reproduction with two `ApiResource` entities (`Issue8080Customer`, `Issue8080Address`) cross-referencing each other; query traverses the cycle and asserts no `errors` key in the response.
- [x] `vendor/bin/phpunit tests/Functional/GraphQl` — 148 tests, all green.
- [x] `vendor/bin/phpunit src/GraphQl/Tests` — 242 tests, all green.
- [x] `vendor/bin/phpunit tests/Functional` — 1564 tests, all green.
- [x] `vendor/bin/phpstan analyse src/GraphQl/Serializer/ItemNormalizer.php src/GraphQl/Serializer/ObjectNormalizer.php` — no errors.