### PR TITLE
fix(mcp): resolve $ref inside oneOf/anyOf when flattening tool outputSchema

### DIFF
--- a/src/Mcp/JsonSchema/SchemaFactory.php
+++ b/src/Mcp/JsonSchema/SchemaFactory.php
@@ -146,6 +146,18 @@ final class SchemaFactory implements SchemaFactoryInterface
             }
         }
 
+        foreach (['oneOf', 'anyOf'] as $combinator) {
+            if (isset($node[$combinator]) && \is_array($node[$combinator])) {
+                foreach ($node[$combinator] as $i => $member) {
+                    $node[$combinator][$i] = self::resolveNode(
+                        $member instanceof \ArrayObject ? $member->getArrayCopy() : $member,
+                        $definitions,
+                        $resolving,
+                    );
+                }
+            }
+        }
+
         return $node;
     }
 }

--- a/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
@@ -371,4 +371,55 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayNotHasKey('type', $value);
         $this->assertSame([['type' => 'string'], ['type' => 'integer']], $value['anyOf']);
     }
+
+    /**
+     * @see https://github.com/api-platform/core/issues/8266
+     *
+     * A nullable embedded relation is emitted upstream as
+     * anyOf: [ {$ref: #/definitions/...}, {type: null} ]. The flattener drops the
+     * definitions block, so the $ref nested inside the anyOf must be resolved during
+     * recursion — otherwise it survives as a dangling reference.
+     */
+    public function testRefInsideAnyOfIsResolved(): void
+    {
+        $innerSchema = new Schema(Schema::VERSION_JSON_SCHEMA);
+        unset($innerSchema['$schema']);
+        $definitions = $innerSchema->getDefinitions();
+        $definitions['Root'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'related' => new \ArrayObject([
+                    'anyOf' => [
+                        ['$ref' => '#/definitions/Related.jsonld'],
+                        ['type' => 'null'],
+                    ],
+                ]),
+            ],
+        ]);
+        $definitions['Related.jsonld'] = new \ArrayObject([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+        ]);
+        $innerSchema['$ref'] = '#/definitions/Root';
+
+        $inner = $this->createMock(SchemaFactoryInterface::class);
+        $inner->method('buildSchema')->willReturn($innerSchema);
+
+        $factory = new SchemaFactory($inner);
+        $result = $factory->buildSchema('App\\Dummy', 'jsonld');
+
+        $arr = $result->getArrayCopy();
+        $related = $arr['properties']['related'];
+
+        // The $ref member must be resolved to its target object, leaving no dangling reference.
+        $this->assertArrayNotHasKey('$ref', $related['anyOf'][0]);
+        $this->assertSame('object', $related['anyOf'][0]['type']);
+        $this->assertSame(['name' => ['type' => 'string']], $related['anyOf'][0]['properties']);
+
+        // The nullable member is left untouched and the anyOf keeps no spurious type fallback.
+        $this->assertSame(['type' => 'null'], $related['anyOf'][1]);
+        $this->assertArrayNotHasKey('type', $related);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Fixes #8266
| License       | MIT
| Doc PR        | n/a

When an `ApiResource` is exposed as an MCP tool with `structuredContent` enabled, a **nullable embedded relation** is emitted upstream as:

```json
{ "anyOf": [ { "$ref": "#/definitions/DeliverySiteInfoOutput.jsonld" }, { "type": "null" } ] }
```

`ApiPlatform\Mcp\JsonSchema\SchemaFactory` flattens the schema into an MCP-compliant shape (no `$ref`, no `allOf`, no `definitions`). It resolved the root node and dropped `definitions`, but `resolveDeep()` only recursed into `items` and `properties` — never into `oneOf`/`anyOf` members. The `$ref` inside the `anyOf` therefore survived as a **dangling reference** with no `definitions` block to resolve it against, and strict MCP clients failed to load the tool ("can't resolve reference").

## Fix

`resolveDeep()` now recurses into `oneOf`/`anyOf` members and resolves any nested `$ref` against `definitions` before they are discarded, mirroring the existing handling for `items` and `properties`. The existing safeguard against injecting `type: object` into `oneOf`/`anyOf` nodes (e.g. the `HydraItemBaseSchema` `@context` case) is preserved — the type fallback is only ever applied to the resolved member sub-schemas, never to the combinator node itself.

## Tests

Adds `testRefInsideAnyOfIsResolved` which reproduces the nullable-embedded-relation shape and asserts:

- the `$ref` member is resolved to its target object (no dangling reference);
- the `{ "type": "null" }` member is left untouched;
- no spurious `type` fallback is added to the `anyOf` node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
