### PR TITLE
fix(doctrine): exclude self-reference relation links from GraphQL root item lookup

### DIFF
--- a/src/Doctrine/Common/State/LinksHandlerTrait.php
+++ b/src/Doctrine/Common/State/LinksHandlerTrait.php
@@ -36,10 +36,12 @@ trait LinksHandlerTrait
 
         if (!($linkClass = $context['linkClass'] ?? false)) {
             // Root item lookup: GraphQl Query.links carries relation links (for nested traversal)
-            // and the identifier-self link. Keep only the identifier-self / self-references so
-            // handleLinks applies WHERE id=X without consuming identifiers via relation joins.
+            // and the identifier-self link. Keep only the identifier-self link so handleLinks
+            // applies WHERE id=X. A relation link always carries a fromProperty/toProperty (even a
+            // self-reference whose toClass equals the resource class, e.g. a ManyToOne to self), so
+            // excluding those prevents consuming the identifier via a bogus relation join.
             if ($operation instanceof GraphQlOperation) {
-                return array_values(array_filter($links, static fn ($l) => null === $l->getToClass() || $l->getToClass() === $resourceClass));
+                return array_values(array_filter($links, static fn ($l) => !$l->getFromProperty() && !$l->getToProperty() && (null === $l->getToClass() || $l->getToClass() === $resourceClass)));
             }
 
             return $links;

--- a/tests/Fixtures/TestBundle/Entity/GraphQlMappedSelfReference/MappedSelfReference.php
+++ b/tests/Fixtures/TestBundle/Entity/GraphQlMappedSelfReference/MappedSelfReference.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlMappedSelfReference;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GraphQl\Query;
+use ApiPlatform\Metadata\GraphQl\QueryCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(
+    operations: [],
+    graphQlOperations: [
+        new Query(),
+        new QueryCollection(),
+    ]
+)]
+#[ORM\Entity]
+class MappedSelfReference
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public ?string $name = null;
+
+    // A real Doctrine association pointing back to the same resource class. Its
+    // link has toClass === resourceClass, so the GraphQL root-item filter must
+    // not mistake it for the identifier-self link and emit a bogus self-join.
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', nullable: true)]
+    public ?self $parent = null;
+}

--- a/tests/Functional/GraphQl/MappedSelfReferenceTest.php
+++ b/tests/Functional/GraphQl/MappedSelfReferenceTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\GraphQl;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\GraphQlMappedSelfReference\MappedSelfReference;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * A GraphQL item query on a self-referencing entity (a mapped ManyToOne pointing
+ * back to the same resource class) must apply WHERE id=X only. The relation link
+ * has toClass === resourceClass like the identifier-self link, but it must not
+ * survive the root-item filter, otherwise handleLinks emits a bogus self-join
+ * plus an extra WHERE condition and the item always resolves to null.
+ *
+ * @see https://github.com/api-platform/core/issues/8305
+ */
+final class MappedSelfReferenceTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [MappedSelfReference::class];
+    }
+
+    public function testItemQueryOnMappedSelfReferenceReturnsTheRecord(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('MappedSelfReference is ORM-only.');
+        }
+
+        $this->recreateSchema([MappedSelfReference::class]);
+
+        $manager = $this->getManager();
+        $root = new MappedSelfReference();
+        $root->name = 'Root';
+        $manager->persist($root);
+        $child = new MappedSelfReference();
+        $child->name = 'Child';
+        $child->parent = $root;
+        $manager->persist($child);
+        $manager->flush();
+
+        // The child's parent is the root, not itself: the bogus self-join
+        // (WHERE parent.id = child.id) would never match, so this proves the
+        // self-reference link is excluded from the root item lookup.
+        $iri = '/mapped_self_references/'.$child->id;
+
+        $response = self::createClient()->request('POST', '/graphql', ['json' => [
+            'query' => <<<GRAPHQL
+            {
+              mappedSelfReference(id: "{$iri}") {
+                id
+                name
+              }
+            }
+            GRAPHQL,
+        ]]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray(false);
+        $this->assertArrayNotHasKey('errors', $json, json_encode($json['errors'] ?? null));
+        $this->assertSame('Child', $json['data']['mappedSelfReference']['name']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Fixes #8305
| License       | MIT
| Doc PR        | n/a

A GraphQL **item** query on a **self-referencing** entity (a mapped `ManyToOne` pointing back to the same resource class) always returned `null`, even though a matching record existed.

## Root cause

In `Doctrine\Common\State\LinksHandlerTrait::getLinks()`, the GraphQL root-item branch keeps the identifier-self link by filtering on `toClass`:

```php
return array_values(array_filter($links, static fn ($l) => null === $l->getToClass() || $l->getToClass() === $resourceClass));
```

A real self-reference association (e.g. `parent` → same class) also has `toClass === $resourceClass`, so it survives the filter and is treated like an identifier link in `handleLinks()`. That produces a bogus self-join plus an extra `WHERE` on the joined alias:

```sql
SELECT ... FROM tree_node t0_
INNER JOIN tree_node t1_ ON (t0_.id = t1_.parent_id)
WHERE t1_.id = $1 AND t0_.id = $2   -- $1 = $2 = id, can never match → null
```

Regression introduced between 4.3.4 and 4.3.13 (changes around the GraphQL-only identifier link handling).

## Fix

The identifier-self link carries neither `fromProperty` nor `toProperty` (`LinkFactory`); every relation link sets one — including a self-reference whose `toClass` equals the resource class. Excluding links with relation properties keeps only the genuine identifier link (`WHERE id = X`):

```php
return array_values(array_filter($links, static fn ($l) => !$l->getFromProperty() && !$l->getToProperty() && (null === $l->getToClass() || $l->getToClass() === $resourceClass)));
```

## Tests

- New functional test `MappedSelfReferenceTest` with a GraphQL-only entity carrying a mapped `ManyToOne(self)` on `parent_id`. Child→parent=root, so the bogus self-join would never match — proving the self-reference link is excluded from the root lookup. Fails (`null`) before the fix, passes after.
- Sibling case `TransientSelfReferenceTest` (#8292) and the full `tests/Functional/GraphQl/` suite (155 tests) stay green.
