### PR TITLE
fix(jsonapi): do not require id in input schema for post operations

### DIFF
--- a/src/JsonApi/JsonSchema/SchemaFactory.php
+++ b/src/JsonApi/JsonSchema/SchemaFactory.php
@@ -20,6 +20,7 @@ use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -369,11 +370,14 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
             ];
         }
 
+        // https://jsonapi.org/format/#crud-creating — clients MAY supply an id when creating a resource.
+        $required = $operation instanceof HttpOperation && 'POST' === $operation->getMethod() ? ['type'] : ['type', 'id'];
+
         return [
             'data' => [
                 'type' => 'object',
                 'properties' => $replacement,
-                'required' => ['type', 'id'],
+                'required' => $required,
             ],
         ] + $included;
     }

--- a/src/JsonApi/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/JsonApi/Tests/JsonSchema/SchemaFactoryTest.php
@@ -22,6 +22,8 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
@@ -49,6 +51,7 @@ class SchemaFactoryTest extends TestCase
         );
         $propertyNameCollectionFactory = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_OUTPUT])->willReturn(new PropertyNameCollection());
+        $propertyNameCollectionFactory->create(Dummy::class, ['enable_getter_setter_extraction' => true, 'schema_type' => Schema::TYPE_INPUT])->willReturn(new PropertyNameCollection());
         $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
 
         $definitionNameFactory = new DefinitionNameFactory(null);
@@ -163,5 +166,27 @@ class SchemaFactoryTest extends TestCase
 
         $forcedCollection = $this->schemaFactory->buildSchema(Dummy::class, 'jsonapi', Schema::TYPE_OUTPUT, forceCollection: true);
         $this->assertEquals($resultSchema['allOf'][0]['$ref'], $forcedCollection['allOf'][0]['$ref']);
+    }
+
+    public function testPostInputSchemaDoesNotRequireId(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonapi', Schema::TYPE_INPUT, new Post());
+        $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+
+        $this->assertTrue(isset($definitions[$rootDefinitionKey]['properties']['data']));
+        $data = $definitions[$rootDefinitionKey]['properties']['data'];
+        $this->assertArrayHasKey('required', $data);
+        $this->assertSame(['type'], $data['required']);
+    }
+
+    public function testPatchInputSchemaRequiresId(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonapi', Schema::TYPE_INPUT, new Patch());
+        $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+
+        $data = $definitions[$rootDefinitionKey]['properties']['data'];
+        $this->assertSame(['type', 'id'], $data['required']);
     }
 }


### PR DESCRIPTION
## Summary

The JSON:API input schema marked `id` as required for every operation, but the spec (https://jsonapi.org/format/#crud-creating) lets a client supply a client-generated id when creating a resource — it is not required. POST schemas now require only `type`; PATCH/PUT/GET still require `id`.

## Reproduction

Calling POST against a JSON:API resource with a body lacking `data.id` was rejected because the generated input schema marked `id` as required.

## Test plan

- [x] Added failing test asserting POST schema does not require `id`.
- [x] Added regression test asserting PATCH still requires `id`.
- [x] JsonApi suite passes locally.

Fixes #6738