### PR TITLE
feat(doctrine): deprecate the legacy SearchFilter/Boolean/Numeric/BackedEnum/OrderFilter

### DIFF
--- a/src/Doctrine/Odm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Odm/Filter/BooleanFilter.php
@@ -105,6 +105,8 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: use {@see ExactFilter} declared with a boolean `nativeType` instead. Removed in 6.0.
  */
 final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {

--- a/src/Doctrine/Odm/Filter/NumericFilter.php
+++ b/src/Doctrine/Odm/Filter/NumericFilter.php
@@ -105,6 +105,8 @@ use Doctrine\ODM\MongoDB\Types\Type as MongoDbType;
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: use {@see ExactFilter} declared with a numeric `nativeType` (int/float) instead. Removed in 6.0.
  */
 final class NumericFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {

--- a/src/Doctrine/Odm/Filter/OrderFilter.php
+++ b/src/Doctrine/Odm/Filter/OrderFilter.php
@@ -199,6 +199,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: use {@see SortFilter} instead. Removed in 6.0.
  */
 final class OrderFilter extends AbstractFilter implements OrderFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Odm/Filter/SearchFilter.php
+++ b/src/Doctrine/Odm/Filter/SearchFilter.php
@@ -133,6 +133,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
+ *
+ * @deprecated since API Platform 4.4: use the per-strategy QueryParameter-based filters instead — {@see ExactFilter} (`exact`), {@see PartialSearchFilter} (`partial`), {@see StartSearchFilter} (`start`), {@see EndSearchFilter} (`end`); for relation properties matched by IRI use {@see IriFilter}. Removed in 6.0.
  */
 final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/BackedEnumFilter.php
+++ b/src/Doctrine/Orm/Filter/BackedEnumFilter.php
@@ -107,6 +107,8 @@ use Doctrine\ORM\QueryBuilder;
  * Given that the collection endpoint is `/books`, you can filter books with the following query: `/books?status=published`.
  *
  * @author Rémi Marseille <marseille.remi@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: use {@see ExactFilter} declared with a backed-enum `nativeType` instead. Removed in 6.0.
  */
 final class BackedEnumFilter extends AbstractFilter
 {

--- a/src/Doctrine/Orm/Filter/BooleanFilter.php
+++ b/src/Doctrine/Orm/Filter/BooleanFilter.php
@@ -107,6 +107,8 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: use {@see ExactFilter} declared with a boolean `nativeType` instead. Removed in 6.0.
  */
 final class BooleanFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/NumericFilter.php
+++ b/src/Doctrine/Orm/Filter/NumericFilter.php
@@ -107,6 +107,8 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  * @author Teoh Han Hui <teohhanhui@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: use {@see ExactFilter} declared with a numeric `nativeType` (int/float) instead. Removed in 6.0.
  */
 final class NumericFilter extends AbstractFilter implements JsonSchemaFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/OrderFilter.php
+++ b/src/Doctrine/Orm/Filter/OrderFilter.php
@@ -198,6 +198,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: use {@see SortFilter} instead. Removed in 6.0.
  */
 final class OrderFilter extends AbstractFilter implements OrderFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/SearchFilter.php
+++ b/src/Doctrine/Orm/Filter/SearchFilter.php
@@ -132,6 +132,8 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * </div>
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @deprecated since API Platform 4.4: use the per-strategy QueryParameter-based filters instead — {@see ExactFilter} (`exact`), {@see PartialSearchFilter} (`partial`), {@see StartSearchFilter} (`start`), {@see EndSearchFilter} (`end`); for relation properties matched by IRI use {@see IriFilter}. Removed in 6.0.
  */
 final class SearchFilter extends AbstractFilter implements SearchFilterInterface
 {


### PR DESCRIPTION
Part of the 4.4 filter-deprecation series (follows #8330 `AbstractFilter` and #8340 Date/Range/Exists extends-form).

These multi-strategy and type-specific Doctrine filters are superseded by the canonical `QueryParameter`-based filter set and are **removed in 6.0**:

| Legacy filter | Replacement |
|---|---|
| `SearchFilter` | per strategy → `ExactFilter` (`exact`), `PartialSearchFilter` (`partial`), `StartSearchFilter` (`start`), `EndSearchFilter` (`end`); relation properties matched by IRI → `IriFilter` |
| `BooleanFilter` | `ExactFilter` + boolean `nativeType` |
| `NumericFilter` | `ExactFilter` + numeric `nativeType` |
| `BackedEnumFilter` | `ExactFilter` + backed-enum `nativeType` |
| `OrderFilter` | `SortFilter` |

Adds `@deprecated` notes (ORM + ODM; `BackedEnumFilter` is ORM-only) pointing at the replacement. URL syntax is unchanged for every replacement.

PHPDoc-only, no runtime trigger — the wiring-level deprecation triggers (`#[ApiFilter]`, `Operation::$filters`) land in a separate PR.