### PR TITLE
fix(symfony): pass operation priority to the route collection

### DIFF
--- a/src/Symfony/Routing/ApiLoader.php
+++ b/src/Symfony/Routing/ApiLoader.php
@@ -126,7 +126,7 @@ final class ApiLoader extends Loader
                         $operation->getCondition() ?? ''
                     );
 
-                    $routeCollection->add($operationName, $route);
+                    $routeCollection->add($operationName, $route, $operation->getPriority() ?? 0);
                 }
             }
         }

--- a/tests/Symfony/Routing/ApiLoaderTest.php
+++ b/tests/Symfony/Routing/ApiLoaderTest.php
@@ -282,6 +282,23 @@ class ApiLoaderTest extends TestCase
         $this->assertNotNull($routeCollection->get('api_genid'));
     }
 
+    public function testApiLoaderRegistersOperationPriorityOnTheRoute(): void
+    {
+        $path = '/dummies/{id}.{_format}';
+
+        $resourceCollection = new ResourceMetadataCollection(Dummy::class, [
+            (new ApiResource())->withShortName('dummy')->withOperations(new Operations([
+                'api_dummies_get_item' => (new Get())->withUriTemplate($path)->withPriority(10),
+                'api_dummies_get_collection' => (new GetCollection())->withUriTemplate('/dummies.{_format}'),
+            ])),
+        ]);
+
+        $routeCollection = $this->getApiLoaderWithResourceMetadataCollection($resourceCollection)->load(null);
+
+        $this->assertSame(10, $routeCollection->getPriority('api_dummies_get_item'));
+        $this->assertNull($routeCollection->getPriority('api_dummies_get_collection'));
+    }
+
     public function testApiLoaderWithUndefinedControllerService(): void
     {
         $this->expectExceptionObject(new \RuntimeException('Operation "api_dummies_my_undefined_controller_method_item" is defining an unknown service as controller "Foo\\Bar\\MyUndefinedController". Make sure it is properly registered in the dependency injection container.'));


### PR DESCRIPTION
## Summary

`ApiLoader::load()` called `$routeCollection->add($operationName, $route)` without passing the operation priority, so `Operation::getPriority()` was silently dropped and route ordering ignored any configured priority.

## Reproduction

An operation declared with a higher `priority` was registered in the `RouteCollection` with priority 0, so it was not sorted ahead of other routes as expected.

## Test plan

- [x] Added failing test asserting the route records the operation priority.
- [x] Test passes after the fix.
- [x] `tests/Symfony/Routing` suite still passes locally (31/31).

Fixes #8135