### PR TITLE
feat(doctrine): per-property filter map in FreeTextQueryFilter

### DIFF
--- a/src/Doctrine/Odm/Filter/FreeTextQueryFilter.php
+++ b/src/Doctrine/Odm/Filter/FreeTextQueryFilter.php
@@ -28,24 +28,51 @@ final class FreeTextQueryFilter implements FilterInterface, ManagerRegistryAware
     use ManagerRegistryAwareTrait;
 
     /**
-     * @param list<string> $properties an array of properties, defaults to `parameter->getProperties()`
+     * @param FilterInterface|array<string, FilterInterface> $filter     a filter applied to every property,
+     *                                                                   or a map of `property => filter` to use a
+     *                                                                   dedicated filter per property
+     * @param list<string>|null                              $properties an array of properties, defaults to
+     *                                                                   the map keys when `$filter` is a map,
+     *                                                                   otherwise to `parameter->getProperties()`
      */
-    public function __construct(private readonly FilterInterface $filter, private readonly ?array $properties = null)
+    public function __construct(private readonly FilterInterface|array $filter, private readonly ?array $properties = null)
     {
     }
 
     public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {
-        if ($this->filter instanceof ManagerRegistryAwareInterface) {
-            $this->filter->setManagerRegistry($this->getManagerRegistry());
-        }
+        $filterMap = \is_array($this->filter) ? $this->filter : null;
 
-        if ($this->filter instanceof LoggerAwareInterface) {
-            $this->filter->setLogger($this->getLogger());
+        if (null === $filterMap) {
+            if ($this->filter instanceof ManagerRegistryAwareInterface) {
+                $this->filter->setManagerRegistry($this->getManagerRegistry());
+            }
+
+            if ($this->filter instanceof LoggerAwareInterface) {
+                $this->filter->setLogger($this->getLogger());
+            }
         }
 
         $parameter = $context['parameter'];
-        foreach ($this->properties ?? $parameter->getProperties() ?? [] as $property) {
+        $properties = $this->properties ?? (null !== $filterMap ? array_keys($filterMap) : $parameter->getProperties()) ?? [];
+
+        foreach ($properties as $property) {
+            $filter = null !== $filterMap ? ($filterMap[$property] ?? null) : $this->filter;
+
+            if (null === $filter) {
+                continue;
+            }
+
+            if (null !== $filterMap) {
+                if ($filter instanceof ManagerRegistryAwareInterface) {
+                    $filter->setManagerRegistry($this->getManagerRegistry());
+                }
+
+                if ($filter instanceof LoggerAwareInterface) {
+                    $filter->setLogger($this->getLogger());
+                }
+            }
+
             $subParameter = $parameter->withProperty($property);
 
             $nestedPropertiesInfo = $parameter->getExtraProperties()['nested_properties_info'] ?? [];
@@ -57,7 +84,7 @@ final class FreeTextQueryFilter implements FilterInterface, ManagerRegistryAware
             ]);
 
             $newContext = ['parameter' => $subParameter, 'match' => $context['match'] ?? $aggregationBuilder->match()->expr()] + $context;
-            $this->filter->apply(
+            $filter->apply(
                 $aggregationBuilder,
                 $resourceClass,
                 $operation,

--- a/src/Doctrine/Orm/Filter/FreeTextQueryFilter.php
+++ b/src/Doctrine/Orm/Filter/FreeTextQueryFilter.php
@@ -31,27 +31,54 @@ final class FreeTextQueryFilter implements FilterInterface, ManagerRegistryAware
     use ManagerRegistryAwareTrait;
 
     /**
-     * @param list<string> $properties an array of properties, defaults to `parameter->getProperties()`
+     * @param FilterInterface|array<string, FilterInterface> $filter     a filter applied to every property,
+     *                                                                   or a map of `property => filter` to use a
+     *                                                                   dedicated filter per property
+     * @param list<string>|null                              $properties an array of properties, defaults to
+     *                                                                   the map keys when `$filter` is a map,
+     *                                                                   otherwise to `parameter->getProperties()`
      */
-    public function __construct(private readonly FilterInterface $filter, private readonly ?array $properties = null)
+    public function __construct(private readonly FilterInterface|array $filter, private readonly ?array $properties = null)
     {
     }
 
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
-        if ($this->filter instanceof ManagerRegistryAwareInterface) {
-            $this->filter->setManagerRegistry($this->getManagerRegistry());
-        }
+        $filterMap = \is_array($this->filter) ? $this->filter : null;
 
-        if ($this->filter instanceof LoggerAwareInterface) {
-            $this->filter->setLogger($this->getLogger());
+        if (null === $filterMap) {
+            if ($this->filter instanceof ManagerRegistryAwareInterface) {
+                $this->filter->setManagerRegistry($this->getManagerRegistry());
+            }
+
+            if ($this->filter instanceof LoggerAwareInterface) {
+                $this->filter->setLogger($this->getLogger());
+            }
         }
 
         $parameter = $context['parameter'];
         $qb = clone $queryBuilder;
         $qb->resetDQLPart('where');
         $qb->setParameters(new ArrayCollection());
-        foreach ($this->properties ?? $parameter->getProperties() ?? [] as $property) {
+        $properties = $this->properties ?? (null !== $filterMap ? array_keys($filterMap) : $parameter->getProperties()) ?? [];
+
+        foreach ($properties as $property) {
+            $filter = null !== $filterMap ? ($filterMap[$property] ?? null) : $this->filter;
+
+            if (null === $filter) {
+                continue;
+            }
+
+            if (null !== $filterMap) {
+                if ($filter instanceof ManagerRegistryAwareInterface) {
+                    $filter->setManagerRegistry($this->getManagerRegistry());
+                }
+
+                if ($filter instanceof LoggerAwareInterface) {
+                    $filter->setLogger($this->getLogger());
+                }
+            }
+
             $subParameter = $parameter->withProperty($property);
 
             $nestedPropertiesInfo = $parameter->getExtraProperties()['nested_properties_info'] ?? [];
@@ -62,7 +89,7 @@ final class FreeTextQueryFilter implements FilterInterface, ManagerRegistryAware
                     : [],
             ]);
 
-            $this->filter->apply(
+            $filter->apply(
                 $qb,
                 $queryNameGenerator,
                 $resourceClass,

--- a/tests/Fixtures/TestBundle/Document/Chicken.php
+++ b/tests/Fixtures/TestBundle/Document/Chicken.php
@@ -47,6 +47,10 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
                 ),
                 'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
                 'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
+                'qmixed' => new QueryParameter(filter: new FreeTextQueryFilter([
+                    'name' => new OrFilter(new PartialSearchFilter()),
+                    'ean' => new OrFilter(new ExactFilter()),
+                ]), description: 'Partial name match or exact ean match'),
                 'ownerNamePartial' => new QueryParameter(
                     filter: new PartialSearchFilter(),
                     property: 'owner.name',

--- a/tests/Fixtures/TestBundle/Entity/Chicken.php
+++ b/tests/Fixtures/TestBundle/Entity/Chicken.php
@@ -47,6 +47,10 @@ use Doctrine\ORM\Mapping as ORM;
                 ),
                 'autocomplete' => new QueryParameter(filter: new FreeTextQueryFilter(new OrFilter(new ExactFilter())), properties: ['name', 'ean']),
                 'q' => new QueryParameter(filter: new FreeTextQueryFilter(new PartialSearchFilter()), properties: ['name', 'ean']),
+                'qmixed' => new QueryParameter(filter: new FreeTextQueryFilter([
+                    'name' => new OrFilter(new PartialSearchFilter()),
+                    'ean' => new OrFilter(new ExactFilter()),
+                ]), description: 'Partial name match or exact ean match'),
                 'ownerNamePartial' => new QueryParameter(
                     filter: new PartialSearchFilter(),
                     property: 'owner.name',

--- a/tests/Functional/Parameters/FreeTextQueryFilterTest.php
+++ b/tests/Functional/Parameters/FreeTextQueryFilterTest.php
@@ -100,6 +100,23 @@ final class FreeTextQueryFilterTest extends ApiTestCase
         $this->assertCount(2, $response['member']);
     }
 
+    public function testFreeTextQueryFilterWithPerPropertyFilterMap(): void
+    {
+        $client = $this->createClient();
+
+        $response = $client->request('GET', '/chickens?qmixed=Henri')->toArray();
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertSame('Henriette', $response['member'][0]['name']);
+
+        $response = $client->request('GET', '/chickens?qmixed=978020137963')->toArray();
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertSame('978020137963', $response['member'][0]['ean']);
+
+        $response = $client->request('GET', '/chickens?qmixed=97802')->toArray();
+        $this->assertJsonContains(['totalItems' => 1]);
+        $this->assertSame('978020137962', $response['member'][0]['name']);
+    }
+
     public function testFreeTextQueryFilterWithTwoLevelTraversalPartialWithPropertyPlaceholder(): void
     {
         $client = $this->createClient();


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | main |
| Bug fix?      | no  |
| New feature?  | yes |
| Deprecations? | no  |
| Issues        | Refs #8249 |
| License       | MIT |

## Summary

Extend `FreeTextQueryFilter` (ORM + ODM) to accept either:

- a single `FilterInterface` — current behaviour, applied to every property;
- an `array<string, FilterInterface>` map — a dedicated filter applied per property.

The map form solves cases where a single filter can't fit every property — e.g. PostgreSQL native `uuid` columns break `LOWER(uuid)` emitted by `PartialSearchFilter`, while `ExactFilter` works fine on them.

```php
'q' => new QueryParameter(filter: new FreeTextQueryFilter([
    'name' => new OrFilter(new PartialSearchFilter()),
    'uuid' => new OrFilter(new ExactFilter()),
]), description: 'Partial name match or exact uuid match'),
```

Single-filter signature is preserved, so the change is non-breaking.

When the map form is used, the iterated properties default to the map keys; the `$properties` constructor arg still takes precedence if set.

## Test plan

- [x] new functional test `testFreeTextQueryFilterWithPerPropertyFilterMap` covers partial-name vs exact-ean differentiation
- [x] all 7 `FreeTextQueryFilterTest` cases pass on ORM
- [ ] ODM mirror executed in CI