### PR TITLE
fix(mcp): support mcp/sdk 0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "jangregor/phpstan-prophecy": "^2.1.11",
         "justinrainbow/json-schema": "^6.5.2",
         "laravel/framework": "^11.0 || ^12.0 || ^13.0",
-        "mcp/sdk": ">=0.4 <1.0",
+        "mcp/sdk": "^0.6",
         "orchestra/testbench": "^10.9 || ^11.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "phpstan/extension-installer": "^1.1",

--- a/src/Mcp/Capability/Registry/Loader.php
+++ b/src/Mcp/Capability/Registry/Loader.php
@@ -23,7 +23,6 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface
 use Mcp\Capability\Registry\Loader\LoaderInterface;
 use Mcp\Capability\RegistryInterface;
 use Mcp\Schema\Annotations;
-use Mcp\Schema\Resource;
 use Mcp\Schema\ResourceDefinition;
 use Mcp\Schema\Tool;
 use Mcp\Schema\ToolAnnotations;
@@ -73,15 +72,12 @@ final class Loader implements LoaderInterface
                                 outputSchema: $outputSchema,
                             ),
                             self::HANDLER,
-                            true,
                         );
                     }
 
                     if ($mcp instanceof McpResource) {
-                        // mcp/sdk 0.6 renamed Mcp\Schema\Resource to ResourceDefinition; support both while symfony/mcp-bundle still pins ^0.5
-                        $resourceClass = class_exists(ResourceDefinition::class) ? ResourceDefinition::class : Resource::class;
                         $registry->registerResource(
-                            new $resourceClass(
+                            new ResourceDefinition(
                                 uri: $mcp->getUri(),
                                 name: $mcp->getName(),
                                 description: $mcp->getDescription(),
@@ -92,7 +88,6 @@ final class Loader implements LoaderInterface
                                 meta: $mcp->getMeta()
                             ),
                             self::HANDLER,
-                            true,
                         );
                     }
                 }

--- a/src/Mcp/Tests/Capability/Registry/LoaderTest.php
+++ b/src/Mcp/Tests/Capability/Registry/LoaderTest.php
@@ -71,7 +71,6 @@ class LoaderTest extends TestCase
                     return true;
                 }),
                 Loader::HANDLER,
-                true,
             );
 
         $loader = new Loader($nameCollectionFactory, $metadataCollectionFactory, $schemaFactory);
@@ -114,7 +113,6 @@ class LoaderTest extends TestCase
                     return true;
                 }),
                 Loader::HANDLER,
-                true,
             );
 
         $loader = new Loader($nameCollectionFactory, $metadataCollectionFactory, $schemaFactory);
@@ -154,7 +152,6 @@ class LoaderTest extends TestCase
                     return true;
                 }),
                 Loader::HANDLER,
-                true,
             );
 
         $loader = new Loader($nameCollectionFactory, $metadataCollectionFactory, $schemaFactory);

--- a/src/Mcp/composer.json
+++ b/src/Mcp/composer.json
@@ -30,7 +30,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^4.3",
         "api-platform/json-schema": "^4.3",
-        "mcp/sdk": ">=0.4 <1.0",
+        "mcp/sdk": "^0.6",
         "symfony/object-mapper": "^7.4 || ^8.0",
         "symfony/polyfill-php85": "^1.32"
     },


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Tickets       | -   |
| License       | MIT |

mcp/sdk 0.6 is out and `symfony/mcp-bundle` now requires `^0.6`, so composer resolves 0.6 and the `PHPStan (PHP 8.5)` job fails on the old API. 0.6:

- renames `Mcp\Schema\Resource` to `Mcp\Schema\ResourceDefinition`
- drops the `bool $isManual` argument from `RegistryInterface::registerTool()` and `registerResource()`

This bumps the `mcp/sdk` constraint to `^0.6` (root + `src/Mcp`), uses `ResourceDefinition` directly (removing the previous `class_exists` shim that supported both 0.5 and 0.6), and drops the `$isManual` argument from the registry loader calls. The loader test is adapted accordingly.