### PR TITLE
fix(state): guard hex2bin against invalid hex strings in malformed query parameters

### DIFF
--- a/src/State/Tests/Util/RequestParserTest.php
+++ b/src/State/Tests/Util/RequestParserTest.php
@@ -42,6 +42,9 @@ class RequestParserTest extends TestCase
 
             // urlencoded [] (square brackets) in query string.
             ['a%5B1%5D=%2525', ['a' => ['1' => '%25']]],
+
+            // malformed query string with unclosed bracket and multibyte characters
+            ['y%5B%C2%9D=', ['79_'."\xC2\x9D" => '']],
         ];
     }
 }

--- a/src/State/Util/RequestParser.php
+++ b/src/State/Util/RequestParser.php
@@ -51,7 +51,18 @@ final class RequestParser
         // parse_str urldecodes both keys and values in resulting array.
         parse_str($source, $params);
 
-        return array_combine(array_map('hex2bin', array_keys($params)), $params);
+        $keys = array_map(
+            static function (string $key): string {
+                if (0 !== \strlen($key) % 2 || \strlen($key) !== strspn($key, '0123456789abcdef')) {
+                    return $key;
+                }
+
+                return hex2bin($key);
+            },
+            array_keys($params),
+        );
+
+        return array_combine($keys, $params);
     }
 
     /**


### PR DESCRIPTION
## Summary

When a query string contains unclosed brackets with multibyte characters (e.g., ?y%5B<garbage>=), parse_str() mangles the parameter name into a non-hex string. The subsequent hex2bin() call then fails with "Hexadecimal input string must have an even length", crashing the request.

## Change

This fix validates keys are valid hex (even length, only 0-9a-f) before decoding. Mangled keys from malformed input are preserved as-is, preventing the crash while maintaining all valid parameter handling.

## Tests

`/src/State/Tests/RequestParser`: included a new entry in the dataprovider to assert fix, green