### PR TITLE
fix(laravel): honor path_segment_name_generator config for url segments

### DIFF
--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -270,7 +270,14 @@ class ApiPlatformProvider extends ServiceProvider
             return new SerializerClassMetadataFactory($app->make(ClassMetadataFactoryInterface::class));
         });
 
-        $this->app->bind(PathSegmentNameGeneratorInterface::class, UnderscorePathSegmentNameGenerator::class);
+        $this->app->bind(PathSegmentNameGeneratorInterface::class, static function (Application $app): PathSegmentNameGeneratorInterface {
+            /** @var ConfigRepository */
+            $config = $app['config'];
+            /** @var class-string<PathSegmentNameGeneratorInterface> $class */
+            $class = $config->get('api-platform.path_segment_name_generator') ?? UnderscorePathSegmentNameGenerator::class;
+
+            return $app->make($class);
+        });
 
         $this->app->singleton(ResourceNameCollectionFactoryInterface::class, static function (Application $app) {
             /** @var ConfigRepository */

--- a/src/Laravel/Tests/PathSegmentNameGeneratorDashTest.php
+++ b/src/Laravel/Tests/PathSegmentNameGeneratorDashTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Metadata\Operation\DashPathSegmentNameGenerator;
+use ApiPlatform\Metadata\Operation\PathSegmentNameGeneratorInterface;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+final class PathSegmentNameGeneratorDashTest extends TestCase
+{
+    use WithWorkbench;
+
+    /**
+     * @param Application $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        tap($app->make('config'), static function (Repository $config): void {
+            $config->set('api-platform.path_segment_name_generator', DashPathSegmentNameGenerator::class);
+            $config->set('app.debug', true);
+        });
+    }
+
+    public function testConfigOverrideBindingResolvesToDashGenerator(): void
+    {
+        $generator = $this->app->make(PathSegmentNameGeneratorInterface::class);
+
+        $this->assertInstanceOf(DashPathSegmentNameGenerator::class, $generator);
+    }
+
+    public function testRouteUsesDashForMultiWordResource(): void
+    {
+        $segments = PathSegmentNameGeneratorTest::collectApiRouteSegments($this->app);
+
+        $this->assertContains('api/product-orders', $segments);
+        $this->assertNotContains('api/product_orders', $segments);
+    }
+}

--- a/src/Laravel/Tests/PathSegmentNameGeneratorTest.php
+++ b/src/Laravel/Tests/PathSegmentNameGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Metadata\Operation\PathSegmentNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation\UnderscorePathSegmentNameGenerator;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Routing\Router;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+
+final class PathSegmentNameGeneratorTest extends TestCase
+{
+    use WithWorkbench;
+
+    public function testDefaultBindingResolvesToUnderscoreGenerator(): void
+    {
+        $generator = $this->app->make(PathSegmentNameGeneratorInterface::class);
+
+        $this->assertInstanceOf(UnderscorePathSegmentNameGenerator::class, $generator);
+    }
+
+    public function testDefaultRouteUsesUnderscoreForMultiWordResource(): void
+    {
+        $segments = self::collectApiRouteSegments($this->app);
+
+        $this->assertContains('api/product_orders', $segments);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function collectApiRouteSegments(Application $app): array
+    {
+        /** @var Router $router */
+        $router = $app->make(Router::class);
+
+        $segments = [];
+        foreach ($router->getRoutes()->getRoutes() as $route) {
+            $uri = $route->uri();
+            $uri = preg_replace('/\{[^}]+\}/', '', $uri);
+            $segments[] = rtrim($uri, '/');
+        }
+
+        return $segments;
+    }
+}

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -11,6 +11,7 @@
 
 declare(strict_types=1);
 
+use ApiPlatform\Metadata\Operation\UnderscorePathSegmentNameGenerator;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
@@ -154,9 +155,15 @@ return [
 
     // 'openapi' => [
     //     'tags' => [],
-        // ],
+    // ],
 
     'url_generation_strategy' => UrlGeneratorInterface::ABS_PATH,
+
+    // Class implementing PathSegmentNameGeneratorInterface used to derive route
+    // segments from resource short names (e.g. `ProductOrder` -> `product_orders`).
+    // Set to DashPathSegmentNameGenerator::class for dasherized segments
+    // (e.g. `product-orders`).
+    'path_segment_name_generator' => UnderscorePathSegmentNameGenerator::class,
 
     'serializer' => [
         'hydra_prefix' => false,


### PR DESCRIPTION
## Summary

The Laravel provider hard-bound `PathSegmentNameGeneratorInterface` to `UnderscorePathSegmentNameGenerator`, so setting `api-platform.path_segment_name_generator` (e.g. to `DashPathSegmentNameGenerator::class`) had no effect. Routes always used underscores. Now the binding resolves from config with the underscore generator as the default, preserving prior behavior.

## Reproduction

Set `'path_segment_name_generator' => DashPathSegmentNameGenerator::class` in `config/api-platform.php` — a resource named `ProductOrder` still routed as `/product_orders` instead of `/product-orders`.

## Test plan

- [x] Added failing tests for the dash override + default underscore behavior.
- [x] Tests pass after the fix.
- [x] Laravel suite green for changed paths.

Fixes #7244