### PR TITLE
fix(elasticsearch): coerce document _id to declared int identifier type

### DIFF
--- a/src/Elasticsearch/Serializer/DocumentNormalizer.php
+++ b/src/Elasticsearch/Serializer/DocumentNormalizer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Elasticsearch\Serializer;
 
 use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
@@ -26,6 +27,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\TypeInfo\TypeIdentifier;
 
 /**
  * Document denormalizer for Elasticsearch.
@@ -49,6 +51,7 @@ final class DocumentNormalizer implements NormalizerInterface, DenormalizerInter
         ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null,
         ?callable $objectClassResolver = null,
         array $defaultContext = [],
+        private readonly ?PropertyMetadataFactoryInterface $propertyMetadataFactory = null,
     ) {
         $this->decoratedNormalizer = new ObjectNormalizer($classMetadataFactory, $nameConverter, $propertyAccessor, $propertyTypeExtractor, $classDiscriminatorResolver, $objectClassResolver, $defaultContext);
     }
@@ -109,13 +112,33 @@ final class DocumentNormalizer implements NormalizerInterface, DenormalizerInter
             }
         }
 
-        $identifier = null === $this->nameConverter ? $identifier : $this->nameConverter->normalize($identifier, $class, self::FORMAT);
+        $sourceKey = null === $this->nameConverter ? $identifier : $this->nameConverter->normalize($identifier, $class, self::FORMAT);
 
-        if (!isset($data['_source'][$identifier])) {
-            $data['_source'][$identifier] = $data['_id'];
+        if (!isset($data['_source'][$sourceKey])) {
+            $data['_source'][$sourceKey] = $this->coerceIdentifier($class, $identifier, $data['_id']);
         }
 
         return $data;
+    }
+
+    /**
+     * Elasticsearch always exposes the document identifier (`_id`) as a string. When the resource
+     * identifier is declared as an int, casting it back avoids a type mismatch in the inner
+     * ObjectNormalizer. String identifiers (e.g. UUIDs) are left untouched.
+     */
+    private function coerceIdentifier(string $class, string $identifier, string $value): int|string
+    {
+        if (null === $this->propertyMetadataFactory || !is_numeric($value)) {
+            return $value;
+        }
+
+        $nativeType = $this->propertyMetadataFactory->create($class, $identifier)->getNativeType();
+
+        if ($nativeType?->isIdentifiedBy(TypeIdentifier::INT) && !$nativeType->isIdentifiedBy(TypeIdentifier::STRING)) {
+            return (int) $value;
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Elasticsearch/Tests/Fixtures/IntegerIdentified.php
+++ b/src/Elasticsearch/Tests/Fixtures/IntegerIdentified.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Elasticsearch\Tests\Fixtures;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+
+#[ApiResource(operations: [new Get()])]
+class IntegerIdentified
+{
+    #[ApiProperty(identifier: true)]
+    public ?int $id = null;
+
+    public ?string $name = null;
+}

--- a/src/Elasticsearch/Tests/Serializer/DocumentNormalizerTest.php
+++ b/src/Elasticsearch/Tests/Serializer/DocumentNormalizerTest.php
@@ -15,16 +15,21 @@ namespace ApiPlatform\Elasticsearch\Tests\Serializer;
 
 use ApiPlatform\Elasticsearch\Serializer\DocumentNormalizer;
 use ApiPlatform\Elasticsearch\Tests\Fixtures\Foo;
+use ApiPlatform\Elasticsearch\Tests\Fixtures\IntegerIdentified;
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\TypeInfo\Type;
 
 final class DocumentNormalizerTest extends TestCase
 {
@@ -83,6 +88,41 @@ final class DocumentNormalizerTest extends TestCase
         $expectedFoo->setBar('Chaverot');
 
         self::assertEquals($expectedFoo, $normalizer->denormalize($document, Foo::class, DocumentNormalizer::FORMAT));
+    }
+
+    public function testDenormalizeCoercesIdentifierToDeclaredType(): void
+    {
+        $document = [
+            '_index' => 'test',
+            '_type' => '_doc',
+            '_id' => '1',
+            '_version' => 1,
+            'found' => true,
+            '_source' => [
+                'name' => 'Caroline',
+            ],
+        ];
+
+        $resourceMetadataFactory = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactory->create(IntegerIdentified::class)->willReturn(new ResourceMetadataCollection(IntegerIdentified::class, [(new ApiResource())->withOperations(new Operations([new Get()]))]));
+
+        $propertyMetadataFactory = $this->prophesize(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->create(IntegerIdentified::class, 'id')->willReturn((new ApiProperty())->withNativeType(Type::nullable(Type::int())));
+
+        // property_info is wired in production (elasticsearch.php), which makes the inner
+        // ObjectNormalizer enforce the declared "int" type on the id property: a raw string
+        // "_id" would be rejected.
+        $normalizer = new DocumentNormalizer(
+            $resourceMetadataFactory->reveal(),
+            propertyTypeExtractor: new ReflectionExtractor(),
+            propertyMetadataFactory: $propertyMetadataFactory->reveal(),
+        );
+
+        $item = $normalizer->denormalize($document, IntegerIdentified::class, DocumentNormalizer::FORMAT);
+
+        self::assertInstanceOf(IntegerIdentified::class, $item);
+        self::assertSame(1, $item->id);
+        self::assertSame('Caroline', $item->name);
     }
 
     public function testSupportsNormalization(): void

--- a/src/Symfony/Bundle/Resources/config/elasticsearch.php
+++ b/src/Symfony/Bundle/Resources/config/elasticsearch.php
@@ -46,6 +46,7 @@ return function (ContainerConfigurator $container) {
             service('serializer.mapping.class_discriminator_resolver')->ignoreOnInvalid(),
             null,
             '%api_platform.serializer.default_context%',
+            service('api_platform.metadata.property.metadata_factory'),
         ])
         ->tag('serializer.normalizer', ['priority' => -922]);
 


### PR DESCRIPTION
## Summary

Elasticsearch always exposes the document identifier (`_id`) as a string. `DocumentNormalizer::populateIdentifier()` wrote that raw string into `_source` under the resource's identifier key, so a resource whose identifier is declared `int` failed denormalization in the inner `ObjectNormalizer` with `NotNormalizableValueException` (`The type of the "id" attribute ... must be one of "int" ("string" given)`).

The normalizer now coerces `_id` to int **only** when the identifier's declared native type is int (and not string). String and UUID identifiers are left untouched. The coercion is type-driven via `PropertyMetadataFactoryInterface::create(...)->getNativeType()`, not a blind cast; when the property metadata factory or type info is unavailable the value is returned unchanged (no behavior change).

## Reproduction

Denormalizing an ES document with a string `_id` into a resource whose identifier is `?int` threw `NotNormalizableValueException` instead of building the item.

## Test plan

- [x] Added failing test `testDenormalizeCoercesIdentifierToDeclaredType` (red before fix, green after).
- [x] Full Elasticsearch test suite passes locally.
- [x] php-cs-fixer + PHPStan clean; the container compiles with the new (nullable, last-position, BC-safe) constructor argument.

Fixes #8010