### PR TITLE
fix(graphql): honor custom mutation output class in payload type

### DIFF
--- a/src/GraphQl/Type/TypeBuilder.php
+++ b/src/GraphQl/Type/TypeBuilder.php
@@ -329,7 +329,8 @@ final class TypeBuilder implements ContextAwareTypeBuilderInterface
             'resolveField' => $this->defaultFieldResolver,
             'fields' => function () use ($resourceClass, $operation, $operationName, $resourceMetadataCollection, $input, $wrapData, $depth, $ioMetadata) {
                 if ($wrapData) {
-                    $queryNormalizationContext = $this->getQueryOperation($resourceMetadataCollection)?->getNormalizationContext() ?? [];
+                    $queryOperation = $this->getQueryOperation($resourceMetadataCollection);
+                    $queryNormalizationContext = $queryOperation?->getNormalizationContext() ?? [];
 
                     try {
                         $mutationNormalizationContext = $operation instanceof Mutation || $operation instanceof Subscription ? ($resourceMetadataCollection->getOperation($operationName)->getNormalizationContext() ?? []) : [];
@@ -339,6 +340,12 @@ final class TypeBuilder implements ContextAwareTypeBuilderInterface
                     // Use a new type for the wrapped object only if there is a specific normalization context for the mutation or the subscription.
                     // If not, use the query type in order to ensure the client cache could be used.
                     $useWrappedType = $queryNormalizationContext !== $mutationNormalizationContext;
+
+                    // The query type can only be reused when both operations produce the same output class.
+                    // A mutation declaring its own output class must expose that class on its payload.
+                    if (!$useWrappedType && ($operation->getOutput()['class'] ?? null) !== ($queryOperation?->getOutput()['class'] ?? null)) {
+                        $useWrappedType = true;
+                    }
 
                     $wrappedOperationName = $operationName;
 

--- a/tests/Fixtures/TestBundle/ApiResource/Issue2754/Sum.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue2754/Sum.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue2754;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Mutation;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\Operation;
+
+#[ApiResource(
+    graphQlOperations: [
+        new Query(
+            name: 'item_query',
+            provider: [self::class, 'provide'],
+        ),
+        new Mutation(
+            name: 'sum',
+            resolver: 'app.graphql.mutation_resolver.issue2754_sum',
+            output: SumResult::class,
+            args: ['operandA' => ['type' => 'Int!'], 'operandB' => ['type' => 'Int!']],
+        ),
+    ]
+)]
+class Sum
+{
+    public function __construct(public ?int $id = null, public ?int $operandA = null, public ?int $operandB = null)
+    {
+    }
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        return new self(1);
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue2754/SumResolver.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue2754/SumResolver.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue2754;
+
+use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
+
+final class SumResolver implements MutationResolverInterface
+{
+    /**
+     * @param object|null $item
+     * @param mixed[]     $context
+     */
+    public function __invoke($item, array $context): SumResult
+    {
+        $input = $context['args']['input'] ?? [];
+
+        return new SumResult(1, ($input['operandA'] ?? 0) + ($input['operandB'] ?? 0));
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/Issue2754/SumResult.php
+++ b/tests/Fixtures/TestBundle/ApiResource/Issue2754/SumResult.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue2754;
+
+// Fields deliberately differ from Sum: the mutation payload exposes them only if it honors output.
+class SumResult
+{
+    public function __construct(public ?int $id = null, public ?int $sum = null)
+    {
+    }
+}

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -506,6 +506,11 @@ services:
         tags:
             - name: 'api_platform.graphql.resolver'
 
+    app.graphql.mutation_resolver.issue2754_sum:
+        class: 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue2754\SumResolver'
+        tags:
+            - name: 'api_platform.graphql.resolver'
+
     app.graphql.query_resolver.security_after_resolver:
         class: 'ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue6427\SecurityAfterResolverResolver'
         tags:

--- a/tests/Functional/GraphQl/Issue2754Test.php
+++ b/tests/Functional/GraphQl/Issue2754Test.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue2754\Sum;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * A custom GraphQL mutation declaring an explicit output DTO must expose the
+ * output DTO's fields on its payload type, not the resource's fields.
+ *
+ * @see https://github.com/api-platform/core/issues/2754
+ */
+final class Issue2754Test extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Sum::class];
+    }
+
+    public function testCustomMutationHonorsOutputClassFields(): void
+    {
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<'GRAPHQL'
+mutation {
+  sumSum(input: {operandA: 2, operandB: 3}) {
+    sum {
+      sum
+    }
+  }
+}
+GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame(5, $json['data']['sumSum']['sum']['sum']);
+    }
+}


### PR DESCRIPTION
## Summary

A custom GraphQL mutation declaring its own `output` class did not expose that class on its payload type. When the mutation and query normalization contexts matched, `TypeBuilder` reused the `item_query` type for the wrapped payload (to allow client cache sharing), so the payload exposed the resource fields instead of the output DTO — producing the reported `Cannot query field "X" on type "..."`. The fix forces a dedicated wrapped type whenever the mutation's output class differs from the query operation's output class.

## Reproduction

A resource with a custom `Mutation(resolver: ..., output: SumResult::class)` whose output DTO has different fields than the resource: before the fix, querying the DTO's fields on the mutation payload fails; the payload carries the resource's fields.

## Test plan

- [x] Added failing functional test (`tests/Functional/GraphQl/Issue2754Test.php`) covering the bug.
- [x] Test passes after the fix.
- [x] Full GraphQl functional suite + `TypeBuilder`/introspection/schema-export tests still pass locally.

Fixes #2754