### PR TITLE
fix(symfony): expose uri variables in security expression context

### DIFF
--- a/src/Symfony/Security/State/AccessCheckerProvider.php
+++ b/src/Symfony/Security/State/AccessCheckerProvider.php
@@ -73,16 +73,17 @@ final class AccessCheckerProvider implements ProviderInterface
         if ($operation instanceof HttpOperation) {
             $request = $context['request'] ?? null;
 
+            // URI variables are exposed to the expression (e.g. is_granted('VIEW', user_id)); reserved keys below must win on collision.
             $resourceAccessCheckerContext = [
                 'object' => $body,
                 'previous_object' => $request?->attributes->get('previous_data'),
                 'request' => $request,
-            ];
+            ] + $uriVariables;
         } else {
             $resourceAccessCheckerContext = [
                 'object' => $body,
                 'previous_object' => $context['graphql_context']['previous_object'] ?? null,
-            ];
+            ] + $uriVariables;
         }
 
         // Skip pre_read optimization when object is used via granted (or usage is not predicatable)

--- a/tests/Symfony/Security/State/AccessCheckerProviderTest.php
+++ b/tests/Symfony/Security/State/AccessCheckerProviderTest.php
@@ -38,6 +38,30 @@ class AccessCheckerProviderTest extends TestCase
         $accessChecker->provide($operation, [], []);
     }
 
+    public function testCheckAccessInjectsUriVariables(): void
+    {
+        $obj = new \stdClass();
+        $operation = new Get(class: DummyEntity::class, security: 'is_granted("USER_STATS_VIEW", user_id)');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->method('provide')->willReturn($obj);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->expects($this->once())->method('isGranted')->with(DummyEntity::class, 'is_granted("USER_STATS_VIEW", user_id)', ['object' => $obj, 'previous_object' => null, 'request' => null, 'user_id' => 1])->willReturn(true);
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker);
+        $accessChecker->provide($operation, ['user_id' => 1], []);
+    }
+
+    public function testReservedContextKeysWinOverUriVariables(): void
+    {
+        $obj = new \stdClass();
+        $operation = new Get(class: DummyEntity::class, security: 'object == null');
+        $decorated = $this->createMock(ProviderInterface::class);
+        $decorated->method('provide')->willReturn($obj);
+        $resourceAccessChecker = $this->createMock(ResourceAccessCheckerInterface::class);
+        $resourceAccessChecker->expects($this->once())->method('isGranted')->with(DummyEntity::class, 'object == null', ['object' => $obj, 'previous_object' => null, 'request' => null])->willReturn(true);
+        $accessChecker = new AccessCheckerProvider($decorated, $resourceAccessChecker);
+        $accessChecker->provide($operation, ['object' => 'should-not-shadow'], []);
+    }
+
     public function testCheckAccessWithEvent(): void
     {
         $obj = new \stdClass();


### PR DESCRIPTION
## Summary

`AccessCheckerProvider` built the security expression context from `object` / `previous_object` / `request` only, never the operation's uri variables. So a `security` expression referencing a route variable — e.g. `is_granted('VIEW', user_id)` — threw `Variable "user_id" is not valid` when the event-listeners backward-compatibility layer is disabled. The now-removed legacy `DenyAccessListener` merged `$request->attributes->all()` (which carried the router-populated uri variables) into the expression variables; the provider path dropped them, and the BC layer masked it.

The provider now merges `$uriVariables` into the expression context for both the HTTP and GraphQL branches, with the reserved keys (`object`, `previous_object`, `request`) winning on collision so a uri variable can't shadow the resource.

## Reproduction

A resource with `security: "is_granted('VIEW', user_id)"` and `event_listeners_backward_compatibility_layer: false` threw an ExpressionLanguage `SyntaxError` instead of evaluating access.

## Test plan

- [x] `testCheckAccessInjectsUriVariables` — fails on HEAD (uri var absent from context), passes after.
- [x] `testReservedContextKeysWinOverUriVariables` — precedence guard.
- [x] `AccessCheckerProviderTest` 10/10, `tests/Symfony/Security` 17/17, GraphQL `QueryTest` 24/24.

Fixes #5959