### PR TITLE
fix(metadata): preserve explicit class on ApiResource when propagating defaults

### DIFF
--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -94,7 +94,7 @@ trait OperationDefaultsTrait
     {
         $resource = $resource
             ->withShortName($resource->getShortName() ?? $shortName)
-            ->withClass($resourceClass);
+            ->withClass($resource->getClass() ?? $resourceClass);
 
         return $this->addGlobalDefaults($resource);
     }

--- a/src/Metadata/Tests/Fixtures/ApiResource/ResourceClassPropagation.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/ResourceClassPropagation.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(class: ResourceClassPropagationTarget::class)]
+final class ResourceClassPropagation
+{
+}

--- a/src/Metadata/Tests/Fixtures/ApiResource/ResourceClassPropagationTarget.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/ResourceClassPropagationTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+final class ResourceClassPropagationTarget
+{
+}

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -34,6 +34,8 @@ use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResources;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ExtraPropertiesResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\PasswordResource;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ResourceClassPropagation;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ResourceClassPropagationTarget;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\SameNameDifferentMethodOperations;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\WithParameter;
 use ApiPlatform\Metadata\Tests\Fixtures\State\AttributeResourceProcessor;
@@ -312,6 +314,29 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertCount(2, $parameters);
         $parameters = $metadataCollection->getOperation('collection')->getParameters();
         $this->assertCount(3, $parameters);
+    }
+
+    /**
+     * Tests issue #7187: a `class` set on the `#[ApiResource]` attribute must propagate
+     * to the resource itself and to every cascaded operation; the factory must not
+     * overwrite the user-provided value with the PHP class name.
+     */
+    public function testCreatePropagatesExplicitResourceClass(): void
+    {
+        $factory = new AttributesResourceMetadataCollectionFactory();
+
+        $collection = $factory->create(ResourceClassPropagation::class);
+
+        $this->assertCount(1, $collection);
+        $resource = $collection[0];
+        $this->assertSame(ResourceClassPropagationTarget::class, $resource->getClass());
+
+        $operations = $resource->getOperations();
+        $this->assertNotNull($operations);
+        $this->assertGreaterThan(0, \count($operations));
+        foreach ($operations as $operation) {
+            $this->assertSame(ResourceClassPropagationTarget::class, $operation->getClass());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

When `#[ApiResource(class: SomeClass::class)]` is set explicitly on a resource, the factory was overwriting the user-provided class with the PHP class name during default propagation. As a result, the explicit `class` never reached cascaded operations.

The change in `OperationDefaultsTrait::getResourceWithDefaults()` now falls back to the PHP class name only when no `class` is already set on the resource.

Maintainer directive (from issue #7187): _"you shouldn't really change the `class` but indeed we should fix this"_.

## Reproduction

```php
#[ApiResource(class: ResourceClassPropagationTarget::class)]
final class ResourceClassPropagation {}
```

Before the fix, every operation's `getClass()` returned `ResourceClassPropagation::class`, ignoring the explicit attribute argument. After the fix, both the resource and every cascaded operation expose `ResourceClassPropagationTarget::class`.

## Test plan

- [x] Added failing test `testCreatePropagatesExplicitResourceClass`.
- [x] Test passes after the fix.
- [x] Full `AttributesResourceMetadataCollectionFactoryTest` class still green (12 tests, 31 assertions).
- [x] `tests/Functional/OverriddenOperationTest.php` still green (10 tests, 20 assertions).
- [x] php-cs-fixer + phpstan clean on changed files.

Fixes #7187