### PR TITLE
fix(hydra): format datetime fields as iso 8601 in cursor pagination urls

### DIFF
--- a/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
+++ b/src/Hydra/Serializer/PartialCollectionViewNormalizer.php
@@ -157,8 +157,13 @@ final class PartialCollectionViewNormalizer implements NormalizerInterface, Norm
 
             $operator = $direction > 0 ? $forwardRangeOperator : $backwardRangeOperator;
 
+            $value = $this->propertyAccessor->getValue($object, $field['field']);
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format(\DateTimeInterface::ATOM);
+            }
+
             $paginationFilters[$field['field']] = [
-                $operator => (string) $this->propertyAccessor->getValue($object, $field['field']),
+                $operator => (string) $value,
             ];
         }
 

--- a/tests/Fixtures/TestBundle/Entity/Issue8085/DatedCursorDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Issue8085/DatedCursorDummy.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue8085;
+
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            paginationItemsPerPage: 3,
+            paginationPartial: true,
+            paginationViaCursor: [['field' => 'createdAt', 'direction' => 'DESC']],
+        ),
+    ],
+    graphQlOperations: [],
+)]
+#[ApiFilter(DateFilter::class, properties: ['createdAt'])]
+#[ORM\Entity]
+#[ORM\Table(name: 'issue_8085_dated_cursor_dummy')]
+class DatedCursorDummy
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    public ?int $id = null;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    public ?\DateTimeImmutable $createdAt = null;
+}

--- a/tests/Functional/JsonLd/CursorPaginationDateTimeTest.php
+++ b/tests/Functional/JsonLd/CursorPaginationDateTimeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\JsonLd;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Issue8085\DatedCursorDummy;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Regression test for https://github.com/api-platform/core/issues/8085.
+ *
+ * Cursor pagination must support DateTimeInterface fields without throwing
+ * "Object of class DateTime could not be converted to string".
+ */
+final class CursorPaginationDateTimeTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    public static function getResources(): array
+    {
+        return [DatedCursorDummy::class];
+    }
+
+    public function testCursorPaginationWithDateTimeField(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema([DatedCursorDummy::class]);
+        $manager = $this->getManager();
+        for ($i = 1; $i <= 5; ++$i) {
+            $d = new DatedCursorDummy();
+            $d->createdAt = new \DateTimeImmutable("2024-01-0$i 12:00:00", new \DateTimeZone('UTC'));
+            $manager->persist($d);
+        }
+        $manager->flush();
+
+        $response = self::createClient()->request('GET', '/dated_cursor_dummies', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $body = $response->toArray();
+
+        $this->assertArrayHasKey('hydra:view', $body);
+        $this->assertArrayHasKey('hydra:next', $body['hydra:view']);
+
+        // 5 rows (2024-01-01..05) sorted DESC + 3 per page → visible page is 05,04,03;
+        // hydra:next must use lt with the last visible item (2024-01-03) as ISO 8601.
+        $this->assertMatchesRegularExpression(
+            '#createdAt%5Blt%5D=2024-01-03T12%3A00%3A00(?:%2B00%3A00|Z)#',
+            $body['hydra:view']['hydra:next'],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Casting a `DateTimeInterface` to string raises `Object of class DateTime could not be converted to string` in `Hydra\Serializer\PartialCollectionViewNormalizer::cursorPaginationFields()`. Format datetime values as ISO 8601 (ATOM) so they serialize cleanly and roundtrip through Doctrine's `DateFilter` when the client follows the cursor URL.

## Reproduction

`GetCollection(paginationViaCursor: [['field' => 'createdAt', 'direction' => 'DESC']], paginationPartial: true)` on an entity whose `createdAt` is a `DateTimeImmutable` (e.g. Gedmo Timestampable) returned HTTP 500 on the listing endpoint.

## Test plan

- [x] Added functional test `tests/Functional/JsonLd/CursorPaginationDateTimeTest.php` (red without fix, green with).
- [x] `DatedCursorDummy` fixture under `tests/Fixtures/TestBundle/Entity/Issue8085/`.
- [x] `vendor/bin/phpunit src/Hydra/Tests tests/Functional/JsonLd/CursorPaginationDateTimeTest.php` — 56 tests, 227 assertions, OK.
- [x] PHPStan + php-cs-fixer clean on changed files.

Fixes #8085