### PR TITLE
fix(hydra): declare hydra:view links as nullable in json schema

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -164,6 +164,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                     break;
             }
 
+            $nullableIriDefinition = $nullableStringDefinition + ['format' => 'iri-reference'];
+
             $definitions[self::COLLECTION_BASE_SCHEMA_NAME_NO_PAGINATION] = [
                 'type' => 'object',
                 'properties' => [
@@ -210,22 +212,10 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
                                     '@type' => [
                                         'type' => 'string',
                                     ],
-                                    $hydraPrefix.'first' => [
-                                        'type' => 'string',
-                                        'format' => 'iri-reference',
-                                    ],
-                                    $hydraPrefix.'last' => [
-                                        'type' => 'string',
-                                        'format' => 'iri-reference',
-                                    ],
-                                    $hydraPrefix.'previous' => [
-                                        'type' => 'string',
-                                        'format' => 'iri-reference',
-                                    ],
-                                    $hydraPrefix.'next' => [
-                                        'type' => 'string',
-                                        'format' => 'iri-reference',
-                                    ],
+                                    $hydraPrefix.'first' => $nullableIriDefinition,
+                                    $hydraPrefix.'last' => $nullableIriDefinition,
+                                    $hydraPrefix.'previous' => $nullableIriDefinition,
+                                    $hydraPrefix.'next' => $nullableIriDefinition,
                                 ],
                                 'example' => [
                                     '@id' => 'string',

--- a/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
@@ -146,10 +146,16 @@ class SchemaFactoryTest extends TestCase
 
         $this->assertTrue(isset($properties['hydra:view']));
         $this->assertArrayHasKey('properties', $properties['hydra:view']);
-        $this->assertArrayHasKey('hydra:first', $properties['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:last', $properties['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:previous', $properties['hydra:view']['properties']);
-        $this->assertArrayHasKey('hydra:next', $properties['hydra:view']['properties']);
+        $viewProperties = $properties['hydra:view']['properties'];
+        $this->assertArrayHasKey('hydra:first', $viewProperties);
+        $this->assertArrayHasKey('hydra:last', $viewProperties);
+        $this->assertArrayHasKey('hydra:previous', $viewProperties);
+        $this->assertArrayHasKey('hydra:next', $viewProperties);
+
+        foreach (['hydra:first', 'hydra:last', 'hydra:previous', 'hydra:next'] as $viewLink) {
+            $this->assertSame(['string', 'null'], $viewProperties[$viewLink]['type'], \sprintf('"%s" must be nullable.', $viewLink));
+            $this->assertSame('iri-reference', $viewProperties[$viewLink]['format']);
+        }
 
         $forcedCollection = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, true);
         $this->assertEquals($resultSchema['allOf'][0]['$ref'], $forcedCollection['allOf'][0]['$ref']);


### PR DESCRIPTION
## Summary

The `hydra:view` (PartialCollectionView) links `hydra:first`, `hydra:last`, `hydra:previous`, `hydra:next` are omitted on the first/last page of a collection, but the generated JSON Schema typed them as non-nullable `string` — so generated client validators rejected valid API responses. The schema now reuses the existing version-aware nullable-string helper: OpenAPI 3.1 / JSON Schema get `['string','null']` with `format: iri-reference`, while Swagger output is unchanged.

## Reproduction

`demo.api-platform.com/docs.json` (and any collection schema): the four view links were declared `type: string`, non-nullable, despite being absent on edge pages.

## Test plan

- [x] Extended `SchemaFactoryTest` to assert the four links are nullable (`['string','null']` + `iri-reference`).
- [x] Test fails on 4.3 HEAD, passes after the fix.
- [x] `src/Hydra/Tests` + JsonLd JSON-Schema functional suite green (56 tests).

Low BC risk — only widens the schema to accept responses the API already produces.

Fixes #8066