### PR TITLE
fix(laravel): persist dirty embedded belongsTo relations

### DIFF
--- a/src/Laravel/Eloquent/State/PersistProcessor.php
+++ b/src/Laravel/Eloquent/State/PersistProcessor.php
@@ -51,7 +51,7 @@ final class PersistProcessor implements ProcessorInterface
             if (BelongsTo::class === $relation['type'] || MorphTo::class === $relation['type']) {
                 $rel = $data->{$relation['name']};
 
-                if (!$rel->exists) {
+                if (!$rel->exists || $rel->isDirty()) {
                     $rel->save();
                 }
 

--- a/src/Laravel/Tests/EmbeddedBelongsToPatchTest.php
+++ b/src/Laravel/Tests/EmbeddedBelongsToPatchTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+final class EmbeddedBelongsToPatchTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    public function testPatchPersistsModifiedEmbeddedBelongsToRelation(): void
+    {
+        $createCart = $this->postJson('/api/shopping_carts', [
+            'userIdentifier' => 'user-original',
+            'status' => 'active',
+            'cartItems' => [
+                [
+                    'productSku' => 'SKU-PATCH-1',
+                    'quantity' => 1,
+                    'priceAtAddition' => 9.99,
+                ],
+            ],
+        ], ['accept' => 'application/ld+json', 'content-type' => 'application/ld+json']);
+        $createCart->assertStatus(201);
+
+        $cartIri = $createCart->json()['@id'];
+        $itemIri = $createCart->json()['cartItems'][0]['@id'];
+
+        $response = $this->patchJson($itemIri, [
+            'shoppingCart' => [
+                'userIdentifier' => 'user-updated',
+            ],
+        ], ['accept' => 'application/ld+json', 'content-type' => 'application/merge-patch+json']);
+        $response->assertStatus(200);
+
+        $check = $this->get($cartIri, ['Accept' => ['application/ld+json']]);
+        $this->assertSame('user-updated', $check->json()['userIdentifier']);
+    }
+}


### PR DESCRIPTION
## Summary

PATCH requests targeting an embedded BelongsTo/MorphTo relation silently dropped attribute changes: the persistor only called `save()` on new relations, never on dirty ones. Save on `new || dirty` so denormalized modifications propagate.

## Reproduction

PATCH a `CartItem` with a nested `shoppingCart` payload containing an updated `userIdentifier` — the parent cart was not updated.

## Test plan

- [x] Added failing test covering the bug.
- [x] Test passes after the fix.
- [x] Related Laravel tests still pass locally.

Fixes #6882