### PR TITLE
test(graphql): cover doctrine collection in dto cursor pagination

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/Issue7038/Author.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7038/Author.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(operations: [], graphQlOperations: [])]
+final class Author
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7038/Book.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7038/Book.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+#[ApiResource(
+    operations: [],
+    provider: [self::class, 'provide'],
+    graphQlOperations: [
+        new Query(),
+    ],
+)]
+final class Book
+{
+    public string $id = '1';
+    public string $title = 'Sample Book';
+    public Author $author;
+
+    /** @var Collection<int, Category> */
+    public Collection $categories;
+
+    public function __construct()
+    {
+        $this->author = new Author('John Doe');
+        $this->categories = new ArrayCollection([
+            new Category('Fiction'),
+            new Category('Adventure'),
+        ]);
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        return new self();
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7038/Category.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7038/Category.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(operations: [], graphQlOperations: [])]
+final class Category
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/tests/Functional/GraphQl/Issue7038Test.php
+++ b/tests/Functional/GraphQl/Issue7038Test.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038\Author;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038\Book;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7038\Category;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * A DTO with a Doctrine \Doctrine\Common\Collections\Collection of nested
+ * resources must expose its items in the cursor-based pagination wrapper
+ * (`edges/node`) the same way an array would.
+ *
+ * @see https://github.com/api-platform/core/issues/7038
+ */
+final class Issue7038Test extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Book::class, Author::class, Category::class];
+    }
+
+    public function testDoctrineCollectionInDtoIsExposedThroughCursorPagination(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+{
+  book(id: "/books/1") {
+    title
+    author {
+      name
+    }
+    categories {
+      edges {
+        node {
+          name
+        }
+      }
+    }
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame('Sample Book', $json['data']['book']['title']);
+        $this->assertSame('John Doe', $json['data']['book']['author']['name']);
+        $edges = $json['data']['book']['categories']['edges'];
+        $this->assertIsArray($edges);
+        $this->assertCount(2, $edges);
+        $this->assertSame('Fiction', $edges[0]['node']['name']);
+        $this->assertSame('Adventure', $edges[1]['node']['name']);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a functional GraphQL regression test pinning the resolution of a
`\Doctrine\Common\Collections\Collection` field on a DTO returned through
the cursor-based pagination wrapper (edges/node).

The bug reported in #7038 (`GraphQL operations return null for DTO collections
while REST operations work correctly`) is **already fixed** by upstream
commit `b714a4451` ("fix(graphql): nested resources without graphqloperations
propagate fields", PR #8076).

Reverting that commit reproduces the exact error from the issue:
`Cannot return null for non-nullable field "Category.name"`. The reporter's
scenario used `Collection<Category>` while #8076's test pinned `array<Category>`.
Both shapes hit the same path
(`AbstractItemNormalizer::getAttributeValue` → `normalizeCollectionOfRelations`
returns a plain array before the GraphQL field resolver wraps it in
`ArrayPaginator`), but only the array form was pinned by a test until now.

## Reproduction

Pre-#8076: `Cannot return null for non-nullable field "Category.name"` on a GraphQL
query of a DTO that exposes a `Collection<NestedResource>`. Post-#8076: resolves
correctly. This test pins the Doctrine-Collection case to keep it from
regressing.

## Test plan

- [x] Added `tests/Functional/GraphQl/Issue7038Test.php` covering the
      Doctrine `Collection<>` field on a DTO under cursor pagination.
- [x] All 153 GraphQl functional tests pass locally (8 new assertions).
- [x] phpstan + cs-fixer clean.

Fixes #7038