### PR TITLE
fix(doctrine): use mb_strtolower for case-insensitive search value

### DIFF
--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -300,7 +300,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 
             $queryBuilder
                 ->andWhere($queryBuilder->expr()->in($wrapCase($aliasedField), $valueParameter))
-                ->setParameter($valueParameter, $caseSensitive ? $values : array_map('strtolower', $values));
+                ->setParameter($valueParameter, $caseSensitive ? $values : array_map('mb_strtolower', $values));
 
             return;
         }
@@ -309,7 +309,7 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         $parameters = [];
         foreach ($values as $key => $value) {
             $keyValueParameter = \sprintf('%s_%s', $valueParameter, $key);
-            $parameters[] = [$caseSensitive ? $value : strtolower($value), $keyValueParameter];
+            $parameters[] = [$caseSensitive ? $value : mb_strtolower($value), $keyValueParameter];
 
             $ors[] = match ($strategy) {
                 self::STRATEGY_PARTIAL => $queryBuilder->expr()->like(

--- a/src/Doctrine/Orm/Tests/Filter/SearchFilterTest.php
+++ b/src/Doctrine/Orm/Tests/Filter/SearchFilterTest.php
@@ -349,6 +349,11 @@ class SearchFilterTest extends DoctrineOrmFilterTestCase
                     ['name_p1_0' => 'partial'],
                     $filterFactory,
                 ],
+                'partial (case insensitive, with multibyte characters)' => [
+                    \sprintf('SELECT %s FROM %s %1$s WHERE LOWER(%1$s.name) LIKE LOWER(CONCAT(\'%%\', :name_p1_0, \'%%\'))', static::ALIAS, Dummy::class),
+                    ['name_p1_0' => 'biały'],
+                    $filterFactory,
+                ],
                 'partial (multiple values)' => [
                     \sprintf('SELECT %s FROM %s %1$s WHERE %1$s.name LIKE CONCAT(\'%%\', :name_p1_0, \'%%\') OR %1$s.name LIKE CONCAT(\'%%\', :name_p1_1, \'%%\')', static::ALIAS, Dummy::class),
                     [

--- a/src/Doctrine/Orm/Tests/Filter/SearchFilterTestTrait.php
+++ b/src/Doctrine/Orm/Tests/Filter/SearchFilterTestTrait.php
@@ -273,6 +273,15 @@ trait SearchFilterTestTrait
                     'name' => 'partial',
                 ],
             ],
+            'partial (case insensitive, with multibyte characters)' => [
+                [
+                    'id' => null,
+                    'name' => 'ipartial',
+                ],
+                [
+                    'name' => 'BIAŁY',
+                ],
+            ],
             'partial (multiple values)' => [
                 [
                     'id' => null,


### PR DESCRIPTION
## Summary

The ORM `SearchFilter` lowercased the case-insensitive search value with byte-wise `strtolower()`, which corrupts multibyte UTF-8 search terms (Polish/Cyrillic/Latin-extended) and can trigger `invalid byte sequence for encoding "UTF8"` on PostgreSQL. Switched both lowercasing sites to `mb_strtolower()`. The SQL-side `LOWER()` / accent-insensitive collation behavior is DB/collation-dependent and intentionally left untouched — this only fixes the PHP value lowercasing.

The ODM `SearchFilter` is unaffected: it uses a MongoDB `Regex` with the `i` flag and never PHP-lowercases the value.

## Reproduction

`ipartial` search for `BIAŁY` produced `biaŁy` (corrupted byte) instead of `biały` before the fix.

## Test plan

- [x] Added failing `ipartial` multibyte case (`BIAŁY`).
- [x] Test passes after the fix.
- [x] Full ORM filter suite green (156 tests).

Fixes #8031