### PR TITLE
fix(jsonld): replace already-populated nested relation from embedded @id on patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.3.11
+
+### Notes
+
+* JSON-LD `PATCH`: an embedded `@id` on a nested writable relation now replaces the currently-linked relation when it points to a different resource. A dangling embedded `@id` now returns a 400 instead of being silently ignored (it previously mutated the existing relation in place). See #8274.
+
 ## v4.3.10
 
 ### Bug fixes

--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -218,6 +218,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
                     throw $e;
                 }
             }
+        } elseif (isset($data['@id']) && ($context['deep_object_to_populate'] ?? false)) {
+            // the object to populate is the relation currently linked to the parent, an explicit @id must replace it instead of mutating it in place
+            $context[self::OBJECT_TO_POPULATE] = $this->iriConverter->getResourceFromIri($data['@id'], $context + ['fetch_data' => true], $context['operation'] ?? null);
         }
 
         return parent::denormalize($data, $type, $format, $context);

--- a/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedDataPool.php
+++ b/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedDataPool.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'nested_data_pool')]
+#[ApiResource(
+    operations: [
+        new Get(),
+        new Post(),
+        new Patch(inputFormats: ['jsonld' => ['application/ld+json'], 'json' => ['application/merge-patch+json']]),
+    ],
+    normalizationContext: ['groups' => ['datapool:read']],
+    denormalizationContext: ['groups' => ['datapool:write']],
+)]
+class NestedDataPool
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Groups(['datapool:read'])]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(cascade: ['persist'])]
+    #[ApiProperty(writableLink: true, readableLink: true)]
+    #[Groups(['datapool:read', 'datapool:write'])]
+    private ?NestedDataPoolStartup $dataPoolStartup = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDataPoolStartup(): ?NestedDataPoolStartup
+    {
+        return $this->dataPoolStartup;
+    }
+
+    public function setDataPoolStartup(?NestedDataPoolStartup $dataPoolStartup): void
+    {
+        $this->dataPoolStartup = $dataPoolStartup;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedDataPoolStartup.php
+++ b/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedDataPoolStartup.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'nested_data_pool_startup')]
+#[ApiResource]
+class NestedDataPoolStartup
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Groups(['datapool:read'])]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(cascade: ['persist'])]
+    #[ApiProperty(writableLink: true, readableLink: true)]
+    #[Groups(['datapool:read', 'datapool:write'])]
+    private ?NestedStartup $startup = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getStartup(): ?NestedStartup
+    {
+        return $this->startup;
+    }
+
+    public function setStartup(?NestedStartup $startup): void
+    {
+        $this->startup = $startup;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedStartup.php
+++ b/tests/Fixtures/TestBundle/Entity/NestedRelationPatch/NestedStartup.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch;
+
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'nested_startup')]
+#[ApiResource]
+class NestedStartup
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    #[Groups(['datapool:read', 'datapool:write'])]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    #[Groups(['datapool:read', 'datapool:write'])]
+    private ?string $name = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(?string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Functional/Serializer/NestedRelationUpdateTest.php
+++ b/tests/Functional/Serializer/NestedRelationUpdateTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Serializer;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch\NestedDataPool;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch\NestedDataPoolStartup;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\NestedRelationPatch\NestedStartup;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class NestedRelationUpdateTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    public static function getResources(): array
+    {
+        return [NestedDataPool::class, NestedDataPoolStartup::class, NestedStartup::class];
+    }
+
+    public function testPatchReplacesAlreadyPopulatedNestedRelationFromEmbeddedIri(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema(self::getResources());
+
+        $manager = static::getContainer()->get('doctrine')->getManager();
+
+        $startupOne = new NestedStartup();
+        $startupOne->setName('one');
+        $manager->persist($startupOne);
+
+        $startupTwo = new NestedStartup();
+        $startupTwo->setName('two');
+        $manager->persist($startupTwo);
+
+        $dataPoolStartup = new NestedDataPoolStartup();
+        $dataPoolStartup->setStartup($startupOne);
+        $manager->persist($dataPoolStartup);
+
+        $dataPool = new NestedDataPool();
+        $dataPool->setDataPoolStartup($dataPoolStartup);
+        $manager->persist($dataPool);
+
+        $manager->flush();
+
+        $dataPoolId = $dataPool->getId();
+        $startupTwoIri = '/nested_startups/'.$startupTwo->getId();
+        $manager->clear();
+
+        self::createClient()->request('PATCH', '/nested_data_pools/'.$dataPoolId, [
+            'json' => [
+                'dataPoolStartup' => [
+                    'startup' => [
+                        '@id' => $startupTwoIri,
+                        'id' => $startupTwo->getId(),
+                    ],
+                ],
+            ],
+            'headers' => [
+                'content-type' => 'application/ld+json',
+            ],
+        ]);
+
+        static::assertResponseIsSuccessful();
+
+        $manager->clear();
+        $updated = $manager->getRepository(NestedDataPool::class)->find($dataPoolId);
+        static::assertSame($startupTwo->getId(), $updated->getDataPoolStartup()->getStartup()->getId());
+    }
+
+    public function testPatchKeepsAndMutatesNestedRelationWhenEmbeddedIriMatches(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema(self::getResources());
+
+        $manager = static::getContainer()->get('doctrine')->getManager();
+
+        $startup = new NestedStartup();
+        $startup->setName('one');
+        $manager->persist($startup);
+
+        $dataPoolStartup = new NestedDataPoolStartup();
+        $dataPoolStartup->setStartup($startup);
+        $manager->persist($dataPoolStartup);
+
+        $dataPool = new NestedDataPool();
+        $dataPool->setDataPoolStartup($dataPoolStartup);
+        $manager->persist($dataPool);
+
+        $manager->flush();
+
+        $dataPoolId = $dataPool->getId();
+        $startupId = $startup->getId();
+        $startupIri = '/nested_startups/'.$startupId;
+        $manager->clear();
+
+        self::createClient()->request('PATCH', '/nested_data_pools/'.$dataPoolId, [
+            'json' => [
+                'dataPoolStartup' => [
+                    'startup' => [
+                        '@id' => $startupIri,
+                        'name' => 'renamed',
+                    ],
+                ],
+            ],
+            'headers' => [
+                'content-type' => 'application/ld+json',
+            ],
+        ]);
+
+        static::assertResponseIsSuccessful();
+
+        $manager->clear();
+        $updated = $manager->getRepository(NestedDataPool::class)->find($dataPoolId);
+        static::assertSame($startupId, $updated->getDataPoolStartup()->getStartup()->getId());
+        static::assertSame('renamed', $updated->getDataPoolStartup()->getStartup()->getName());
+    }
+
+    public function testPatchWithDanglingNestedIriFailsAndKeepsRelationUntouched(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped();
+        }
+
+        $this->recreateSchema(self::getResources());
+
+        $manager = static::getContainer()->get('doctrine')->getManager();
+
+        $startup = new NestedStartup();
+        $startup->setName('one');
+        $manager->persist($startup);
+
+        $dataPoolStartup = new NestedDataPoolStartup();
+        $dataPoolStartup->setStartup($startup);
+        $manager->persist($dataPoolStartup);
+
+        $dataPool = new NestedDataPool();
+        $dataPool->setDataPoolStartup($dataPoolStartup);
+        $manager->persist($dataPool);
+
+        $manager->flush();
+
+        $dataPoolId = $dataPool->getId();
+        $startupId = $startup->getId();
+        $manager->clear();
+
+        self::createClient()->request('PATCH', '/nested_data_pools/'.$dataPoolId, [
+            'json' => [
+                'dataPoolStartup' => [
+                    'startup' => [
+                        '@id' => '/nested_startups/99999',
+                        'name' => 'should not be applied',
+                    ],
+                ],
+            ],
+            'headers' => [
+                'content-type' => 'application/ld+json',
+            ],
+        ]);
+
+        static::assertResponseStatusCodeSame(400);
+
+        $manager->clear();
+        $untouched = $manager->getRepository(NestedDataPool::class)->find($dataPoolId);
+        static::assertSame($startupId, $untouched->getDataPoolStartup()->getStartup()->getId());
+        static::assertSame('one', $untouched->getDataPoolStartup()->getStartup()->getName());
+    }
+}


