### PR TITLE
fix(metadata): read ApiProperty from trait private properties inherited via parent class

### DIFF
--- a/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/AttributePropertyMetadataFactory.php
@@ -77,6 +77,20 @@ final class AttributePropertyMetadataFactory implements PropertyMetadataFactoryI
             }
         }
 
+        // Private properties declared in a trait used by a parent class (e.g. a Doctrine STI parent) are
+        // not exposed on the child's reflection, so walk the hierarchy to read the ApiProperty attribute.
+        $parentReflectionClass = $reflectionClass->getParentClass();
+        while ($parentReflectionClass) {
+            if ($parentReflectionClass->hasProperty($property)) {
+                $reflectionProperty = $parentReflectionClass->getProperty($property);
+                if ($attributes = $reflectionProperty->getAttributes(ApiProperty::class)) {
+                    return $this->createMetadata($attributes[0]->newInstance(), $parentPropertyMetadata);
+                }
+            }
+
+            $parentReflectionClass = $parentReflectionClass->getParentClass();
+        }
+
         foreach (array_merge(Reflection::ACCESSOR_PREFIXES, Reflection::MUTATOR_PREFIXES) as $prefix) {
             $methodName = $prefix.ucfirst($property);
             if (!$reflectionClass->hasMethod($methodName) && !$reflectionEnum?->hasMethod($methodName)) {

--- a/src/Metadata/Tests/Fixtures/ApiResource/AbstractTraitPropertyParent.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/AbstractTraitPropertyParent.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+abstract class AbstractTraitPropertyParent
+{
+    use PrivateTraitPropertyTrait;
+}

--- a/src/Metadata/Tests/Fixtures/ApiResource/ConcreteTraitPropertyChild.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/ConcreteTraitPropertyChild.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource]
+final class ConcreteTraitPropertyChild extends AbstractTraitPropertyParent
+{
+}

--- a/src/Metadata/Tests/Fixtures/ApiResource/PrivateTraitPropertyTrait.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/PrivateTraitPropertyTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiProperty;
+
+trait PrivateTraitPropertyTrait
+{
+    #[ApiProperty(writable: false)]
+    private ?string $createdAt = null;
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?string $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+}

--- a/src/Metadata/Tests/Property/Factory/AttributePropertyMetadataFactoryTest.php
+++ b/src/Metadata/Tests/Property/Factory/AttributePropertyMetadataFactoryTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Exception\PropertyNotFoundException;
 use ApiPlatform\Metadata\Property\Factory\AttributePropertyMetadataFactory;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ConcreteTraitPropertyChild;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\DummyEnum;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\DummyWithApiPropertyAttributes;
 use PHPUnit\Framework\TestCase;
@@ -42,6 +43,15 @@ class AttributePropertyMetadataFactoryTest extends TestCase
 
         $metadata = $factory->create(DummyEnum::class, 'B');
         $this->assertSame('The B.', $metadata->getDescription());
+    }
+
+    public function testPrivateTraitPropertyAttributeIsReadFromAbstractParent(): void
+    {
+        $factory = new AttributePropertyMetadataFactory();
+
+        $metadata = $factory->create(ConcreteTraitPropertyChild::class, 'createdAt');
+
+        $this->assertFalse($metadata->isWritable());
     }
 
     public function testClassNotFound(): void


### PR DESCRIPTION
## Summary

`#[ApiProperty(writable: false)]` declared on a **private** property inside a trait that is composed into an abstract parent class (e.g. a Doctrine STI parent) was silently ignored on child resources, leaving the property writable. PHP's reflection does not expose private parent/trait-declared properties on the child's own `ReflectionClass`, so `AttributePropertyMetadataFactory` never read the attribute. Protected/public trait properties are unaffected (they remain visible on the child), which is why moving the trait into the subclass or using `protected` "worked".

The factory now walks the parent class hierarchy and reads `#[ApiProperty]` from the declaring class when the child's own reflection doesn't expose the property. The child's own attribute still takes precedence.

## Reproduction

Trait with a private `#[ApiProperty(writable: false)]` property → abstract STI parent → concrete `#[ApiResource]` child with a public accessor: the property was accepted on write before the fix.

## Test plan

- [x] Added failing test (`testPrivateTraitPropertyAttributeIsReadFromAbstractParent`) + fixtures (trait, abstract parent, concrete child).
- [x] Test passes after the fix.
- [x] `src/Metadata/Tests/Property/` green (38 tests). Two unrelated pre-existing failures in the wider suite confirmed on the clean base.

Fixes #8028