### PR TITLE
test: drop stale serializer 8.1 getErrors() deprecation expectation

### DIFF
--- a/tests/Functional/EnumDenormalizationValidationTest.php
+++ b/tests/Functional/EnumDenormalizationValidationTest.php
@@ -17,8 +17,6 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\EnumValidationResource;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 /**
  * @see https://github.com/api-platform/core/issues/8183
@@ -67,13 +65,8 @@ final class EnumDenormalizationValidationTest extends ApiTestCase
         $this->assertNotNull($genderViolation, 'Expected a constraint violation on "gender" property.');
     }
 
-    #[IgnoreDeprecations]
     public function testInvalidBackedEnumValueWithCollectDenormalizationErrors(): void
     {
-        if (InstalledVersions::satisfies(new VersionParser(), 'symfony/serializer', '>=8.1')) {
-            $this->expectUserDeprecationMessage('Since symfony/serializer 8.1: The "Symfony\Component\Serializer\Exception\PartialDenormalizationException::getErrors()" method is deprecated, use "Symfony\Component\Serializer\Exception\PartialDenormalizationException::getNotNormalizableValueErrors()" instead.');
-        }
-
         $response = static::createClient()->request('POST', '/enum_validation_resources_collect', [
             'headers' => ['Content-Type' => 'application/ld+json'],
             'json' => ['gender' => 'unknown'],

--- a/tests/Functional/NullOnNonNullablePropertyTest.php
+++ b/tests/Functional/NullOnNonNullablePropertyTest.php
@@ -16,9 +16,6 @@ namespace ApiPlatform\Tests\Functional;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\NullOnNonNullableProperty\NullOnNonNullableResource;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
-use Composer\InstalledVersions;
-use Composer\Semver\VersionParser;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 /** @see https://github.com/symfony/symfony/issues/64159 */
 final class NullOnNonNullablePropertyTest extends ApiTestCase
@@ -48,13 +45,8 @@ final class NullOnNonNullablePropertyTest extends ApiTestCase
         $this->assertStringContainsString('Expected argument of type "string", "null" given at property path "name"', $body['hydra:description'] ?? $body['detail'] ?? '');
     }
 
-    #[IgnoreDeprecations]
     public function testNullOnNonNullablePropertyReturns422WhenCollectingErrors(): void
     {
-        if (InstalledVersions::satisfies(new VersionParser(), 'symfony/serializer', '>=8.1')) {
-            $this->expectUserDeprecationMessage('Since symfony/serializer 8.1: The "Symfony\Component\Serializer\Exception\PartialDenormalizationException::getErrors()" method is deprecated, use "Symfony\Component\Serializer\Exception\PartialDenormalizationException::getNotNormalizableValueErrors()" instead.');
-        }
-
         $response = self::createClient()->request('POST', '/null_on_non_nullable_resources_collect', [
             'headers' => ['Content-Type' => 'application/ld+json'],
             'json' => ['name' => null],


### PR DESCRIPTION
## Problem

`main` CI fails on PHP 8.4/8.5 (all DB + Symfony variants) with 2 test failures:

- `EnumDenormalizationValidationTest::testInvalidBackedEnumValueWithCollectDenormalizationErrors`
- `NullOnNonNullablePropertyTest::testNullOnNonNullablePropertyReturns422WhenCollectingErrors`

Both:

```
Expected deprecation with message "Since symfony/serializer 8.1: The
"...PartialDenormalizationException::getErrors()" method is deprecated,
use "...getNotNormalizableValueErrors()" instead." was not triggered
```

## Cause

Since #8211 the denormalization violation factories
(`src/Validator/DenormalizationViolationFactory.php`,
`src/Laravel/State/DenormalizationViolationFactory.php`) guard the call:

```php
$errors = method_exists($exception, 'getNotNormalizableValueErrors')
    ? $exception->getNotNormalizableValueErrors()
    : $exception->getErrors();
```

On `symfony/serializer >=8.1` the new method exists, so the deprecated
`getErrors()` is never called and the deprecation never fires. The
`expectUserDeprecationMessage` assertions are stale — production code was
fixed to avoid the deprecation, but the expectations weren't removed.

## Fix

Remove the `expectUserDeprecationMessage` blocks from both tests plus the
now-unused `VersionParser` / `InstalledVersions` / `IgnoreDeprecations`
imports.

Verified against `symfony/serializer:^8.1` (4/4 pass) and unchanged on
8.0 (the block was already skipped there). php-cs-fixer clean.

Refs #8211