### PR TITLE
feat(doctrine): promote ComparisonFilter out of @experimental

### DIFF
--- a/src/Doctrine/Odm/Filter/ComparisonFilter.php
+++ b/src/Doctrine/Odm/Filter/ComparisonFilter.php
@@ -29,8 +29,6 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
 
 /**
  * Decorates an equality filter (ExactFilter) to add comparison operators (gt, gte, lt, lte).
- *
- * @experimental
  */
 final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, LoggerAwareInterface
 {

--- a/src/Doctrine/Orm/Filter/ComparisonFilter.php
+++ b/src/Doctrine/Orm/Filter/ComparisonFilter.php
@@ -30,8 +30,6 @@ use Doctrine\ORM\QueryBuilder;
 
 /**
  * Decorates an equality filter (ExactFilter, UuidFilter) to add comparison operators (gt, gte, lt, lte).
- *
- * @experimental
  */
 final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, LoggerAwareInterface
 {


### PR DESCRIPTION
## Summary

Stabilizes `ComparisonFilter` (ORM + ODM) by dropping the `@experimental` annotation. No behavior, signature, or wiring change — the filter is part of the canonical 4.4 set.

## Roadmap

Part of the 4.4 preparation. Spec: TODO-filters.md §5.2, §8.
Phase: 4.4 (stabilization / annotation-only, no BC break).

## Test plan

- [x] Existing functional coverage green: `ComparisonFilterTest` + `DateFilterTest` + `Uuid/UuidComparisonFilterTest` (43 tests, 98 assertions).
- [x] php-cs-fixer + phpstan clean (ORM); pre-existing unrelated ODM `class.notFound` (MongoDB ODM not installed) and `Issue7916` failures confirmed present at `upstream/main` HEAD, not introduced here.
- [x] Diff is exactly the two `@experimental` annotation removals (4 deletions).