### PR TITLE
feat(doctrine): deprecate the extends-AbstractFilter form of Date/Range/Exists filters

### DIFF
--- a/src/Doctrine/Odm/Filter/DateFilter.php
+++ b/src/Doctrine/Odm/Filter/DateFilter.php
@@ -120,6 +120,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating the `[before]`/`[strictly_before]`/`[after]`/`[strictly_after]` syntax) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class DateFilter extends AbstractFilter implements DateFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Odm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Odm/Filter/ExistsFilter.php
@@ -110,6 +110,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone filter (reading its value from the QueryParameter instead of the legacy `context['filters']` lookup) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Odm/Filter/RangeFilter.php
+++ b/src/Doctrine/Odm/Filter/RangeFilter.php
@@ -107,6 +107,8 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating `[between]=X..Y` to `[gte]=X` + `[lte]=Y`, passing through `[gt]`/`[gte]`/`[lt]`/`[lte]`) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -124,6 +124,8 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating the `[before]`/`[strictly_before]`/`[after]`/`[strictly_after]` syntax) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class DateFilter extends AbstractFilter implements DateFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Orm/Filter/ExistsFilter.php
@@ -116,6 +116,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Given that the collection endpoint is `/books`, you can filter books with the following query: `/books?exists[comment]=true`.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone filter (reading its value from the QueryParameter instead of the legacy `context['filters']` lookup) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Doctrine/Orm/Filter/RangeFilter.php
@@ -108,6 +108,8 @@ use Doctrine\ORM\QueryBuilder;
  * Given that the collection endpoint is `/books`, you can filter books with the following query: `/books?price[between]=12.99..15.99`.
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
+ *
+ * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating `[between]=X..Y` to `[gte]=X` + `[lte]=Y`, passing through `[gt]`/`[gte]`/`[lt]`/`[lte]`) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
 final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {


### PR DESCRIPTION
Part of the 4.4 filter-deprecation series (follows #8330, which deprecated the `AbstractFilter` base).

`DateFilter`, `RangeFilter` and `ExistsFilter` (ORM + ODM) still extend the `AbstractFilter` base deprecated in 4.4. Unlike the doomed legacy filters (`SearchFilter`, `BooleanFilter`, `NumericFilter`, `BackedEnumFilter`, `OrderFilter`), these three **survive**: in 5.0 they are rewritten standalone —

- `DateFilter` / `RangeFilter` → overlays over `ComparisonFilter` (same `[before]`/`[after]`, `[between]`/`[gt]`/`[lt]` URL syntax)
- `ExistsFilter` → standalone, reading its value from the `QueryParameter` instead of the legacy `context['filters']` lookup

Same class name, same URL syntax, drop-in.

This adds an `@deprecated` note on the **legacy `extends AbstractFilter` form** so users migrate their declarations to `QueryParameter` ahead of the 5.0 rewrite. The classes themselves are **not** removed. PHPDoc-only, no runtime trigger.