### PR TITLE
fix(laravel): register graphql routes before catch-all entrypoint

### DIFF
--- a/src/Laravel/Tests/GraphQlRoutePrefixTest.php
+++ b/src/Laravel/Tests/GraphQlRoutePrefixTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Laravel\Test\ApiTestAssertionsTrait;
+use Illuminate\Config\Repository;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+class GraphQlRoutePrefixTest extends TestCase
+{
+    use ApiTestAssertionsTrait;
+    use RefreshDatabase;
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app['config'], static function (Repository $config): void {
+            $config->set('app.debug', true);
+            $config->set('api-platform.graphql.enabled', true);
+            $config->set('api-platform.defaults.route_prefix', '');
+        });
+    }
+
+    public function testPostGraphQlWithEmptyRoutePrefix(): void
+    {
+        $response = $this->postJson('/graphql', ['query' => '{books { edges { node { id }}}}'], ['accept' => ['application/json']]);
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayNotHasKey('errors', $data);
+    }
+
+    public function testGetGraphQlWithEmptyRoutePrefix(): void
+    {
+        $response = $this->get('/graphql?query='.urlencode('{books { edges { node { id }}}}'), ['accept' => ['application/json']]);
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertArrayHasKey('data', $data);
+        $this->assertArrayNotHasKey('errors', $data);
+    }
+
+    public function testGetGraphiQlWithEmptyRoutePrefix(): void
+    {
+        $response = $this->get('/graphiql');
+        $response->assertStatus(200);
+    }
+}

--- a/src/Laravel/routes/api.php
+++ b/src/Laravel/routes/api.php
@@ -79,6 +79,25 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(static function ()
     $prefix = config()->get('api-platform.defaults.route_prefix', '');
 
     Route::group(['prefix' => $prefix], static function (): void {
+        if (config()->get('api-platform.graphql.enabled')) {
+            Route::group([
+                'middleware' => config()->get('api-platform.graphql.middleware', []),
+            ], static function (): void {
+                Route::addRoute(['POST', 'GET'], '/graphql', GraphQlEntrypointController::class)
+                    ->name('api_graphql');
+            });
+
+            if (config()->get('api-platform.graphiql.enabled', true)) {
+                Route::group([
+                    'middleware' => config()->get('api-platform.graphiql.middleware', []),
+                    'domain' => config()->get('api-platform.graphiql.domain', ''),
+                ], static function (): void {
+                    Route::get('/graphiql', GraphiQlController::class)
+                        ->name('api_graphiql');
+                });
+            }
+        }
+
         Route::group(['middleware' => ApiPlatformMiddleware::class], static function (): void {
             Route::get('/contexts/{shortName?}{_format?}', static function (Request $request, ContextAction $contextAction, string $shortName = 'Entrypoint') {
                 return $contextAction($shortName, $request);
@@ -98,25 +117,6 @@ Route::domain($domain)->middleware($globalMiddlewares)->group(static function ()
                 ->where('index', 'index')
                 ->name('api_entrypoint');
         });
-
-        if (config()->get('api-platform.graphql.enabled')) {
-            Route::group([
-                'middleware' => config()->get('api-platform.graphql.middleware', []),
-            ], static function (): void {
-                Route::addRoute(['POST', 'GET'], '/graphql', GraphQlEntrypointController::class)
-                    ->name('api_graphql');
-            });
-
-            if (config()->get('api-platform.graphiql.enabled', true)) {
-                Route::group([
-                    'middleware' => config()->get('api-platform.graphiql.middleware', []),
-                    'domain' => config()->get('api-platform.graphiql.domain', ''),
-                ], static function (): void {
-                    Route::get('/graphiql', GraphiQlController::class)
-                        ->name('api_graphiql');
-                });
-            }
-        }
     });
 });
 


### PR DESCRIPTION
## Summary

With `api-platform.defaults.route_prefix=''`, Laravel's route matcher hit the catch-all entrypoint `/{index?}{_format?}` before `/graphql`, stripping the leading `g` as the optional `index` parameter. GET `/graphql` and `/graphiql` resolved to the entrypoint controller and returned a format error. Reordering the GraphQL/GraphiQL registrations to run before the entrypoint group restores correct matching.

## Reproduction

Set `api-platform.defaults.route_prefix=''` and GET `/graphql` — got `Format "raphql" is not supported` instead of the GraphQL playground.

## Test plan

- [x] Added failing tests covering empty route prefix for POST `/graphql`, GET `/graphql`, GET `/graphiql`.
- [x] Tests pass after the fix.
- [x] No regressions in Laravel suite.

Fixes #8128