### PR TITLE
fix(openapi): throw clear error for openapi parameter missing name in yaml config

### DIFF
--- a/src/Metadata/Extractor/YamlResourceExtractor.php
+++ b/src/Metadata/Extractor/YamlResourceExtractor.php
@@ -258,6 +258,14 @@ final class YamlResourceExtractor extends AbstractResourceExtractor
         if (\array_key_exists('parameters', $resource['openapi']) && \is_array($openapiParameters = $resource['openapi']['parameters'] ?? [])) {
             $parameters = [];
             foreach ($openapiParameters as $parameter) {
+                if (!isset($parameter['name'])) {
+                    throw new InvalidArgumentException('OpenAPI parameter is missing the required "name" key.');
+                }
+
+                if (!isset($parameter['in'])) {
+                    throw new InvalidArgumentException(\sprintf('OpenAPI parameter "%s" is missing the required "in" key.', $parameter['name']));
+                }
+
                 $parameters[] = new Parameter(
                     name: $parameter['name'],
                     in: $parameter['in'],

--- a/src/Metadata/Tests/Extractor/YamlExtractorTest.php
+++ b/src/Metadata/Tests/Extractor/YamlExtractorTest.php
@@ -518,6 +518,14 @@ class YamlExtractorTest extends TestCase
         $this->assertEquals('john-doe', $operation->getParameters()[0]->getExample());
     }
 
+    public function testOpenApiParameterWithoutNameThrowsClearException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('OpenAPI parameter is missing the required "name" key');
+
+        (new YamlResourceExtractor([__DIR__.'/yaml/openapi-parameter-without-name.yaml']))->getResources();
+    }
+
     public function testInputAndOutputAreBooleans(): void
     {
         $extractor = new YamlResourceExtractor([__DIR__.'/yaml/input-and-output-are-booleans.yaml']);

--- a/src/Metadata/Tests/Extractor/yaml/openapi-parameter-without-name.yaml
+++ b/src/Metadata/Tests/Extractor/yaml/openapi-parameter-without-name.yaml
@@ -1,0 +1,9 @@
+resources:
+    ApiPlatform\Metadata\Tests\Fixtures\ApiResource\Program:
+        -   uriTemplate: /programs.{_format}
+            operations:
+                ApiPlatform\Metadata\GetCollection:
+                    openapi:
+                        parameters:
+                            -   in: query
+                                description: A parameter without a name


### PR DESCRIPTION
## Summary

When a YAML/XML-configured operation declares an `openapi.parameters` entry without a `name` (or `in`), `YamlResourceExtractor::buildOpenapi()` accessed `$parameter['name']` / `$parameter['in']` unguarded. This emitted a `Warning: Undefined array key "name"` (the original symptom of #8013, surfaced via `api:openapi:export`) followed by a cryptic `TypeError` from the `Parameter` constructor.

`name` and `in` are required fields of an OpenAPI parameter object. The extractor now throws a clear `InvalidArgumentException` naming the missing required key, instead of leaking a PHP warning and producing broken output.

The original report used the removed 2.6 `collectionOperations`/`openapi_context` syntax (that array path is gone from `OpenApiFactory`), but the modern config equivalent (`openapi.parameters` arrays) reaches the same unguarded code in the extractor.

## Reproduction

Declaring an operation `openapi.parameters` entry with no `name` key crashed with `Undefined array key "name"` + `TypeError` rather than a helpful error.

## Test plan

- [x] Added `testOpenApiParameterWithoutNameThrowsClearException` (fails before fix, passes after).
- [x] `YamlExtractorTest` passes; php-cs-fixer + PHPStan clean.

Fixes #8013