### PR TITLE
feat(metadata): document BackwardCompatibleFilterDescriptionTrait as public API

### DIFF
--- a/src/Metadata/BackwardCompatibleFilterDescriptionTrait.php
+++ b/src/Metadata/BackwardCompatibleFilterDescriptionTrait.php
@@ -14,9 +14,13 @@ declare(strict_types=1);
 namespace ApiPlatform\Metadata;
 
 /**
- * @author Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
+ * Lets a filter satisfy the legacy FilterInterface::getDescription() requirement without implementing it by hand.
  *
- * @internal
+ * Use this trait in a filter that does not need to describe itself through the deprecated getDescription() mechanism:
+ * it returns an empty array, which is the expected value now that filters are described through QueryParameter metadata.
+ * The trait will be removed in 6.0 together with FilterInterface::getDescription().
+ *
+ * @author Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
  */
 trait BackwardCompatibleFilterDescriptionTrait
 {

--- a/src/Metadata/Tests/BackwardCompatibleFilterDescriptionTraitTest.php
+++ b/src/Metadata/Tests/BackwardCompatibleFilterDescriptionTraitTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests;
+
+use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
+use PHPUnit\Framework\TestCase;
+
+final class BackwardCompatibleFilterDescriptionTraitTest extends TestCase
+{
+    public function testGetDescriptionReturnsEmptyArray(): void
+    {
+        $filter = new class {
+            use BackwardCompatibleFilterDescriptionTrait;
+        };
+
+        $this->assertSame([], $filter->getDescription('Foo'));
+    }
+}


### PR DESCRIPTION
## Summary

Promotes `BackwardCompatibleFilterDescriptionTrait` from an `@internal` helper to a documented, user-facing public API. Drops the `@internal` tag and adds a class-level docblock describing it as the way for a filter to satisfy the legacy `FilterInterface::getDescription()` requirement (returns `[]`) until that method is removed in 6.0. No code/behavior change.

## Roadmap

Part of the 4.4 preparation. Spec: TODO-filters.md §5.6, §8.
Phase: 4.4 (additive — exposes an existing symbol as public, no BC break).

## Test plan

- [x] New unit test pins the public contract (`getDescription('Foo') === []` via an anonymous class using the trait).
- [x] phpstan + php-cs-fixer clean; no new internal-usage findings across the 9 ORM filters that use the trait.
- [x] tests/Functional/Parameters green (pre-existing unrelated Issue7916 failures confirmed at upstream/main).