### PR TITLE
fix(mcp): always serialize payload into TextContent when structuredContent is disabled

### DIFF
--- a/src/Mcp/State/StructuredContentProcessor.php
+++ b/src/Mcp/State/StructuredContentProcessor.php
@@ -64,8 +64,6 @@ final class StructuredContentProcessor implements ProcessorInterface
             $serializerContext['uri_variables'] = $uriVariables;
             $format = $request->getRequestFormat('') ?: 'jsonld';
             $normalized = $this->serializer->normalize($result, $format, $serializerContext);
-            // The serialized payload is always exposed as the mandatory TextContent;
-            // only the optional structuredContent field depends on the flag.
             $result = $this->serializer->encode($normalized, $format, $serializerContext);
 
             if ($includeStructuredContent) {

--- a/src/Mcp/State/StructuredContentProcessor.php
+++ b/src/Mcp/State/StructuredContentProcessor.php
@@ -56,15 +56,21 @@ final class StructuredContentProcessor implements ProcessorInterface
         $includeStructuredContent = $operation instanceof McpTool || $operation instanceof McpResource ? $operation->getStructuredContent() ?? true : false;
         $structuredContent = null;
 
-        if ($includeStructuredContent && $request && $this->serializer instanceof NormalizerInterface && $this->serializer instanceof EncoderInterface) {
+        if ($request && $this->serializer instanceof NormalizerInterface && $this->serializer instanceof EncoderInterface) {
             $serializerContext = $this->serializerContextBuilder->createFromRequest($request, true, [
                 'resource_class' => $class,
                 'operation' => $operation,
             ]);
             $serializerContext['uri_variables'] = $uriVariables;
             $format = $request->getRequestFormat('') ?: 'jsonld';
-            $structuredContent = $this->serializer->normalize($result, $format, $serializerContext);
-            $result = $this->serializer->encode($structuredContent, $format, $serializerContext);
+            $normalized = $this->serializer->normalize($result, $format, $serializerContext);
+            // The serialized payload is always exposed as the mandatory TextContent;
+            // only the optional structuredContent field depends on the flag.
+            $result = $this->serializer->encode($normalized, $format, $serializerContext);
+
+            if ($includeStructuredContent) {
+                $structuredContent = $normalized;
+            }
         }
 
         return new Response(

--- a/src/Mcp/Tests/State/StructuredContentProcessorTest.php
+++ b/src/Mcp/Tests/State/StructuredContentProcessorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Mcp\Tests\State;
+
+use ApiPlatform\Mcp\State\StructuredContentProcessor;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\State\SerializerContextBuilderInterface;
+use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\JsonRpc\Request;
+use Mcp\Schema\JsonRpc\Response;
+use Mcp\Schema\Result\CallToolResult;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * @see https://github.com/api-platform/core/issues/8267
+ */
+class StructuredContentProcessorTest extends TestCase
+{
+    /**
+     * When structuredContent is disabled, the payload must still be serialized
+     * into the mandatory TextContent: only the extra structuredContent field
+     * should be omitted, not the human-readable text.
+     */
+    public function testTextContentIsPopulatedWhenStructuredContentIsDisabled(): void
+    {
+        // The MCP Handler disables serialization, so the decorated processor
+        // returns a non-string collection object (here a Paginator-like object
+        // with no public/JsonSerializable state, which json_encodes to "{}").
+        $collection = new \stdClass();
+
+        $expectedJson = '{"@context":"\/contexts\/Dummy","@type":"hydra:Collection","hydra:member":[{"name":"foo"}]}';
+
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->method('process')->willReturn($collection);
+
+        $serializer = $this->createMock(SerializerEncoderNormalizer::class);
+        $serializer->method('normalize')->willReturn(['hydra:member' => [['name' => 'foo']]]);
+        $serializer->method('encode')->willReturn($expectedJson);
+
+        $contextBuilder = $this->createMock(SerializerContextBuilderInterface::class);
+        $contextBuilder->method('createFromRequest')->willReturn([]);
+
+        $processor = new StructuredContentProcessor($serializer, $contextBuilder, $decorated);
+
+        $operation = (new McpTool())->withStructuredContent(false)->withClass(\stdClass::class);
+
+        $mcpRequest = $this->createMock(Request::class);
+        $mcpRequest->method('getId')->willReturn('req-1');
+
+        /** @var Response $response */
+        $response = $processor->process([], $operation, [], [
+            'mcp_request' => $mcpRequest,
+            'request' => new HttpRequest(),
+        ]);
+
+        $result = $response->result;
+        $this->assertInstanceOf(CallToolResult::class, $result);
+
+        // structuredContent flag disabled -> extra field must be absent.
+        $this->assertNull($result->structuredContent);
+
+        // ...but the mandatory text content must still carry the real payload.
+        $textContent = $result->content[0];
+        $this->assertInstanceOf(TextContent::class, $textContent);
+        $this->assertNotSame('{}', $textContent->text);
+        $this->assertSame($expectedJson, $textContent->text);
+    }
+}
+
+/**
+ * Helper interface so the mocked serializer satisfies the
+ * `instanceof NormalizerInterface && instanceof EncoderInterface` guard.
+ */
+interface SerializerEncoderNormalizer extends SerializerInterface, NormalizerInterface, EncoderInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Closes #8267
| License       | MIT
| Doc PR        | ∅

## Problem

An MCP tool declared with `structuredContent: false` returned an empty result: `content: [{ "type": "text", "text": "{}" }]` with no usable data.

In `StructuredContentProcessor::process()`, the `serializer->encode(...)` call lived **inside** the `if ($includeStructuredContent && ...)` block. When the flag was `false`:

- the block was skipped, so `$result` kept the raw decorated-processor output (a `Paginator`/collection object, since the MCP `Handler` disables serialization);
- `new TextContent($result)` then `json_encode`d an object with no public state, yielding `"{}"`.

The flag conflated three concerns: advertising `outputSchema`, populating the `structuredContent` field, and serializing the mandatory `TextContent`. Per the MCP spec, `content` (text) is always present; `structuredContent` is an optional addition.

## Fix

Serialization now runs whenever the serializer is capable and a request exists, so the payload is always encoded into the mandatory `TextContent`. Only the optional `structuredContent` field stays gated behind the flag.

## Test

Added `StructuredContentProcessorTest::testTextContentIsPopulatedWhenStructuredContentIsDisabled`, which reproduces the bug (a non-string collection object from the decorated processor) and asserts the `TextContent` carries the serialized payload — not `"{}"` — while `structuredContent` remains `null`.
