### PR TITLE
fix(metadata) metadata mutators for resource & operations with lower priority

### DIFF
--- a/src/Symfony/Bundle/Resources/config/metadata/resource.php
+++ b/src/Symfony/Bundle/Resources/config/metadata/resource.php
@@ -66,14 +66,6 @@ return function (ContainerConfigurator $container) {
             '%api_platform.defaults%',
         ]);
 
-    $services->set('api_platform.metadata.resource.metadata_collection_factory.mutator', MutatorResourceMetadataCollectionFactory::class)
-        ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 800)
-        ->args([
-            service('api_platform.metadata.mutator_collection.resource'),
-            service('api_platform.metadata.mutator_collection.operation'),
-            service('api_platform.metadata.resource.metadata_collection_factory.mutator.inner'),
-        ]);
-
     $services->set('api_platform.metadata.resource.metadata_collection_factory.concerns', ConcernsResourceMetadataCollectionFactory::class)
         ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 800)
         ->args([
@@ -115,6 +107,14 @@ return function (ContainerConfigurator $container) {
             service('api_platform.metadata.resource.link_factory'),
             service('api_platform.metadata.resource.metadata_collection_factory.link.inner'),
             '%api_platform.graphql.enabled%',
+        ]);
+
+    $services->set('api_platform.metadata.resource.metadata_collection_factory.mutator', MutatorResourceMetadataCollectionFactory::class)
+        ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 400)
+        ->args([
+            service('api_platform.metadata.mutator_collection.resource'),
+            service('api_platform.metadata.mutator_collection.operation'),
+            service('api_platform.metadata.resource.metadata_collection_factory.mutator.inner'),
         ]);
 
     $services->set('api_platform.metadata.resource.metadata_collection_factory.operation_name', OperationNameResourceMetadataCollectionFactory::class)


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | 
| License       | MIT
| Doc PR        | 

metadata mutators for resource & operations need lower priority to run after `UriTemplateResourceMetadataCollectionFactory` so an operation that is tried to be mutated when using `AsOperationMutator` actually exists if created by this factory.

Im not sure if it might need even lower priority, but for my usecase to run after `UriTemplateResourceMetadataCollectionFactory` was enough to make it work, as this one is creation the metadata, but maybe an argument can be made that mutators should generally run after other factories

Maybe im also misunderstanding that the mutator feature is not a replacement for decorating collection factories on my own using`#[AsDecorator('api_platform.metadata.resource.metadata_collection_factory')]`