### PR DESCRIPTION
## Summary

On `PATCH` of a resource with a nested writable-link relation, `SerializerContextBuilder` sets `deep_object_to_populate`, which makes Symfony inject the currently-linked related object as `OBJECT_TO_POPULATE`. In `JsonLd\Serializer\ItemNormalizer::denormalize`, the `@id` of an embedded object was only resolved when no `OBJECT_TO_POPULATE` was set — so an embedded object carrying an `@id` for an already-populated relation was mutated in place and the `@id` ignored. When the relation was null it resolved correctly, producing the asymmetry reported. The fix resolves the embedded `@id` and swaps the populate target when it points to a different resource.

## Reproduction

PATCH `dataPool` with `{"dataPoolStartup":{"startup":{"@id":"/startups/2"}}}` where `dataPoolStartup.startup` is already linked to a different startup: before the fix the existing link is kept; the embedded `@id` is honored only when the relation was empty.

## Test plan

- [x] Added failing test covering the bug (`NestedRelationUpdateTest`, 2 cases: replace + keep-on-match).
- [x] Test passes after the fix.
- [x] Related test classes still pass locally (JsonLd functional + serializer unit 218; Serializer/Doctrine/SubResource functional 189).

Fixes #8055

## Note (behavior change)

A dangling embedded `@id` on a nested writable relation now returns a 400 (`ItemNotFoundException`) instead of being silently ignored — previously the remaining payload fields mutated the existing relation in place. Consistent with the root-level `@id` resolution on PATCH. Changelog note added under v4.3.11.
