### PR TITLE
fix(jsonschema): embed relations of non-resource objects in output schema

### DIFF
--- a/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
+++ b/src/JsonSchema/Metadata/Property/Factory/SchemaPropertyMetadataFactory.php
@@ -73,6 +73,11 @@ final class SchemaPropertyMetadataFactory implements PropertyMetadataFactoryInte
         // on output the serializer embeds the relation as soon as gen_id is false, even when it is not a readable link (see AbstractItemNormalizer::normalizeRelation())
         $link = $isInput ? $propertyMetadata->isWritableLink() : ($propertyMetadata->isReadableLink() || false === $propertyMetadata->getGenId());
 
+        // on output a non-resource object is serialized by the standard object normalizer, which embeds related resources regardless of readableLink (see AbstractItemNormalizer::supportsNormalization())
+        if (!$isInput && !$this->isResourceClass($resourceClass)) {
+            $link = true;
+        }
+
         $propertySchema = $propertyMetadata->getSchema() ?? [];
 
         if (null !== $propertyMetadata->getUriTemplate() || (!\array_key_exists('readOnly', $propertySchema) && false === $propertyMetadata->isWritable() && !$propertyMetadata->isInitializable())) {

--- a/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
+++ b/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
@@ -206,6 +206,59 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
         $this->assertSame(['type' => Schema::UNKNOWN_TYPE], $apiProperty->getSchema());
     }
 
+    /**
+     * A relation borne by a non-resource object (e.g. a raw Doctrine entity embedded as a readable link)
+     * is serialized by the standard object normalizer, which embeds the related resource regardless of its
+     * readableLink/genId. The output schema must embed it too, otherwise a strict client rejects the payload.
+     */
+    public function testRelationOnNonResourceParentIsEmbeddedInOutputSchema(): void
+    {
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
+            $this->markTestSkipped('This test only supports type-info component');
+        }
+
+        $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
+        // the parent (DummyWithEnum) is not a resource, the related class (Dummy) is
+        $resourceClassResolver->method('isResourceClass')->willReturnCallback(static fn (string $class): bool => Dummy::class === $class);
+
+        // not a readable link, gen_id left to its default: the relation would normally be an iri-reference string
+        $apiProperty = (new ApiProperty(nativeType: Type::object(Dummy::class)))
+            ->withReadableLink(false);
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())->method('create')->with(DummyWithEnum::class, 'relatedDummy')->willReturn($apiProperty);
+
+        $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
+        $apiProperty = $schemaPropertyMetadataFactory->create(DummyWithEnum::class, 'relatedDummy');
+
+        // defers to SchemaFactory ($ref to embedded subschema) instead of an iri-reference string
+        $this->assertSame(['type' => Schema::UNKNOWN_TYPE], $apiProperty->getSchema());
+    }
+
+    /**
+     * Counterpart to the non-resource case: a non-readable-link relation on a *resource* parent still follows
+     * readableLink and stays an iri-reference string — the non-resource guard must not widen to resources.
+     */
+    public function testRelationOnResourceParentStaysIriReference(): void
+    {
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
+            $this->markTestSkipped('This test only supports type-info component');
+        }
+
+        $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
+        // both the parent and the related class are resources
+        $resourceClassResolver->method('isResourceClass')->willReturn(true);
+
+        $apiProperty = (new ApiProperty(nativeType: Type::object(Dummy::class)))
+            ->withReadableLink(false);
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())->method('create')->with(Dummy::class, 'relatedDummy')->willReturn($apiProperty);
+
+        $schemaPropertyMetadataFactory = new SchemaPropertyMetadataFactory($resourceClassResolver, $decorated);
+        $apiProperty = $schemaPropertyMetadataFactory->create(Dummy::class, 'relatedDummy');
+
+        $this->assertSame(['type' => 'string', 'format' => 'iri-reference', 'example' => 'https://example.com/'], $apiProperty->getSchema());
+    }
+
     public function testMixed(): void
     {
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
| Doc PR        | -

## What

On output, a relation declared on a **non-resource** object (e.g. a Doctrine entity embedded as a readable link, but not itself an `#[ApiResource]`) is now embedded as a `$ref` in the generated JSON Schema, instead of being typed as an `iri-reference` string.

## Why

A non-resource object is serialized by Symfony's standard object normalizer — `AbstractItemNormalizer::supportsNormalization()` only handles resource classes — which embeds its related resources as full objects regardless of their `readableLink` or `gen_id`. `SchemaPropertyMetadataFactory` decided embed-vs-IRI per property and, for such a relation (default `readableLink: false`, and a real IRI so `gen_id` is not `false`), emitted an `iri-reference` string. The advertised schema therefore diverged from the actual payload, and a strict JSON Schema client rejected it (for instance an MCP client validating a tool's `structuredContent` against its advertised `outputSchema`, where an embedded `OrderItem.supplier` object failed `{type: string, null}`).

The fix mirrors the serializer at the single factory that owns the decision: on output, when the parent class is not a resource, treat its resource relations as embedded. Relations on resource DTOs keep following their own `readableLink` and are unaffected — covered by an added test that pins a resource parent to `iri-reference`.
