### PR TITLE
fix(symfony): skip ErrorResourceAttributeLoaderPass on Symfony 6.4

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/Compiler/ErrorResourceAttributeLoaderPass.php
+++ b/src/Symfony/Bundle/DependencyInjection/Compiler/ErrorResourceAttributeLoaderPass.php
@@ -18,6 +18,7 @@ use ApiPlatform\Validator\Exception\ValidationException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 
 /**
@@ -43,6 +44,25 @@ final class ErrorResourceAttributeLoaderPass implements CompilerPassInterface
             return;
         }
 
+        // Symfony 6.4 ships an AttributeLoader with a different constructor signature
+        // (`?Doctrine\Common\Annotations\Reader`), incompatible with the `allowAnyClass`/`mappedClasses`
+        // arguments below. The `AnnotationLoader` class only exists on the 6.4 branch
+        // (removed in 7.0), so its presence is a reliable marker for that signature. See #8244.
+        if (class_exists(AnnotationLoader::class)) {
+            return;
+        }
+
+        $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
+        $loaders = $chainLoader->getArgument(0);
+
+        // Skip when Symfony already wired an AttributeLoader (i.e. `enable_attributes: true`).
+        // Adding another one would duplicate work and re-process every class twice.
+        foreach ($loaders as $loader) {
+            if ($loader instanceof Definition && is_a($loader->getClass(), AttributeLoader::class, true)) {
+                return;
+            }
+        }
+
         $mappedClasses = [
             Error::class => [Error::class],
             ValidationException::class => [ValidationException::class],
@@ -50,8 +70,6 @@ final class ErrorResourceAttributeLoaderPass implements CompilerPassInterface
 
         $loaderDefinition = new Definition(AttributeLoader::class, [true, $mappedClasses]);
 
-        $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
-        $loaders = $chainLoader->getArgument(0);
         $loaders[] = $loaderDefinition;
         $chainLoader->replaceArgument(0, $loaders);
 

--- a/tests/Symfony/Bundle/DependencyInjection/Compiler/ErrorResourceAttributeLoaderPassTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/Compiler/ErrorResourceAttributeLoaderPassTest.php
@@ -78,6 +78,41 @@ final class ErrorResourceAttributeLoaderPassTest extends TestCase
         $this->assertFalse($container->hasDefinition('serializer.mapping.chain_loader'));
     }
 
+    public function testDoesNothingWhenChainAlreadyContainsAnAttributeLoader(): void
+    {
+        $container = new ContainerBuilder();
+        $existing = new Definition(AttributeLoader::class);
+        $container->setDefinition('serializer.mapping.chain_loader', new Definition(LoaderChain::class, [[$existing]]));
+        $container->setDefinition('serializer.mapping.cache_warmer', new Definition(\stdClass::class, [[$existing]]));
+
+        (new ErrorResourceAttributeLoaderPass())->process($container);
+
+        $loaders = $container->getDefinition('serializer.mapping.chain_loader')->getArgument(0);
+        $this->assertCount(1, $loaders, 'pass must not add another AttributeLoader when one is already wired (enable_attributes: true).');
+
+        $warmerLoaders = $container->getDefinition('serializer.mapping.cache_warmer')->getArgument(0);
+        $this->assertCount(1, $warmerLoaders);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/8244
+     */
+    public function testSkipsOnSymfony64SerializerSignature(): void
+    {
+        if (!class_exists(\Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader::class)) {
+            $this->markTestSkipped('Only relevant when running against symfony/serializer 6.4 (AnnotationLoader still present).');
+        }
+
+        $container = new ContainerBuilder();
+        $container->setDefinition('serializer.mapping.chain_loader', new Definition(LoaderChain::class, [[]]));
+        $container->setDefinition('serializer.mapping.cache_warmer', new Definition(\stdClass::class, [[]]));
+
+        (new ErrorResourceAttributeLoaderPass())->process($container);
+
+        $this->assertSame([], $container->getDefinition('serializer.mapping.chain_loader')->getArgument(0));
+        $this->assertSame([], $container->getDefinition('serializer.mapping.cache_warmer')->getArgument(0));
+    }
+
     /**
      * Mirrors the runtime behavior with `framework.serializer.enable_attributes: false`:
      * Symfony builds the `AttributeLoader` with `allowAnyClass = false` and no mapped classes,


### PR DESCRIPTION
## Summary

- Guards `ErrorResourceAttributeLoaderPass` against the Symfony 6.4 `AttributeLoader` signature (`?Doctrine\Common\Annotations\Reader` instead of `(bool, array)`), which was crashing cache warmup with a `TypeError` since 4.3.8.
- Detection uses `class_exists(Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader::class)` — that class only exists on the 6.4 branch (removed in 7.0), so it's a reliable version marker without depending on Composer metadata.
- Also short-circuits the pass when an `AttributeLoader` is already wired into `serializer.mapping.chain_loader` (i.e. `framework.serializer.enable_attributes: true`), so we no longer register a duplicate loader on the default config.
- Symfony 6.4 users keep the original #8174 behavior: with `enable_attributes: false`, Error/ValidationException metadata won't be loaded. The 6.4 `AttributeLoader` has no `mappedClasses` filter, and the only way to restore it would be to re-enable global attribute discovery for every class — silently defeating the user's opt-out. They can either set `enable_attributes: true` or upgrade to Symfony 7.x.

Fixes #8244, refs #8231, refs #8174.

## Test plan

- [x] `vendor/bin/phpunit tests/Symfony/Bundle/DependencyInjection/Compiler/ErrorResourceAttributeLoaderPassTest.php`
- [x] New regression test: pass is a no-op when the chain already contains an `AttributeLoader` (`enable_attributes: true` path).
- [x] New 6.4 skip test: only runs when `AnnotationLoader` is present, asserts the pass leaves the chain untouched.
- [ ] CI green on the 4.3 matrix (includes Symfony 6.4 + 7.x runs).