### PR TITLE
fix(serializer): fix union types denormalization fallback after security mismatch

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -766,7 +766,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
             // Type-confusion guard: declared relation class must match the IRI's resource.
             if (!is_a($item, $resourceClass)) {
-                throw new InvalidArgumentException(\sprintf('The iri "%s" does not reference the correct resource.', $data));
+                throw new NotNormalizableValueException(\sprintf('The iri "%s" does not reference the correct resource.', $data));
             }
 
             return $item;

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1238,6 +1238,53 @@ class AbstractItemNormalizerTest extends TestCase
         $propertyAccessorProphecy->setValue($actual, 'relatedDummiesWithUnionTypes', [0 => $relatedDummy3, 1 => $relatedDummy4])->shouldHaveBeenCalled();
     }
 
+    public function testUnionTypeDenormalizationFallsThroughAfterTypeConfusionGuardMismatch(): void
+    {
+        $data = ['relatedDummyUnion' => '/related_dummies/1'];
+        $relatedDummy = new RelatedDummy();
+
+        $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection(['relatedDummyUnion']));
+
+        // Dummy is the mismatching member tried first; RelatedDummy is the one that actually matches.
+        $propertyMetadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->method('create')->willReturn(
+            (new ApiProperty())
+                ->withNativeType(Type::union(Type::object(Dummy::class), Type::object(RelatedDummy::class)))
+                ->withWritable(true)->withWritableLink(true)
+        );
+
+        // Always resolves to a RelatedDummy, no matter which type of the union is being attempted.
+        $iriConverter = $this->createStub(IriConverterInterface::class);
+        $iriConverter->method('getResourceFromIri')->willReturn($relatedDummy);
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturnMap([
+            [Dummy::class, true],
+            [RelatedDummy::class, true],
+        ]);
+        $resourceClassResolver->method('getResourceClass')->willReturnMap([
+            [null, Dummy::class, Dummy::class],
+            [null, RelatedDummy::class, RelatedDummy::class],
+        ]);
+
+        $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
+        $propertyAccessor->expects($this->once())
+            ->method('setValue')
+            ->with($this->isInstanceOf(Dummy::class), 'relatedDummyUnion', $relatedDummy);
+
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $normalizer = new class($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializer);
+
+        // The first union member (Dummy) should correctly fail and we expect to fallback to the second
+        // member (RelatedDummy).
+        $actual = $normalizer->denormalize($data, Dummy::class);
+
+        $this->assertInstanceOf(Dummy::class, $actual);
+    }
+
     public function testDenormalizeRelationNotFoundReturnsNull(): void
     {
         $data = [


### PR DESCRIPTION
Closes https://github.com/api-platform/core/issues/8329

This PR
- Adds Test to prove broken functionality / regression
- Updates to fix regression


## Original Issue
- Regression found where Union type properties were not denormalizing when the first type does not match.
- This was caused by a new Exception being thrown with a Type Guard.

## Solution
- Update the Exception type to be one that is caught by the union type handler.

## Considerations
- NotNormalizableValueException being thrown after a security check doesnt make the biggest sense to me. However, InvalidArgumentException also does not make 100 percent sense either so I think it is okay. Other wise, we would have to create a new Exception and catch it, similar to NotNormalizableValueException.