### PR TITLE
test(mongodb): failing repro for ODM nullable field unset

### DIFF
--- a/src/Doctrine/Odm/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Doctrine/Odm/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -271,6 +271,21 @@ class DoctrineExtractorTest extends TestCase
         yield ['notMapped', null];
     }
 
+    /**
+     * In ODM, a Field's `nullable` flag does not mean "may hold null" — it controls whether a null
+     * value is persisted as an explicit null key or the key is omitted from the document. Every ODM
+     * field can therefore receive null, so the extracted TypeInfo Type must permit null even when the
+     * mapping uses the default `nullable=false`. Otherwise PATCH {"field": null} is rejected with
+     * "The type of the ... attribute must be ..., NULL given." (issue #3746).
+     */
+    public function testExtractScalarFieldPermitsNull(): void
+    {
+        $type = $this->createExtractor()->getType(DoctrineDummy::class, 'string');
+
+        $this->assertNotNull($type);
+        $this->assertTrue($type->isNullable(), 'ODM scalar fields are always nullable; the extracted type must permit null.');
+    }
+
     public function testGetPropertiesCatchException(): void
     {
         $this->assertNull($this->createExtractor()->getProperties('Not\Exist'));


### PR DESCRIPTION
## Context

Failing-repro PR requested by @soyuka in the design discussion for #3746.

In Doctrine MongoDB ODM, a `#[Field]`'s `nullable` flag does **not** mean "the field may hold null". It controls whether a PHP `null` is persisted as an explicit `null` key or the key is omitted from the document (`nullable=false`, the default = omit). Every ODM field can therefore receive `null`.

`src/Doctrine/Odm/PropertyInfo/DoctrineExtractor::getType()` feeds `ClassMetadata::isNullable()` into the TypeInfo `Type` nullable flag, so a plain `#[Field(type: 'string')]` yields a **non-nullable** Type. As a result `PATCH {"field": null}` is rejected with `The type of the "field" attribute must be "string", "NULL" given.` instead of unsetting the field.


## This PR

A single failing test (`testExtractScalarFieldPermitsNull`) asserting the expected-correct behavior — an ODM scalar field's extracted type permits null. It fails on current `4.3` HEAD, demonstrating the bug.

**No production code is changed.** The fix direction is pending a maintainer decision between the three options posted in the validation thread (always-nullable for ODM scalars / defer to PHP property type / drop the flag).

Refs #3746