### PR TITLE
perf(laravel): memoize the Symfony RouteCollection in Router

### DIFF
--- a/src/Laravel/Routing/Router.php
+++ b/src/Laravel/Routing/Router.php
@@ -37,6 +37,7 @@ final class Router implements RouterInterface, UrlGeneratorInterface
     ];
 
     private RequestContext $context;
+    private ?RouteCollection $routeCollection = null;
 
     public function __construct(private readonly BaseRouter $router, private readonly int $urlGenerationStrategy = UrlGeneratorInterface::ABS_PATH)
     {
@@ -63,10 +64,14 @@ final class Router implements RouterInterface, UrlGeneratorInterface
      */
     public function getRouteCollection(): RouteCollection
     {
+        if (null !== $this->routeCollection) {
+            return $this->routeCollection;
+        }
+
         /** @var \Illuminate\Routing\RouteCollection $routes */
         $routes = $this->router->getRoutes();
 
-        return $routes->toSymfonyRouteCollection();
+        return $this->routeCollection = $routes->toSymfonyRouteCollection();
     }
 
     /**

--- a/src/Laravel/Routing/SkolemIriConverter.php
+++ b/src/Laravel/Routing/SkolemIriConverter.php
@@ -17,6 +17,7 @@ use ApiPlatform\Metadata\Exception\ItemNotFoundException;
 use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * {@inheritdoc}
@@ -37,7 +38,7 @@ final class SkolemIriConverter implements IriConverterInterface
      */
     private array $classHashMap = [];
 
-    public function __construct(private readonly Router $router)
+    public function __construct(private readonly RouterInterface $router)
     {
         $this->objectHashMap = new \SplObjectStorage();
     }

--- a/src/Laravel/Tests/Unit/Routing/RouterTest.php
+++ b/src/Laravel/Tests/Unit/Routing/RouterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Unit\Routing;
+
+use ApiPlatform\Laravel\Routing\Router;
+use Illuminate\Routing\RouteCollection as IlluminateRouteCollection;
+use Illuminate\Routing\Router as BaseRouter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouteCollection;
+
+class RouterTest extends TestCase
+{
+    public function testGetRouteCollectionIsMemoizedAcrossCalls(): void
+    {
+        $symfonyRoutes = new RouteCollection();
+
+        $illuminateRoutes = $this->createMock(IlluminateRouteCollection::class);
+        $illuminateRoutes->expects($this->once())
+            ->method('toSymfonyRouteCollection')
+            ->willReturn($symfonyRoutes);
+
+        $baseRouter = $this->createStub(BaseRouter::class);
+        $baseRouter->method('getRoutes')->willReturn($illuminateRoutes);
+
+        $router = new Router($baseRouter);
+
+        $first = $router->getRouteCollection();
+        $second = $router->getRouteCollection();
+
+        $this->assertSame($symfonyRoutes, $first);
+        $this->assertSame($first, $second);
+    }
+}


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Closes #8337 |
| License       | MIT |

## Problem

`ApiPlatform\Laravel\Routing\Router::generate()` calls `getRouteCollection()`, which rebuilds the entire Symfony `RouteCollection` on every call via `Illuminate\Routing\AbstractRouteCollection::toSymfonyRouteCollection()` — converting the whole Laravel route table each time, with no memoization.

`generate()` runs once per IRI during normalization (once per relation/sub-resource reference). A single response with several relations triggers the full route-table conversion repeatedly — ~65 times for a resource with ~8 relations in the reporter's Xdebug profiling. `php artisan route:cache` doesn't help; this conversion happens after Laravel's own route loading.

## Fix

Routes are static within a request and `Router` is registered as a per-request singleton (`ApiPlatformProvider`), so the built `RouteCollection` is safely cached on the instance:

```php
public function getRouteCollection(): RouteCollection
{
    if (null !== $this->routeCollection) {
        return $this->routeCollection;
    }

    $routes = $this->router->getRoutes();

    return $this->routeCollection = $routes->toSymfonyRouteCollection();
}
```

Only the `RouteCollection` is memoized, not the `UrlGenerator` — the generator depends on `$this->context` (mutable via `setContext()`), while the collection is context-independent and is the expensive part. Memoizing the generator would risk a stale-context bug.

`IriConverter` and `SkolemIriConverter` inject the concrete `Router` directly, so the fix lands in `Router` itself rather than in a decorator of the interface binding.

## SkolemIriConverter typing

As noted in the issue, `SkolemIriConverter` hard-typed the `final` concrete `Router` in its constructor, blocking any userland wrapper (a replacement must stay `instanceof Router`, impossible for a `final` class). It only uses `$this->router->generate()`, so its constructor now type-hints `Symfony\Component\Routing\RouterInterface` (matching `IriConverter`), removing the dependency on the concrete class.

## Tests

Added `Tests/Unit/Routing/RouterTest.php` asserting `toSymfonyRouteCollection()` is invoked once across multiple `getRouteCollection()` calls and that the same instance is returned. Functional suites (`JsonLdTest`, `JsonApiTest`) pass unchanged.