### PR TITLE
fix(mcp): support mcp/sdk 0.6 ResourceDefinition in Loader

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,6 +46,11 @@ parameters:
 		-
 			message: '#Symfony\\Component\\PropertyInfo\\Type#'
 			identifier: class.notFound
+		# mcp/sdk 0.6 renamed Mcp\Schema\Resource to ResourceDefinition; Loader resolves at runtime, only one exists per installed version
+		-
+			message: '#class Mcp\\Schema\\(Resource|ResourceDefinition) not found#'
+			identifier: class.notFound
+			path: src/Mcp/Capability/Registry/Loader.php
 		# False positives
 		-   message: '#Call to an undefined method Negotiation\\AcceptHeader::getType\(\).#'
 		-

--- a/src/Mcp/Capability/Registry/Loader.php
+++ b/src/Mcp/Capability/Registry/Loader.php
@@ -24,6 +24,7 @@ use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Schema\Annotations;
 use Mcp\Schema\Resource;
+use Mcp\Schema\ResourceDefinition;
 use Mcp\Schema\Tool;
 use Mcp\Schema\ToolAnnotations;
 
@@ -77,8 +78,10 @@ final class Loader implements LoaderInterface
                     }
 
                     if ($mcp instanceof McpResource) {
+                        // mcp/sdk 0.6 renamed Mcp\Schema\Resource to ResourceDefinition; support both while symfony/mcp-bundle still pins ^0.5
+                        $resourceClass = class_exists(ResourceDefinition::class) ? ResourceDefinition::class : Resource::class;
                         $registry->registerResource(
-                            new Resource(
+                            new $resourceClass(
                                 uri: $mcp->getUri(),
                                 name: $mcp->getName(),
                                 description: $mcp->getDescription(),


### PR DESCRIPTION
## Summary

`mcp/sdk` 0.6 renamed `Mcp\Schema\Resource` to `Mcp\Schema\ResourceDefinition`. The MCP `Loader` instantiated `Mcp\Schema\Resource` directly, so it fatals on 0.6 (class not found).

This resolves the class at runtime via `class_exists`, so the `Loader` works on **both** 0.5 and 0.6.

The composer constraint (`mcp/sdk: >=0.4 <1.0`) already permits 0.6 — no constraint change needed. Dual support is required because `symfony/mcp-bundle` still pins `mcp/sdk: ^0.5`, which forces 0.5 to be installed in the current stack.

## Details

`src/Mcp/Capability/Registry/Loader.php` is the only file in `api-platform/mcp` touching renamed 0.6 API. Everything else (`Handler`, `StructuredContentProcessor` — `JsonRpc\*`, `CallToolResult`, `ReadResourceResult`, `TextContent`, `Tool`, `Annotations`) is unchanged between 0.5 and 0.6.

The trailing `$isManual` argument on `registerResource`/`registerTool` is kept: 0.6 dropped it from the signature, but PHP silently ignores the extra positional argument on a userland method, while 0.5 still honors it.

`Tool` and `ResourceDefinition` constructors take the same named arguments as their 0.5 counterparts, so no other change is needed.

## Tests

Existing `LoaderTest` passes (asserts resource properties, not the class type, so it is robust to either class). The 0.6 branch can't be exercised in CI until `symfony/mcp-bundle` drops its `^0.5` pin — verified against the 0.6 source by inspection.