### PR TITLE
fix(serializer): accept union-typed IRI collections on denormalization

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -764,8 +764,15 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         try {
             $item = $this->iriConverter->getResourceFromIri($data, $context + ['fetch_data' => true]);
 
-            // Type-confusion guard: declared relation class must match the IRI's resource.
-            if (!is_a($item, $resourceClass)) {
+            // Type-confusion guard: the IRI's resource must satisfy the declared relation type.
+            // When a union/intersection type is known, validate against it so any member is accepted;
+            // otherwise fall back to the single declared class.
+            $relationType = $context['relation_native_type'] ?? null;
+            $matchesType = $relationType instanceof Type
+                ? $relationType->isSatisfiedBy(static fn (Type $t): bool => $t instanceof ObjectType && is_a($item, $t->getClassName()))
+                : is_a($item, $resourceClass);
+
+            if (!$matchesType) {
                 throw new NotNormalizableValueException(\sprintf('The iri "%s" does not reference the correct resource.', $data));
             }
 
@@ -1227,6 +1234,12 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 $context['resource_class'] = $resourceClass;
                 unset($context['uri_variables']);
 
+                // Validate the IRI target against the declared collection value type so a union
+                // (array<Foo|Bar>) accepts an IRI pointing to any of its members, not just the first.
+                if ($collectionValueType instanceof Type) {
+                    $context['relation_native_type'] = $collectionValueType;
+                }
+
                 try {
                     return $t instanceof Type
                         ? $this->denormalizeObjectCollection($attribute, $propertyMetadata, $t, $resourceClass, $value, $format, $context)
@@ -1249,6 +1262,9 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
             ) {
                 $resourceClass = $this->resourceClassResolver->getResourceClass(null, $className);
                 $childContext = $this->createChildContext($this->createOperationContext($context, $resourceClass, $propertyMetadata), $attribute, $format);
+                if ($t instanceof Type) {
+                    $childContext['relation_native_type'] = $t;
+                }
 
                 try {
                     return $this->denormalizeRelation($attribute, $propertyMetadata, $resourceClass, $value, $format, $childContext);

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1285,6 +1285,50 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $actual);
     }
 
+    public function testUnionTypeCollectionDenormalizationAcceptsAnyMember(): void
+    {
+        $data = ['attachments' => ['/related_dummies/1']];
+        $relatedDummy = new RelatedDummy();
+
+        $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection(['attachments']));
+
+        // array<Dummy|RelatedDummy>: the collection value type is a union; the IRI points to the second member.
+        $propertyMetadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->method('create')->willReturn(
+            (new ApiProperty())
+                ->withNativeType(Type::list(Type::union(Type::object(Dummy::class), Type::object(RelatedDummy::class))))
+                ->withWritable(true)
+        );
+
+        $iriConverter = $this->createStub(IriConverterInterface::class);
+        $iriConverter->method('getResourceFromIri')->willReturn($relatedDummy);
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturnMap([
+            [Dummy::class, true],
+            [RelatedDummy::class, true],
+        ]);
+        $resourceClassResolver->method('getResourceClass')->willReturnMap([
+            [null, Dummy::class, Dummy::class],
+            [null, RelatedDummy::class, RelatedDummy::class],
+        ]);
+
+        $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
+        $propertyAccessor->expects($this->once())
+            ->method('setValue')
+            ->with($this->isInstanceOf(Dummy::class), 'attachments', [0 => $relatedDummy]);
+
+        $serializer = $this->createStub(SerializerInterface::class);
+
+        $normalizer = new class($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializer);
+
+        $actual = $normalizer->denormalize($data, Dummy::class);
+
+        $this->assertInstanceOf(Dummy::class, $actual);
+    }
+
     public function testDenormalizeRelationNotFoundReturnsNull(): void
     {
         $data = [

--- a/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Bar.php
+++ b/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Bar.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+
+#[Get(
+    shortName: 'UnionIriCollectionBar',
+    uriTemplate: '/union_iri_collection_bars/{id}',
+    provider: [self::class, 'provide'],
+)]
+class Bar
+{
+    #[ApiProperty(identifier: true)]
+    public int $id;
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        $bar = new self();
+        $bar->id = (int) ($uriVariables['id'] ?? 1);
+
+        return $bar;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Container.php
+++ b/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Container.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Post;
+
+#[Post(
+    shortName: 'UnionIriCollectionContainer',
+    uriTemplate: '/union_iri_collection_containers',
+    processor: [self::class, 'process'],
+)]
+class Container
+{
+    #[ApiProperty(identifier: true)]
+    public int $id = 1;
+
+    /**
+     * @var array<array-key, Foo|Bar>
+     */
+    public array $attachments = [];
+
+    public static function process(mixed $data): self
+    {
+        return $data;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Foo.php
+++ b/tests/Fixtures/TestBundle/ApiResource/UnionIriCollection/Foo.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+
+#[Get(
+    shortName: 'UnionIriCollectionFoo',
+    uriTemplate: '/union_iri_collection_foos/{id}',
+    provider: [self::class, 'provide'],
+)]
+class Foo
+{
+    #[ApiProperty(identifier: true)]
+    public int $id;
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        $foo = new self();
+        $foo->id = (int) ($uriVariables['id'] ?? 1);
+
+        return $foo;
+    }
+}

