### PR TITLE
feat(doctrine): deprecate AbstractFilter base class

### DIFF
--- a/src/Doctrine/Odm/Filter/AbstractFilter.php
+++ b/src/Doctrine/Odm/Filter/AbstractFilter.php
@@ -18,7 +18,9 @@ use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Doctrine\Odm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
+use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
 use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\FilterInterface as MetadataFilterInterface;
 use ApiPlatform\Metadata\Operation;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -32,6 +34,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Abstract class for easing the implementation of a filter.
  *
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4, implement {@see MetadataFilterInterface} directly together with {@see BackwardCompatibleFilterDescriptionTrait} and the canonical QueryParameter-based filters (ExactFilter, PartialSearchFilter, EndSearchFilter, ComparisonFilter, OrFilter, …) instead; this class is removed in 6.0
  */
 abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface
 {

--- a/src/Doctrine/Orm/Filter/AbstractFilter.php
+++ b/src/Doctrine/Orm/Filter/AbstractFilter.php
@@ -19,7 +19,9 @@ use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\PropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\PropertyHelperTrait as OrmPropertyHelperTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\BackwardCompatibleFilterDescriptionTrait;
 use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\FilterInterface as MetadataFilterInterface;
 use ApiPlatform\Metadata\Operation;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -27,6 +29,9 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
+/**
+ * @deprecated since API Platform 4.4, implement {@see MetadataFilterInterface} directly together with {@see BackwardCompatibleFilterDescriptionTrait} and the canonical QueryParameter-based filters (ExactFilter, PartialSearchFilter, EndSearchFilter, ComparisonFilter, OrFilter, …) instead; this class is removed in 6.0
+ */
 abstract class AbstractFilter implements FilterInterface, PropertyAwareFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface
 {
     use OrmPropertyHelperTrait;


### PR DESCRIPTION
## What

Mark the ORM and ODM Doctrine `AbstractFilter` base classes as `@deprecated` since API Platform 4.4.

## How

Class-level PHPDoc `@deprecated` on both `src/Doctrine/Orm/Filter/AbstractFilter.php` and `src/Doctrine/Odm/Filter/AbstractFilter.php`:

> @deprecated since API Platform 4.4, implement `FilterInterface` directly together with `BackwardCompatibleFilterDescriptionTrait` and the canonical QueryParameter-based filters (ExactFilter, PartialSearchFilter, EndSearchFilter, ComparisonFilter, OrFilter, …) instead; this class is removed in 6.0

Gives third parties extending `AbstractFilter` a migration window toward implementing `ApiPlatform\Metadata\FilterInterface` directly (the public BC path documented in #8326) + the canonical `QueryParameter` filters.

## Why PHPDoc-only (no `trigger_deprecation`)

`AbstractFilter` is still extended by the first-party legacy filters (`SearchFilter`, `BooleanFilter`, `NumericFilter`, `OrderFilter`, `DateFilter`, `RangeFilter`, `ExistsFilter`, `BackedEnumFilter`). A runtime trigger in the base would self-fire on every internal instantiation and spam users. A PHPDoc tag gives static-analysis / IDE migration signalling without runtime noise. All subclasses keep `extends AbstractFilter` (no inheritance dropped).

## BC

Zero BC break — annotation only. Removal target 6.0 (matches the repo's existing 4.4 `@deprecated` entries and TODO-filters 6.0 deliverables).

Part of the 4.4 filter refactor: ship replacement primaries, then deprecate legacy.