### PR TITLE
fix(jsonschema): don't leak operation deprecation onto sub-schemas

### DIFF
--- a/src/JsonSchema/SchemaFactory.php
+++ b/src/JsonSchema/SchemaFactory.php
@@ -65,6 +65,8 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
     {
         $schema = $schema ? clone $schema : new Schema();
 
+        $operationWasProvided = null !== $operation;
+
         if (!$this->isResourceClass($className)) {
             $operation = null;
             $inputOrOutputClass = $className;
@@ -130,7 +132,10 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         }
 
         // see https://github.com/json-schema-org/json-schema-spec/pull/737
-        if (Schema::VERSION_SWAGGER !== $version && $operation && $operation->getDeprecationReason()) {
+        // deprecation belongs to the operation/path, not to a resource shape embedded in another schema:
+        // a guessed operation under FORCE_SUBSCHEMA must not leak `deprecated` onto the sub-schema (see #7064)
+        if (Schema::VERSION_SWAGGER !== $version && $operation && $operation->getDeprecationReason()
+            && ($operationWasProvided || !($serializerContext[self::FORCE_SUBSCHEMA] ?? false))) {
             $definition['deprecated'] = true;
         }
 

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7064/DeprecatedPutUser.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7064/DeprecatedPutUser.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7064;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Put;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    normalizationContext: ['groups' => ['issue7064_read']],
+    denormalizationContext: ['groups' => ['issue7064_update']],
+    operations: [
+        new Get(),
+        new GetCollection(),
+        new Put(deprecationReason: 'Use PATCH instead'),
+        new Patch(),
+    ],
+)]
+class DeprecatedPutUser
+{
+    #[Groups(['issue7064_read', 'issue7064_custom_read'])]
+    public string $username = '';
+
+    #[Groups(['issue7064_custom_update', 'issue7064_custom_read'])]
+    public string $foo = '';
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue7064/DeprecatedPutUserAction.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue7064/DeprecatedPutUserAction.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7064;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ApiResource(
+    operations: [
+        new Post(),
+    ],
+    normalizationContext: ['groups' => ['issue7064_custom_read']],
+    denormalizationContext: ['groups' => ['issue7064_custom_update']],
+)]
+class DeprecatedPutUserAction
+{
+    #[Groups(['issue7064_custom_update', 'issue7064_custom_read'])]
+    #[ApiProperty(required: true)]
+    public DeprecatedPutUser $user;
+}

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -19,6 +19,8 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Crud;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\CrudOpenApiApiPlatformTag;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DummyWebhook;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6151\OverrideOpenApiResponses;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7064\DeprecatedPutUser;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7064\DeprecatedPutUserAction;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\ParentAttribute;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\AbstractDummy;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\CircularReference;
@@ -106,7 +108,31 @@ class OpenApiTest extends ApiTestCase
             WrappedResponseEntity::class,
             ParentAttribute::class,
             ChildAttribute::class,
+            DeprecatedPutUser::class,
+            DeprecatedPutUserAction::class,
         ];
+    }
+
+    public function testDeprecatedPutDoesNotLeakIntoNestedResourceSchema(): void
+    {
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $json = $response->toArray();
+        $schemas = $json['components']['schemas'];
+
+        // The POST input schema of DeprecatedPutUserAction embeds DeprecatedPutUser.
+        $postRef = $json['paths']['/deprecated_put_user_actions']['post']['requestBody']['content']['application/ld+json']['schema']['$ref'] ?? null;
+        $this->assertNotNull($postRef, 'POST input schema ref is missing');
+
+        $postName = substr($postRef, \strlen('#/components/schemas/'));
+        $userRef = $schemas[$postName]['properties']['user']['$ref'] ?? null;
+        $this->assertNotNull($userRef, 'Nested user property schema ref is missing');
+
+        $userName = substr($userRef, \strlen('#/components/schemas/'));
+        $this->assertArrayHasKey($userName, $schemas, 'Nested DeprecatedPutUser schema is missing from components');
+        $this->assertArrayNotHasKey('deprecated', $schemas[$userName], 'Nested DeprecatedPutUser schema must not be marked deprecated because of the deprecated PUT operation');
     }
 
     public function testErrorsAreDocumented(): void


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Closes #7064 |
| License       | MIT |

## Problem

A deprecated write operation (e.g. a `Put` with a `deprecationReason`) marked the embedded resource's component schema as `deprecated: true` whenever that resource was reused as a property of another resource.

Given a `User` resource with a deprecated `Put`, embedded as a property of a `CustomUserAction` (`Post`), the nested `User` schema in the OpenAPI docs got flagged deprecated (and dropped from Swagger UI) even though it's reached through the non-deprecated `Post`.

## Cause

When a resource is embedded, `SchemaFactory::buildSchema()` recurses with `operation = null` and `FORCE_SUBSCHEMA`. `ResourceMetadataTrait::findOperation()` then *guesses* an operation: for an input sub-schema, `findOperationForType()` picks the **first** operation whose method is in `[POST, PATCH, PUT]` — here the deprecated `Put`. The deprecation flag at `SchemaFactory:133` was then stamped onto a sub-schema that was never built *for* that operation.

Note the output path already behaved correctly (the guessed operation is blanked), so only input sub-schemas leaked.

## Fix

Only set `deprecated` when the operation was explicitly provided, or when the schema is **not** a forced sub-schema. Deprecation belongs to the operation/path, not to a resource shape embedded elsewhere.

- The operation's own input schema (`...-update`) stays `deprecated`.
- `PATCH` keeps its own distinct key (`...-update.jsonMergePatch`).
- The embedded variant (`...-custom_update`) is no longer deprecated.

No change to operation selection (`findOperationForType`), so generated schema names/content are unchanged — minimal BC impact. No existing test asserts `deprecated` on a component schema (all deprecation assertions are path-level via `OpenApiFactory` or Hydra `owl:deprecated`).

## Tests

Functional test in `OpenApiTest` with two fixtures reproducing the issue (deprecated `Put` resource embedded in a `Post` resource), asserting the nested component schema is present and not deprecated.