### PR TITLE
chore: fix phpstan on 4.3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -83,7 +83,6 @@ parameters:
 			path: src/GraphQl/Tests/Type/TypesContainerTest.php
 
 		# Expected, due to backward compatibility
-		- '#Method GraphQL\\Type\\Definition\\WrappingType::getWrappedType\(\) invoked with 1 parameter, 0 required\.#'
 		- '#Access to an undefined property GraphQL\\Type\\Definition\\NamedType&GraphQL\\Type\\Definition\\Type::\$name\.#'
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\PropertyInfo\\\\\\\\PropertyInfoExtractor' and 'getType' will always evaluate to true\\.#"
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\HttpFoundation\\\\\\\\Request' and 'getContentTypeFormat' will always evaluate to true\\.#"

--- a/src/GraphQl/Type/FieldsBuilder.php
+++ b/src/GraphQl/Type/FieldsBuilder.php
@@ -435,11 +435,7 @@ final class FieldsBuilder implements FieldsBuilderEnumInterface
 
             $graphqlWrappedType = $graphqlType;
             if ($graphqlType instanceof WrappingType) {
-                if (method_exists($graphqlType, 'getInnermostType')) {
-                    $graphqlWrappedType = $graphqlType->getInnermostType();
-                } else {
-                    $graphqlWrappedType = $graphqlType->getWrappedType(true);
-                }
+                $graphqlWrappedType = $graphqlType->getInnermostType();
             }
             $isStandardGraphqlType = \in_array($graphqlWrappedType, GraphQLType::getStandardTypes(), true);
             if ($isStandardGraphqlType) {

--- a/src/Laravel/Tests/Console/DumpMetadataCommandTest.php
+++ b/src/Laravel/Tests/Console/DumpMetadataCommandTest.php
@@ -123,7 +123,7 @@ class DumpMetadataCommandTest extends TestCase
     }
 
     /**
-     * @param list<class-string> $classes
+     * @param list<string> $classes
      */
     private function stubResourceClasses(array $classes): void
     {
@@ -144,7 +144,7 @@ class DumpMetadataCommandTest extends TestCase
     }
 
     /**
-     * @return array{fingerprint: string, attributes: array<class-string, mixed>, relations: array<class-string, mixed>}
+     * @return array{fingerprint: string, attributes: array<mixed, mixed>, relations: array<mixed, mixed>}
      */
     private function readDump(): array
     {
@@ -158,6 +158,13 @@ class DumpMetadataCommandTest extends TestCase
             $this->fail('The dump file did not contain an array.');
         }
 
-        return $dumped;
+        $fingerprint = $dumped['fingerprint'] ?? null;
+        $attributes = $dumped['attributes'] ?? null;
+        $relations = $dumped['relations'] ?? null;
+        if (!\is_string($fingerprint) || !\is_array($attributes) || !\is_array($relations)) {
+            $this->fail('The dump file did not contain the expected structure.');
+        }
+
+        return ['fingerprint' => $fingerprint, 'attributes' => $attributes, 'relations' => $relations];
     }
 }

--- a/src/Laravel/Tests/Metadata/DumpedMetadataBootTest.php
+++ b/src/Laravel/Tests/Metadata/DumpedMetadataBootTest.php
@@ -75,12 +75,12 @@ class DumpedMetadataBootTest extends TestCase
     {
         // The canned dump written in setUp() carries no fingerprint, so it never matches the
         // current migrations and must be reported as stale.
-        Log::spy();
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(static fn (string $message): bool => str_contains($message, 'stale'));
         $this->app->forgetInstance(ModelMetadata::class);
 
         $this->app->make(ModelMetadata::class);
-
-        Log::shouldHaveReceived('warning')->withArgs(static fn (string $message): bool => str_contains($message, 'stale'))->once();
     }
 
     public function testItDoesNotWarnWhenTheFingerprintMatches(): void
@@ -91,12 +91,10 @@ class DumpedMetadataBootTest extends TestCase
             'relations' => [Book::class => self::CANNED_RELATIONS],
         ]));
 
-        Log::spy();
+        Log::shouldReceive('warning')->never();
         $this->app->forgetInstance(ModelMetadata::class);
 
         $this->app->make(ModelMetadata::class);
-
-        Log::shouldNotHaveReceived('warning');
     }
 
     public function testItIsNotSeededWhenDebugIsEnabled(): void

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -212,7 +212,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         }
 
         if (($filter = $this->getFilterInstance($parameter->getFilter())) && $filter instanceof PropertyAwareFilterInterface) {
-            if (!method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check @see interface
+            if (!method_exists($filter, 'getProperties')) { // todo 5.x remove this check
                 trigger_deprecation('api-platform/core', 'In API Platform 5.0 "%s" will implement a method named "getProperties"', PropertyAwareFilterInterface::class);
                 $refl = new \ReflectionClass($filter);
                 $filterProperties = $refl->hasProperty('properties') ? $refl->getProperty('properties')->getValue($filter) : [];

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -212,7 +212,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         }
 
         if (($filter = $this->getFilterInstance($parameter->getFilter())) && $filter instanceof PropertyAwareFilterInterface) {
-            if (!method_exists($filter, 'getProperties')) { // todo 5.x remove this check
+            if (!method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check @see interface
                 trigger_deprecation('api-platform/core', 'In API Platform 5.0 "%s" will implement a method named "getProperties"', PropertyAwareFilterInterface::class);
                 $refl = new \ReflectionClass($filter);
                 $filterProperties = $refl->hasProperty('properties') ? $refl->getProperty('properties')->getValue($filter) : [];


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Bug fix?      | no  |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | -   |
| License       | MIT |

Restores a green PHPStan run on `4.3` (both the root level-6 config and the Laravel larastan level-7 config).

**Core (`phpstan.neon.dist`)**
- `FieldsBuilder`: drop the dead `getWrappedType(true)` BC branch — `webonyx/graphql-php ^15` always exposes `getInnermostType()` and `getWrappedType()` no longer takes an argument; remove the now-unmatched ignore pattern.
- `ParameterResourceMetadataCollectionFactory`: the `method_exists($filter, 'getProperties')` BC shim is always-true now that the interface declares the method via `@method`; suppress it the same way its twin in `ParameterExtensionTrait` already is (kept until 5.x).

**Laravel (larastan)** — the metadata-dump tests added in #8290:
- `stubResourceClasses` was typed `list<class-string>` yet intentionally receives a non-model class name → loosen to `list<string>`.
- `readDump` returned the untyped result of `unserialize()` → validate and reshape the payload.
- the `Log::spy()` / `shouldHaveReceived()` spy chain is not statically resolvable → assert with `Log::shouldReceive()` as the rest of the suite already does.