### PR TITLE
chore: drop phpstan mcp/sdk class.notFound ignore

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -46,11 +46,6 @@ parameters:
 		-
 			message: '#Symfony\\Component\\PropertyInfo\\Type#'
 			identifier: class.notFound
-		# mcp/sdk 0.6 renamed Mcp\Schema\Resource to ResourceDefinition; Loader resolves at runtime, only one exists per installed version
-		-
-			message: '#class Mcp\\Schema\\(Resource|ResourceDefinition) not found#'
-			identifier: class.notFound
-			path: src/Mcp/Capability/Registry/Loader.php
 		# False positives
 		-   message: '#Call to an undefined method Negotiation\\AcceptHeader::getType\(\).#'
 		-


### PR DESCRIPTION
Since #8302 the MCP Loader statically imports \`Mcp\Schema\ResourceDefinition\`, which always exists under the required \`mcp/sdk: ^0.6\`. The PHPStan \`class.notFound\` ignore pattern for \`Mcp\Schema\(Resource|ResourceDefinition)\` in \`src/Mcp/Capability/Registry/Loader.php\` can therefore never match, so \`reportUnmatchedIgnoredErrors\` fails the PHPStan job on 4.3.

Removes the dead ignore pattern.