### PR TITLE
fix(mongodb): resolve search filter identifier from reference target metadata

### DIFF
--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -222,7 +222,8 @@ final class SearchFilter extends AbstractFilter implements SearchFilterInterface
         $values = array_map($this->getIdFromValue(...), $values);
 
         $associationResourceClass = $metadata->getAssociationTargetClass($field);
-        $associationFieldIdentifier = $metadata->getIdentifierFieldNames()[0];
+        $associationMetadata = $this->getClassMetadata($associationResourceClass);
+        $associationFieldIdentifier = $associationMetadata->getIdentifierFieldNames()[0];
         $doctrineTypeField = $this->getDoctrineFieldType($associationFieldIdentifier, $associationResourceClass);
 
         if (!$this->hasValidValues($values, $doctrineTypeField)) {

--- a/src/Doctrine/Odm/Tests/Filter/SearchFilterTest.php
+++ b/src/Doctrine/Odm/Tests/Filter/SearchFilterTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Doctrine\Odm\Filter\SearchFilter;
 use ApiPlatform\Doctrine\Odm\Tests\DoctrineMongoDbOdmFilterTestCase;
 use ApiPlatform\Doctrine\Odm\Tests\Fixtures\CustomConverter;
 use ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document\Dummy;
+use ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document\DummyWithEmbeddedReference;
 use ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document\RelatedDummy;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\IriConverterInterface;
@@ -35,6 +36,29 @@ class SearchFilterTest extends DoctrineMongoDbOdmFilterTestCase
 
     protected string $filterClass = SearchFilter::class;
     protected string $resourceClass = Dummy::class;
+
+    public function testApplyWithReferenceHeldByEmbeddedDocument(): void
+    {
+        $filter = self::buildSearchFilter($this, $this->managerRegistry, ['embeddedReferenceHolder.relatedDummy' => 'exact']);
+
+        $repository = $this->manager->getRepository(DummyWithEmbeddedReference::class);
+        $aggregationBuilder = $repository->createAggregationBuilder();
+
+        $context = ['filters' => ['embeddedReferenceHolder.relatedDummy' => '1']];
+        $filter->apply($aggregationBuilder, DummyWithEmbeddedReference::class, null, $context);
+
+        $this->assertEquals([
+            [
+                '$match' => [
+                    'embeddedReferenceHolder.relatedDummy' => [
+                        '$in' => [
+                            1,
+                        ],
+                    ],
+                ],
+            ],
+        ], $aggregationBuilder->getPipeline());
+    }
 
     public function testGetDescriptionDefaultFields(): void
     {

--- a/src/Doctrine/Odm/Tests/Fixtures/Document/DummyWithEmbeddedReference.php
+++ b/src/Doctrine/Odm/Tests/Fixtures/Document/DummyWithEmbeddedReference.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Document embedding a document that holds a reference, see
+ * https://github.com/api-platform/core/issues/6376.
+ */
+#[ODM\Document]
+class DummyWithEmbeddedReference
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\EmbedOne(targetDocument: EmbeddedReferenceHolder::class)]
+    public ?EmbeddedReferenceHolder $embeddedReferenceHolder = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/src/Doctrine/Odm/Tests/Fixtures/Document/EmbeddedReferenceHolder.php
+++ b/src/Doctrine/Odm/Tests/Fixtures/Document/EmbeddedReferenceHolder.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Odm\Tests\Fixtures\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Embedded document holding a reference to another document.
+ *
+ * Reproduces the structure of https://github.com/api-platform/core/issues/6376
+ * where an embedded document (which has no identifier of its own) carries a
+ * reference to a top-level document.
+ */
+#[ODM\EmbeddedDocument]
+class EmbeddedReferenceHolder
+{
+    #[ODM\Field(type: 'string')]
+    public ?string $name = null;
+
+    #[ODM\ReferenceOne(targetDocument: RelatedDummy::class, storeAs: 'id')]
+    public ?RelatedDummy $relatedDummy = null;
+}


### PR DESCRIPTION
## Summary

The MongoDB ODM `SearchFilter` crashed with a `TypeError` when filtering through an **embedded document that holds a reference** (e.g. `Distribution` → embedded `Participant` → referenced `Employee`). At `filterProperty()` it read `getIdentifierFieldNames()[0]` from the *embedded parent's* metadata — embedded documents have no identifier, so it returned `null`, which was then passed to `getDoctrineFieldType(string $property, ...)`.

The fix resolves the association **target** class metadata (via the existing `getClassMetadata()` helper) and reads the identifier from it — exactly what the ORM `SearchFilter` already does. One-line change, no shim.

## Reproduction

A SearchFilter on an embedded document's reference threw `getDoctrineFieldType(): Argument #1 must be of type string, null given`.

## Test plan

- [x] Added `testApplyWithReferenceHeldByEmbeddedDocument` + minimal fixtures (Document → EmbedOne → embedded doc → ReferenceOne → RelatedDummy).
- [x] Reproduced the exact TypeError on 4.3 HEAD, green after the fix.
- [x] ODM filter suite 158/158, full ODM Tests 262/262.

Fixes #6376