### PR TITLE
feat(doctrine): promote OrFilter out of @experimental

### DIFF
--- a/src/Doctrine/Orm/Filter/OrFilter.php
+++ b/src/Doctrine/Orm/Filter/OrFilter.php
@@ -26,8 +26,6 @@ use Doctrine\ORM\QueryBuilder;
 
 /**
  * @author Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
- *
- * @experimental
  */
 final class OrFilter implements FilterInterface, OpenApiParameterFilterInterface, ManagerRegistryAwareInterface, LoggerAwareInterface
 {


### PR DESCRIPTION
## Summary

Stabilizes `OrFilter` by dropping the `@experimental` annotation on the ORM filter. The ODM `OrFilter` already carries no `@experimental` tag and is left untouched. No behavior or signature change.

## Roadmap

Part of the 4.4 preparation (canonical filter set). Spec: TODO-filters.md §5.3, §8.
Phase: 4.4 (stabilization / annotation-only, no BC break).

## Test plan

- [x] Existing functional coverage green: `tests/Functional/Parameters/OrFilterTest.php` (6 tests, 13 assertions).
- [x] phpstan + php-cs-fixer clean.
- [x] Diff is exactly the ORM `@experimental` removal (2 deletions); ODM confirmed already tag-free.