### PR TITLE
fix(httpcache): allow custom http method on SouinPurger and SurrogateKeysPurger

### DIFF
--- a/src/HttpCache/SouinPurger.php
+++ b/src/HttpCache/SouinPurger.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\HttpCache;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -29,8 +30,8 @@ class SouinPurger extends SurrogateKeysPurger
     /**
      * @param HttpClientInterface[] $clients
      */
-    public function __construct(iterable $clients, int $maxHeaderLength = self::MAX_HEADER_SIZE_PER_BATCH)
+    public function __construct(iterable $clients, int $maxHeaderLength = self::MAX_HEADER_SIZE_PER_BATCH, string $method = Request::METHOD_PURGE)
     {
-        parent::__construct($clients, $maxHeaderLength, self::HEADER, self::SEPARATOR);
+        parent::__construct($clients, $maxHeaderLength, self::HEADER, self::SEPARATOR, $method);
     }
 }

--- a/src/HttpCache/SurrogateKeysPurger.php
+++ b/src/HttpCache/SurrogateKeysPurger.php
@@ -31,7 +31,7 @@ class SurrogateKeysPurger implements PurgerInterface
     /**
      * @param HttpClientInterface[] $clients
      */
-    public function __construct(protected readonly iterable $clients, protected readonly int $maxHeaderLength = self::MAX_HEADER_SIZE_PER_BATCH, protected readonly string $header = self::HEADER, protected readonly string $separator = self::SEPARATOR)
+    public function __construct(protected readonly iterable $clients, protected readonly int $maxHeaderLength = self::MAX_HEADER_SIZE_PER_BATCH, protected readonly string $header = self::HEADER, protected readonly string $separator = self::SEPARATOR, protected readonly string $method = Request::METHOD_PURGE)
     {
     }
 
@@ -71,7 +71,7 @@ class SurrogateKeysPurger implements PurgerInterface
 
             foreach ($this->clients as $client) {
                 $client->request(
-                    Request::METHOD_PURGE,
+                    $this->method,
                     '',
                     ['headers' => [$this->header => $chunk]]
                 );

--- a/src/HttpCache/Tests/SouinPurgerTest.php
+++ b/src/HttpCache/Tests/SouinPurgerTest.php
@@ -150,4 +150,13 @@ class SouinPurgerTest extends TestCase
         self::assertSame(['Surrogate-Key' => 'first-value/, second'], $purger->getResponseHeaders(['first-value/', 'second']));
         self::assertSame(['Surrogate-Key' => 'C0mplex_Value/, The value with spaces'], $purger->getResponseHeaders(['C0mplex_Value/', 'The value with spaces']));
     }
+
+    public function testPurgeWithCustomHttpMethod(): void
+    {
+        $clientProphecy = $this->prophesize(HttpClientInterface::class);
+        $clientProphecy->request('DELETE', '', ['headers' => ['Surrogate-Key' => '/foo']])->shouldBeCalled();
+
+        $purger = new SouinPurger([$clientProphecy->reveal()], method: Request::METHOD_DELETE);
+        $purger->purge(['/foo']);
+    }
 }


### PR DESCRIPTION
## Summary

`SouinPurger` (and its parent `SurrogateKeysPurger`) hardcodes `PURGE` when calling the invalidation endpoint. Backends like the Caddy cache-handler `souin-api` endpoint only accept `DELETE` with a `Surrogate-Key` header, so every mutation currently fails with a 500 even though the write succeeded. This PR adds an optional `$method` constructor parameter (default `Request::METHOD_PURGE`, fully BC) so users can configure `DELETE` without writing a custom purger.

## Reproduction

Configure `SouinPurger` against a Caddy cache-handler `api { basepath /souin-api; souin }` endpoint; any `POST`/`PATCH`/`DELETE` returns 500 with `"Empty reply from server"` because Caddy's endpoint only handles `DELETE`, not `PURGE`.

## Test plan

- [x] Added failing test (`SouinPurgerTest::testPurgeWithCustomHttpMethod`) covering the new constructor argument.
- [x] Test passes after the fix.
- [x] All existing HttpCache tests still pass locally (36/36).

Fixes #8258