### PR TITLE
fix(symfony): register http cache purgers independently of invalidation flag

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -30,6 +30,7 @@ use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
 use ApiPlatform\GraphQl\Resolver\QueryCollectionResolverInterface;
 use ApiPlatform\GraphQl\Resolver\QueryItemResolverInterface;
 use ApiPlatform\GraphQl\Type\Definition\TypeInterface as GraphQlTypeInterface;
+use ApiPlatform\HttpCache\PurgerInterface;
 use ApiPlatform\JsonApi\Serializer\ItemNormalizer as JsonApiItemNormalizer;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\AsOperationMutator;
@@ -870,6 +871,13 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
     {
         $loader->load('http_cache.php');
 
+        // Concrete purger services are always registered when the http-cache package is present,
+        // so userland can decorate or inject them even when invalidation is disabled (#8095).
+        // The invalidation listener, the AddTagsProcessor and the HTTP-client wiring stay gated below.
+        if (interface_exists(PurgerInterface::class)) {
+            $loader->load('http_cache_purger.php');
+        }
+
         if (!$this->isConfigEnabled($container, $config['http_cache']['invalidation'])) {
             return;
         }
@@ -879,7 +887,6 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         }
 
         $loader->load('state/http_cache_purger.php');
-        $loader->load('http_cache_purger.php');
 
         foreach ($config['http_cache']['invalidation']['scoped_clients'] as $client) {
             $definition = $container->getDefinition($client);

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -444,4 +444,43 @@ class ApiPlatformExtensionTest extends TestCase
             }
         }
     }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/8095
+     */
+    public function testHttpCachePurgersRegisteredWhenInvalidationDisabled(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['http_cache']['invalidation']['enabled'] = false;
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertContainerHasService('api_platform.http_cache.purger.varnish.ban');
+        $this->assertContainerHasService('api_platform.http_cache.purger.varnish.xkey');
+        $this->assertContainerHasService('api_platform.http_cache.purger.souin');
+        $this->assertContainerHasAlias('api_platform.http_cache.purger.varnish');
+
+        $this->assertNotContainerHasService('api_platform.doctrine.listener.http_cache.purge');
+        $this->assertNotContainerHasService('api_platform.http_cache_purger.processor.add_tags');
+        $this->assertFalse($this->container->hasAlias('api_platform.http_cache.purger'));
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/8095
+     */
+    public function testHttpCachePurgersAndListenerRegisteredWhenInvalidationEnabled(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['http_cache']['invalidation']['enabled'] = true;
+        $config['api_platform']['doctrine']['enabled'] = true;
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertContainerHasService('api_platform.http_cache.purger.varnish.ban');
+        $this->assertContainerHasService('api_platform.http_cache.purger.varnish.xkey');
+        $this->assertContainerHasService('api_platform.http_cache.purger.souin');
+        $this->assertContainerHasAlias('api_platform.http_cache.purger.varnish');
+
+        $this->assertContainerHasService('api_platform.doctrine.listener.http_cache.purge');
+        $this->assertContainerHasService('api_platform.http_cache_purger.processor.add_tags');
+        $this->assertContainerHasAlias('api_platform.http_cache.purger');
+    }
 }


### PR DESCRIPTION
## Summary

When `http_cache.invalidation.enabled` is `false`, the bundle previously skipped loading the concrete purger services (`api_platform.http_cache.purger.varnish.ban`, `.varnish.xkey`, `.souin`, plus the `api_platform.http_cache.purger.varnish` alias). Userland decorating or injecting those purgers then booted with a `ServiceNotFoundException`. This PR moves the purger services load outside the invalidation early-return — gated only on `interface_exists(PurgerInterface::class)` — while keeping the listener, `AddTagsProcessor`, scoped HTTP-clients and the `api_platform.http_cache.purger` alias behind the invalidation flag.

## Reproduction

```yaml
App\HttpCache\PurgeHttpCacheListener:
    decorates: 'api_platform.doctrine.listener.http_cache.purge'
    bind:
        $purger: '@api_platform.http_cache.purger'
```

Boot a kernel with `api_platform.http_cache.invalidation.enabled: false`: container compilation failed because `api_platform.http_cache.purger.varnish.ban` (the decorated alias target) was missing.

## Test plan

- [x] Added failing test (`testHttpCachePurgersRegisteredWhenInvalidationDisabled`) covering the bug.
- [x] Added symmetric test (`testHttpCachePurgersAndListenerRegisteredWhenInvalidationEnabled`) covering the unchanged path.
- [x] Both tests pass after the fix.
- [x] Surrounding `ApiPlatformExtensionTest` and `tests/Symfony/Bundle/DependencyInjection/ConfigurationTest` still pass locally (the pre-existing `testSwaggerUiDisabledConfiguration` failure is unrelated and reproduces on `upstream/4.3` HEAD).
- [x] `vendor/bin/php-cs-fixer fix --dry-run` and `vendor/bin/phpstan analyse` clean on touched files.

Fixes #8095