### PR TITLE
fix(jsonschema): embed genId:false relations in output schema

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -72,10 +72,6 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
         $isInput = ($options['schema_type'] ?? null) === Schema::TYPE_INPUT;
         $link = $isInput ? $propertyMetadata->isWritableLink() : $propertyMetadata->isReadableLink();
 
-        // On output, the serializer embeds a related resource (instead of emitting an IRI) as soon
-        // as "gen_id" is false, even when the relation is not a readable link (see
-        // AbstractItemNormalizer::normalizeRelation()). Mirror that here so the advertised schema
-        // does not type an embedded object as an "iri-reference" string.
         if (!$isInput && false === $propertyMetadata->getGenId()) {
             $link = true;
         }

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -70,11 +70,8 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
         }
 
         $isInput = ($options['schema_type'] ?? null) === Schema::TYPE_INPUT;
-        $link = $isInput ? $propertyMetadata->isWritableLink() : $propertyMetadata->isReadableLink();
-
-        if (!$isInput && false === $propertyMetadata->getGenId()) {
-            $link = true;
-        }
+        // on output the serializer embeds the relation as soon as gen_id is false, even when it is not a readable link (see AbstractItemNormalizer::normalizeRelation())
+        $link = $isInput ? $propertyMetadata->isWritableLink() : ($propertyMetadata->isReadableLink() || false === $propertyMetadata->getGenId());
 
         $propertySchema = $propertyMetadata->getSchema() ?? [];
 

--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -69,7 +69,17 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
             return $propertyMetadata;
         }
 
-        $link = (($options['schema_type'] ?? null) === Schema::TYPE_INPUT) ? $propertyMetadata->isWritableLink() : $propertyMetadata->isReadableLink();
+        $isInput = ($options['schema_type'] ?? null) === Schema::TYPE_INPUT;
+        $link = $isInput ? $propertyMetadata->isWritableLink() : $propertyMetadata->isReadableLink();
+
+        // On output, the serializer embeds a related resource (instead of emitting an IRI) as soon
+        // as "gen_id" is false, even when the relation is not a readable link (see
+        // AbstractItemNormalizer::normalizeRelation()). Mirror that here so the advertised schema
+        // does not type an embedded object as an "iri-reference" string.
+        if (!$isInput && false === $propertyMetadata->getGenId()) {
+            $link = true;
+        }
+
         $propertySchema = $propertyMetadata->getSchema() ?? [];
 
         if (null !== $propertyMetadata->getUriTemplate() || (!\array_key_exists('readOnly', $propertySchema) && false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable())) {

--- a/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
+++ b/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
@@ -26,6 +26,7 @@ use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
 
@@ -181,18 +182,11 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
     }
 
     /**
-     * A non-nullable relation to a resource class that is not a readable link is normally
-     * typed as an "iri-reference" string. But when the property declares "genId: false",
-     * the serializer embeds the related object instead of emitting an IRI
-     * (see AbstractItemNormalizer::normalizeRelation()). The output schema must reflect that
-     * embedding decision, otherwise the advertised schema (string) disagrees with the
-     * serialized payload (object).
-     *
      * @see https://github.com/api-platform/core/issues/8271
      */
     public function testRelationWithGenIdFalseIsEmbeddedInOutputSchema(): void
     {
-        if (!method_exists(\Symfony\Component\PropertyInfo\PropertyInfoExtractor::class, 'getType')) {
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
             $this->markTestSkipped('This test only supports type-info component');
         }
 
@@ -208,8 +202,7 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
         $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
         $apiProperty = $schemaPropertyMetadataFactory->create(DummyWithEnum::class, 'relatedDummy');
 
-        // The schema must not type the embedded relation as an "iri-reference" string;
-        // it must defer to SchemaFactory so a "$ref" to the embedded subschema is built.
+        // defers to SchemaFactory ($ref to embedded subschema) instead of an iri-reference string
         $this->assertSame(['type' => Schema::UNKNOWN_TYPE], $apiProperty->getSchema());
     }
 

--- a/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
+++ b/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace ApiPlatform\JsonSchema\Tests\Metadata\Property\Factory;
 
 use ApiPlatform\JsonSchema\Metadata\Property\Factory\SchemaPropertyMetadataFactory;
+use ApiPlatform\JsonSchema\Schema;
+use ApiPlatform\JsonSchema\Tests\Fixtures\ApiResource\Dummy;
 use ApiPlatform\JsonSchema\Tests\Fixtures\DummyWithCustomOpenApiContext;
 use ApiPlatform\JsonSchema\Tests\Fixtures\DummyWithEnum;
 use ApiPlatform\JsonSchema\Tests\Fixtures\DummyWithMixed;
@@ -176,6 +178,39 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
         ];
 
         $this->assertEquals($expectedSchema, $apiProperty->getSchema());
+    }
+
+    /**
+     * A non-nullable relation to a resource class that is not a readable link is normally
+     * typed as an "iri-reference" string. But when the property declares "genId: false",
+     * the serializer embeds the related object instead of emitting an IRI
+     * (see AbstractItemNormalizer::normalizeRelation()). The output schema must reflect that
+     * embedding decision, otherwise the advertised schema (string) disagrees with the
+     * serialized payload (object).
+     *
+     * @see https://github.com/api-platform/core/issues/8271
+     */
+    public function testRelationWithGenIdFalseIsEmbeddedInOutputSchema(): void
+    {
+        if (!method_exists(\Symfony\Component\PropertyInfo\PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('This test only supports type-info component');
+        }
+
+        $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturn(true);
+
+        $apiProperty = (new ApiProperty(nativeType: Type::object(Dummy::class)))
+            ->withReadableLink(false)
+            ->withGenId(false);
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())->method('create')->with(DummyWithEnum::class, 'relatedDummy')->willReturn($apiProperty);
+
+        $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
+        $apiProperty = $schemaPropertyMetadataFactory->create(DummyWithEnum::class, 'relatedDummy');
+
+        // The schema must not type the embedded relation as an "iri-reference" string;
+        // it must defer to SchemaFactory so a "$ref" to the embedded subschema is built.
+        $this->assertSame(['type' => Schema::UNKNOWN_TYPE], $apiProperty->getSchema());
     }
 
     public function testMixed(): void


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | main |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Fixes #8271 |
| License       | MIT |

## What

A non-nullable relation to a resource class that is not a readable link is typed in the output schema as an `iri-reference` string. But the serializer (`AbstractItemNormalizer::normalizeRelation()`) embeds the related object whenever `gen_id` is false — independently of `readableLink` — so the advertised schema (string) disagreed with the serialized payload (object).

`SchemaPropertyMetadataFactory` now mirrors that decision: on output, when a property declares `genId: false`, the relation is treated as embedded so `SchemaFactory` builds a `$ref` to the embedded subschema instead of stamping an `iri-reference` string.

## Why

Exposed over MCP with `structuredContent: true`, this disagreement makes the returned `structuredContent` fail client-side validation against the advertised `outputSchema` (`-32602: ... must be string, … got object`).

Scoped to the non-nullable case on purpose: the nullable-relation variant is a distinct dangling-`$ref` problem tracked in #8266 / #8268, which touches different files (`src/Mcp/JsonSchema/SchemaFactory.php`), so there is no overlap or merge conflict between the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
