### PR TITLE
fix(state): guard hex2bin against malformed query parameter keys

### DIFF
--- a/src/State/Tests/Util/RequestParserTest.php
+++ b/src/State/Tests/Util/RequestParserTest.php
@@ -42,6 +42,9 @@ class RequestParserTest extends TestCase
 
             // urlencoded [] (square brackets) in query string.
             ['a%5B1%5D=%2525', ['a' => ['1' => '%25']]],
+
+            ['y%5B%C2%9D=', ['79_'."\xC2\x9D" => '']],
+            ['z%5Bg=', ['7a_g' => '']],
         ];
     }
 }

--- a/src/State/Util/RequestParser.php
+++ b/src/State/Util/RequestParser.php
@@ -51,7 +51,12 @@ final class RequestParser
         // parse_str urldecodes both keys and values in resulting array.
         parse_str($source, $params);
 
-        return array_combine(array_map('hex2bin', array_keys($params)), $params);
+        $keys = array_map(
+            static fn (string $key): string => preg_match('/\A(?:[0-9a-f]{2})+\z/', $key) ? hex2bin($key) : $key,
+            array_keys($params),
+        );
+
+        return array_combine($keys, $params);
     }
 
     /**


### PR DESCRIPTION
## Summary

Supersedes #8250 (kept author credit via `Co-authored-by`).

When a query string contains unclosed brackets with multibyte or non-hex bytes (e.g. `?y%5B%C2%9D=`), `parse_str()` mangles the hex-encoded key into a value `hex2bin()` cannot decode. PHP emits an `E_WARNING` which Symfony's debug error handler converts into a 500.

## Change

Pre-check key shape with a single regex (`/\A(?:[0-9a-f]{2})+\z/`) before calling `hex2bin()`. Mangled keys pass through verbatim — no warning, no crash, no silent empty-key collision.

Differences vs #8250:

- Single regex check instead of `strlen % 2` + `strspn` (no double `\strlen` call, no duplicated hex validation)
- Two test cases instead of one: covers both the multibyte (`?y%5B%C2%9D=`) and the even-length-non-hex (`?z%5Bg=`) branches independently

## Test plan

- [x] `vendor/bin/phpunit src/State/Tests/Util/RequestParserTest.php` — 6/6 green
- [x] Both new entries fail with `''` (silent empty-key) on `main` before fix
- [x] All 4 pre-existing entries still pass

Closes #8250