### PR TITLE
fix(doctrine): extract alias from sql function in orderby parts

### DIFF
--- a/src/Doctrine/Orm/Tests/Util/QueryCheckerTest.php
+++ b/src/Doctrine/Orm/Tests/Util/QueryCheckerTest.php
@@ -204,6 +204,33 @@ class QueryCheckerTest extends TestCase
         $this->assertTrue(QueryChecker::hasOrderByOnFetchJoinedToManyAssociation($queryBuilder, $managerRegistryProphecy->reveal()));
     }
 
+    public function testHasOrderByOnFetchJoinedToManyAssociationWithSqlFunctionInOrderBy(): void
+    {
+        $dummyMetadata = new ClassMetadata(Dummy::class);
+        $dummyMetadata->mapManyToMany([
+            'fieldName' => 'relatedDummies',
+            'targetEntity' => RelatedDummy::class,
+        ]);
+
+        $relatedDummyMetadata = new ClassMetadata(RelatedDummy::class);
+
+        $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);
+        $entityManagerProphecy->getClassMetadata(Dummy::class)->willReturn($dummyMetadata);
+        $entityManagerProphecy->getClassMetadata(RelatedDummy::class)->willReturn($relatedDummyMetadata);
+
+        $queryBuilder = new QueryBuilder($entityManagerProphecy->reveal());
+        $queryBuilder->select('d', 'a_1');
+        $queryBuilder->from(Dummy::class, 'd');
+        $queryBuilder->leftJoin('d.relatedDummies', 'a_1');
+        $queryBuilder->addOrderBy("find_in_set(d.name, 'INTERVIEW')", 'ASC');
+
+        $managerRegistryProphecy = $this->prophesize(ManagerRegistry::class);
+        $managerRegistryProphecy->getManagerForClass(Dummy::class)->willReturn($entityManagerProphecy);
+        $managerRegistryProphecy->getManagerForClass(RelatedDummy::class)->willReturn($entityManagerProphecy);
+
+        $this->assertFalse(QueryChecker::hasOrderByOnFetchJoinedToManyAssociation($queryBuilder, $managerRegistryProphecy->reveal()));
+    }
+
     public function testHasJoinedToManyAssociationWithoutJoin(): void
     {
         $entityManagerProphecy = $this->prophesize(EntityManagerInterface::class);

--- a/src/Doctrine/Orm/Util/QueryChecker.php
+++ b/src/Doctrine/Orm/Util/QueryChecker.php
@@ -107,6 +107,9 @@ final class QueryChecker
                 if (str_contains((string) $part, '.')) {
                     [$alias] = explode('.', (string) $part);
 
+                    // strip leading SQL function call, e.g. "find_in_set(t.type, ...)" → "t"
+                    $alias = str_contains($alias, '(') ? substr($alias, strpos($alias, '(') + 1) : $alias;
+
                     $orderByAliases[] = $alias;
                 }
             }


### PR DESCRIPTION
## Summary

`QueryChecker::hasOrderByOnFetchJoinedToManyAssociation()` derives an alias by splitting each orderBy part on `.`. When the orderBy is a SQL function call such as `find_in_set(t.type, 'INTERVIEW')`, the split yields `['find_in_set(t', "type, 'INTERVIEW')"]` — the first segment is then passed to `QueryBuilderHelper::traverseJoins()`, which throws:

```
LogicException: The alias "find_in_set(t" does not exist in the QueryBuilder.
```

Fix: strip the leading SQL function prefix (everything up to and including `(`) before treating the segment as an alias. Applies the patch the reporter validated locally.

Fixes #8083

## Test plan

- [x] New unit test `testHasOrderByOnFetchJoinedToManyAssociationWithSqlFunctionInOrderBy` reproduces the crash without the fix and passes with it.
- [x] All existing `QueryCheckerTest` cases remain green (15/15).
- [x] PHPStan + php-cs-fixer dry-run clean on changed files.