--- a/tests/Functional/UnionIriCollectionTest.php
+++ b/tests/Functional/UnionIriCollectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Bar;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Container;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Foo;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class UnionIriCollectionTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Container::class, Foo::class, Bar::class];
+    }
+
+    public function testDenormalizeCollectionAcceptsIriOfEachUnionMember(): void
+    {
+        $response = self::createClient()->request('POST', '/union_iri_collection_containers', [
+            'headers' => ['Content-Type' => 'application/ld+json', 'Accept' => 'application/ld+json'],
+            'json' => ['attachments' => ['/union_iri_collection_foos/1', '/union_iri_collection_bars/2']],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'attachments' => [
+                '/union_iri_collection_foos/1',
+                '/union_iri_collection_bars/2',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Tickets       | Closes #8335 |
| License       | MIT |

## Problem

The type-confusion guard added in 6bcbeb2 (GHSA-9rjg-x2p2-h68h) validates an IRI's resolved resource against a single declared class via `is_a($item, $resourceClass)`.

For a collection typed `array<Foo|Bar>`, `AbstractItemNormalizer::createAndValidateAttributeValue` resolves **one** class for the whole collection — `UnionType::isSatisfiedBy` short-circuits at the first member, so `$className = Foo`. An IRI pointing to the second member (`/api/bars/2`) then resolves to a `Bar`, fails `is_a(Bar, Foo)`, and the whole collection is rejected with a misleading 422. Unlike the scalar union case, the collection path has no `$isMultipleTypes` retry loop, so there is no fallback.

This is the sibling of #8329 (scalar union, fixed in #8333) on the collection path.

## Fix

Validate the resolved item against the declared relation **Type** via `Type::isSatisfiedBy` instead of a single class string — TypeInfo already models union/intersection membership, so no class list needs to be hand-rolled.

The declared relation native type is threaded through `context['relation_native_type']` (collection value type for collections, `$t` for scalar relations). `getResourceFromIri` uses it when present and falls back to `is_a()` otherwise, leaving the single-class and legacy-type paths unchanged.

The security guard still rejects an IRI whose resource resolves **outside** the declared union.

## Tests

- Unit: `AbstractItemNormalizerTest::testUnionTypeCollectionDenormalizationAcceptsAnyMember` — reproduces the exact `array<Foo|Bar>` stack, fails before / passes after. Full Serializer component suite green (104 tests).
- Functional: `tests/Functional/UnionIriCollectionTest` — POSTs IRIs of each union member into an `array<Foo|Bar>` collection, expects 201 with both resolved.

> Note: the functional harness wouldn't boot in my local sandbox (kernel warmup hangs, unrelated to this change). The unit test covers the precise denormalization path; CI validates the functional one.