### PR TITLE
fix(metadata): keep explicitly set GraphQL mutation description

### DIFF
--- a/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
+++ b/src/Metadata/Resource/Factory/OperationDefaultsTrait.php
@@ -202,7 +202,7 @@ trait OperationDefaultsTrait
                 throw new RuntimeException('No GraphQL operation name.');
             }
 
-            if ($operation instanceof Mutation) {
+            if ($operation instanceof Mutation && null === $operation->getDescription()) {
                 $operation = $operation->withDescription(ucfirst("{$operation->getName()}s a {$resource->getShortName()}."));
             }
 

--- a/src/Metadata/Tests/Fixtures/ApiResource/MutationDescription.php
+++ b/src/Metadata/Tests/Fixtures/ApiResource/MutationDescription.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests\Fixtures\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+
+/**
+ * Reproduces issue #8285: an explicit mutation description must not be
+ * overwritten by the generated default.
+ */
+#[ApiResource(graphQlOperations: [
+    new Mutation(name: 'create', description: 'My custom description.'),
+    new Mutation(name: 'update'),
+])]
+final class MutationDescription
+{
+}

--- a/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/AttributesResourceMetadataCollectionFactoryTest.php
@@ -33,6 +33,7 @@ use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeOnlyOperation;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\AttributeResources;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ExtraPropertiesResource;
+use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\MutationDescription;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\PasswordResource;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ResourceClassPropagation;
 use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\ResourceClassPropagationTarget;
@@ -337,6 +338,20 @@ class AttributesResourceMetadataCollectionFactoryTest extends TestCase
         foreach ($operations as $operation) {
             $this->assertSame(ResourceClassPropagationTarget::class, $operation->getClass());
         }
+    }
+
+    /**
+     * Tests issue #8285: an explicitly set GraphQL mutation description must be preserved;
+     * the generated "{name}s a {shortName}." text is only a fallback when none is provided.
+     */
+    public function testGraphQlMutationDescriptionIsNotOverwritten(): void
+    {
+        $factory = new AttributesResourceMetadataCollectionFactory(graphQlEnabled: true);
+
+        $graphQlOperations = $factory->create(MutationDescription::class)[0]->getGraphQlOperations();
+
+        $this->assertSame('My custom description.', $graphQlOperations['create']->getDescription());
+        $this->assertSame('Updates a MutationDescription.', $graphQlOperations['update']->getDescription());
     }
 
     /**


### PR DESCRIPTION
| Q             | A      |
| ------------- | ------ |
| Branch?       | 4.3    |
| Bug fix?      | yes    |
| New feature?  | no     |
| Deprecations? | no     |
| BC breaks?    | no     |
| Tests pass?   | yes    |
| Fixed tickets | Fixes #8285 |
| License       | MIT    |

`OperationDefaultsTrait::getOperationWithDefaults()` unconditionally replaced every GraphQL mutation description with the generated `"{name}s a {ShortName}."` text, discarding a description set explicitly on the operation:

```php
#[ApiResource(graphQlOperations: [
    new Mutation(name: 'create', description: 'My custom description.'),
])]
```

still produced `"""Creates a Book."""` in the SDL. Queries are not affected, so mutations behaved inconsistently.

This restores the behavior documented in #3477, where the generated text was introduced as a fallback only: the default is now applied solely when no description is set. One-line change plus a regression test covering both directions — an explicit description is preserved, and a mutation without a description still gets the generated default.
