### PR TITLE
fix(metadata): preserve nested array query parameters in IriHelper

### DIFF
--- a/src/Metadata/Tests/Util/IriHelperTest.php
+++ b/src/Metadata/Tests/Util/IriHelperTest.php
@@ -70,6 +70,41 @@ class IriHelperTest extends TestCase
         $this->assertSame('//foo:bar@localhost:443/hello.json?foo=bar&bar=3&page=2#foo', IriHelper::createIri($parsed['parts'], $parsed['parameters'], 'page', 2., UrlGeneratorInterface::NET_PATH));
     }
 
+    public function testHelpersPreserveNestedArrayQueryParameters(): void
+    {
+        $parts = [
+            'path' => '/objects',
+            'query' => '',
+        ];
+        $parameters = [
+            'filters' => [
+                0 => ['a' => 'foo', 'b' => 'bar'],
+            ],
+        ];
+
+        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
+
+        $this->assertSame('/objects?filters%5B0%5D%5Ba%5D=foo&filters%5B0%5D%5Bb%5D=bar&page=2', $iri);
+
+        $reparsed = IriHelper::parseIri($iri, 'page');
+        $this->assertSame($parameters, $reparsed['parameters']);
+    }
+
+    public function testHelpersCollapseSimpleListQueryParameters(): void
+    {
+        $parts = [
+            'path' => '/objects',
+            'query' => '',
+        ];
+        $parameters = [
+            'foo' => ['a', 'b'],
+        ];
+
+        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
+
+        $this->assertSame('/objects?foo%5B%5D=a&foo%5B%5D=b&page=2', $iri);
+    }
+
     public function testParseIriWithInvalidUrl(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Metadata/Util/IriHelper.php
+++ b/src/Metadata/Util/IriHelper.php
@@ -65,7 +65,10 @@ final class IriHelper
         }
 
         $query = http_build_query($parameters, '', '&', \PHP_QUERY_RFC3986);
-        $parts['query'] = preg_replace('/%5B\d+%5D/', '%5B%5D', $query);
+        // Only collapse a numeric index when it is the leaf segment of a bracket chain
+        // (a simple list element). Collapsing a non-leaf index would merge distinct keys of a
+        // nested array into separate elements (e.g. filters[0][a] must stay filters[0][a]).
+        $parts['query'] = preg_replace('/%5B\d+%5D(?!%5B)/', '%5B%5D', $query);
 
         $url = '';
         if ((UrlGeneratorInterface::ABS_URL === $urlGenerationStrategy || UrlGeneratorInterface::NET_PATH === $urlGenerationStrategy) && isset($parts['host'])) {


### PR DESCRIPTION
## Summary

`IriHelper::createIri` collapsed every URL-encoded numeric bracket index `[N]` to `[]`, which corrupts nested array query parameters: `filters[0][a]=foo&filters[0][b]=bar` became `filters[][a]&filters[][b]` and re-parsed as two separate elements (`[{a:foo},{b:bar}]`) instead of one element with two keys. A negative lookahead now collapses a numeric index only when it is the leaf segment of the bracket chain (a real list element), preserving nested structure while still normalizing simple list params (`foo[0]` → `foo[]`).

## Reproduction

A collection request with `filters[0][a]=foo&filters[0][b]=bar` produced corrupted pagination links (`hydra:next` etc.) that split the nested filter into two.

## Test plan

- [x] Added failing test round-tripping a nested param through `createIri` + `parseIri` (structure preserved).
- [x] Added a test asserting simple-list params still normalize (no regression).
- [x] `IriHelperTest` 5/5 green; Hydra `PartialCollectionViewNormalizerTest` (production caller) 9/9.

Fixes #5221