### PR TITLE
fix(jsonschema): don't require @id in single-item MCP output schema

### DIFF
--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -22,6 +22,9 @@ use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\McpResource;
+use ApiPlatform\Metadata\McpTool;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 
@@ -133,7 +136,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
 
         if (!$collectionKey) {
             $definitionName = $schema->getRootDefinitionKey() ?? $this->definitionNameFactory->create($className, $format, $inputOrOutputClass, $operation, $serializerContext);
-            $this->decorateItemDefinition($definitionName, $definitions, $prefix, $type, $serializerContext);
+            $this->decorateItemDefinition($definitionName, $definitions, $prefix, $type, $serializerContext, $operation);
 
             if (isset($definitions[$definitionName])) {
                 $currentDefinitions = $schema->getDefinitions();
@@ -254,7 +257,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         unset($schema['items']);
 
         if (isset($definitions[$collectionKey])) {
-            $this->decorateItemDefinition($collectionKey, $definitions, $prefix, $type, $serializerContext);
+            $this->decorateItemDefinition($collectionKey, $definitions, $prefix, $type, $serializerContext, $operation);
         }
 
         return $schema;
@@ -267,13 +270,16 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         }
     }
 
-    private function decorateItemDefinition(string $definitionName, \ArrayObject $definitions, string $prefix, string $type, ?array $serializerContext): void
+    private function decorateItemDefinition(string $definitionName, \ArrayObject $definitions, string $prefix, string $type, ?array $serializerContext, ?Operation $operation = null): void
     {
         if (!isset($definitions[$definitionName])) {
             return;
         }
 
-        $hasNoId = Schema::TYPE_OUTPUT === $type && false === ($serializerContext['gen_id'] ?? true);
+        // A single-item MCP operation has no routed item URI: the serializer omits `@id`, so don't require it.
+        $isMcpItem = ($operation instanceof McpTool || $operation instanceof McpResource) && !$operation instanceof CollectionOperationInterface;
+
+        $hasNoId = Schema::TYPE_OUTPUT === $type && (false === ($serializerContext['gen_id'] ?? true) || $isMcpItem);
         $baseName = self::ITEM_BASE_SCHEMA_NAME;
         if ($hasNoId) {
             $baseName = self::ITEM_WITHOUT_ID_BASE_SCHEMA_NAME;

--- a/src/Hydra/JsonSchema/SchemaFactory.php
+++ b/src/Hydra/JsonSchema/SchemaFactory.php
@@ -22,9 +22,6 @@ use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryAwareInterface;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\JsonSchema\SchemaUriPrefixTrait;
-use ApiPlatform\Metadata\CollectionOperationInterface;
-use ApiPlatform\Metadata\McpResource;
-use ApiPlatform\Metadata\McpTool;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 
@@ -136,7 +133,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
 
         if (!$collectionKey) {
             $definitionName = $schema->getRootDefinitionKey() ?? $this->definitionNameFactory->create($className, $format, $inputOrOutputClass, $operation, $serializerContext);
-            $this->decorateItemDefinition($definitionName, $definitions, $prefix, $type, $serializerContext, $operation);
+            $this->decorateItemDefinition($definitionName, $definitions, $prefix, $type, $serializerContext);
 
             if (isset($definitions[$definitionName])) {
                 $currentDefinitions = $schema->getDefinitions();
@@ -257,7 +254,7 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         unset($schema['items']);
 
         if (isset($definitions[$collectionKey])) {
-            $this->decorateItemDefinition($collectionKey, $definitions, $prefix, $type, $serializerContext, $operation);
+            $this->decorateItemDefinition($collectionKey, $definitions, $prefix, $type, $serializerContext);
         }
 
         return $schema;
@@ -270,16 +267,13 @@ final class SchemaFactory implements SchemaFactoryInterface, SchemaFactoryAwareI
         }
     }
 
-    private function decorateItemDefinition(string $definitionName, \ArrayObject $definitions, string $prefix, string $type, ?array $serializerContext, ?Operation $operation = null): void
+    private function decorateItemDefinition(string $definitionName, \ArrayObject $definitions, string $prefix, string $type, ?array $serializerContext): void
     {
         if (!isset($definitions[$definitionName])) {
             return;
         }
 
-        // A single-item MCP operation has no routed item URI: the serializer omits `@id`, so don't require it.
-        $isMcpItem = ($operation instanceof McpTool || $operation instanceof McpResource) && !$operation instanceof CollectionOperationInterface;
-
-        $hasNoId = Schema::TYPE_OUTPUT === $type && (false === ($serializerContext['gen_id'] ?? true) || $isMcpItem);
+        $hasNoId = Schema::TYPE_OUTPUT === $type && false === ($serializerContext['gen_id'] ?? true);
         $baseName = self::ITEM_BASE_SCHEMA_NAME;
         if ($hasNoId) {
             $baseName = self::ITEM_WITHOUT_ID_BASE_SCHEMA_NAME;

--- a/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
@@ -23,6 +23,8 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\Metadata\McpToolCollection;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
@@ -159,6 +161,32 @@ class SchemaFactoryTest extends TestCase
 
         $forcedCollection = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, null, null, null, true);
         $this->assertEquals($resultSchema['allOf'][0]['$ref'], $forcedCollection['allOf'][0]['$ref']);
+    }
+
+    // Single-item McpTool: serializer omits `@id`, so the output schema must not require it.
+    public function testSingleItemMcpToolOutputSchemaDoesNotRequireId(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new McpTool(class: Dummy::class));
+
+        $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
+
+        $this->assertSame(['$ref' => '#/definitions/HydraItemBaseSchemaWithoutId'], $definitions[$rootDefinitionKey]['allOf'][0]);
+        $this->assertArrayHasKey('HydraItemBaseSchemaWithoutId', $definitions);
+        $this->assertSame(['@type'], $definitions['HydraItemBaseSchemaWithoutId']['required']);
+        $this->assertArrayNotHasKey('HydraItemBaseSchema', $definitions);
+    }
+
+    // McpToolCollection: members get `@id` (member normalization sets item_uri_template), so it stays required.
+    public function testMcpToolCollectionOutputSchemaStillRequiresIdOnMembers(): void
+    {
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new McpToolCollection(class: Dummy::class));
+
+        $definitions = $resultSchema->getDefinitions();
+
+        $this->assertSame(['$ref' => '#/definitions/HydraItemBaseSchema'], $definitions['Dummy.jsonld']['allOf'][0]);
+        $this->assertSame(['@id', '@type'], $definitions['HydraItemBaseSchema']['required']);
+        $this->assertArrayNotHasKey('HydraItemBaseSchemaWithoutId', $definitions);
     }
 
     public function testSchemaTypeBuildSchemaWithoutPrefix(): void

--- a/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Hydra/Tests/JsonSchema/SchemaFactoryTest.php
@@ -23,8 +23,6 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
-use ApiPlatform\Metadata\McpTool;
-use ApiPlatform\Metadata\McpToolCollection;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
@@ -163,10 +161,10 @@ class SchemaFactoryTest extends TestCase
         $this->assertEquals($resultSchema['allOf'][0]['$ref'], $forcedCollection['allOf'][0]['$ref']);
     }
 
-    // Single-item McpTool: serializer omits `@id`, so the output schema must not require it.
-    public function testSingleItemMcpToolOutputSchemaDoesNotRequireId(): void
+    // gen_id=false output schema must not require `@id` (e.g. an operation whose serializer omits the IRI).
+    public function testGenIdFalseOutputSchemaDoesNotRequireId(): void
     {
-        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new McpTool(class: Dummy::class));
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new Get(), null, ['gen_id' => false]);
 
         $definitions = $resultSchema->getDefinitions();
         $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
@@ -177,14 +175,15 @@ class SchemaFactoryTest extends TestCase
         $this->assertArrayNotHasKey('HydraItemBaseSchema', $definitions);
     }
 
-    // McpToolCollection: members get `@id` (member normalization sets item_uri_template), so it stays required.
-    public function testMcpToolCollectionOutputSchemaStillRequiresIdOnMembers(): void
+    // Default (gen_id left to its true default): the output schema keeps `@id` required.
+    public function testOutputSchemaRequiresIdByDefault(): void
     {
-        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new McpToolCollection(class: Dummy::class));
+        $resultSchema = $this->schemaFactory->buildSchema(Dummy::class, 'jsonld', Schema::TYPE_OUTPUT, new Get());
 
         $definitions = $resultSchema->getDefinitions();
+        $rootDefinitionKey = $resultSchema->getRootDefinitionKey();
 
-        $this->assertSame(['$ref' => '#/definitions/HydraItemBaseSchema'], $definitions['Dummy.jsonld']['allOf'][0]);
+        $this->assertSame(['$ref' => '#/definitions/HydraItemBaseSchema'], $definitions[$rootDefinitionKey]['allOf'][0]);
         $this->assertSame(['@id', '@type'], $definitions['HydraItemBaseSchema']['required']);
         $this->assertArrayNotHasKey('HydraItemBaseSchemaWithoutId', $definitions);
     }

--- a/src/Mcp/JsonSchema/SchemaFactory.php
+++ b/src/Mcp/JsonSchema/SchemaFactory.php
@@ -15,6 +15,9 @@ namespace ApiPlatform\Mcp\JsonSchema;
 
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\McpResource;
+use ApiPlatform\Metadata\McpTool;
 use ApiPlatform\Metadata\Operation;
 
 /**
@@ -32,6 +35,16 @@ final class SchemaFactory implements SchemaFactoryInterface
 
     public function buildSchema(string $className, string $format = 'json', string $type = Schema::TYPE_OUTPUT, ?Operation $operation = null, ?Schema $schema = null, ?array $serializerContext = null, bool $forceCollection = false): Schema
     {
+        // A single-item MCP operation has no routed item URI (Mcp\Routing\IriConverter returns null),
+        // so the serializer omits `@id`: mirror that here so the advertised output schema doesn't require it.
+        if (Schema::TYPE_OUTPUT === $type
+            && ($operation instanceof McpTool || $operation instanceof McpResource)
+            && !$operation instanceof CollectionOperationInterface
+        ) {
+            $serializerContext ??= [];
+            $serializerContext['gen_id'] = false;
+        }
+
         $schema = $this->decorated->buildSchema($className, $format, $type, $operation, $schema, $serializerContext, $forceCollection);
 
         $definitions = [];

--- a/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
+++ b/src/Mcp/Tests/JsonSchema/SchemaFactoryTest.php
@@ -16,6 +16,9 @@ namespace ApiPlatform\Mcp\Tests\JsonSchema;
 use ApiPlatform\JsonSchema\Schema;
 use ApiPlatform\JsonSchema\SchemaFactoryInterface;
 use ApiPlatform\Mcp\JsonSchema\SchemaFactory;
+use ApiPlatform\Metadata\McpResource;
+use ApiPlatform\Metadata\McpTool;
+use ApiPlatform\Metadata\McpToolCollection;
 use PHPUnit\Framework\TestCase;
 
 class SchemaFactoryTest extends TestCase
@@ -421,5 +424,69 @@ class SchemaFactoryTest extends TestCase
         // The nullable member is left untouched and the anyOf keeps no spurious type fallback.
         $this->assertSame(['type' => 'null'], $related['anyOf'][1]);
         $this->assertArrayNotHasKey('type', $related);
+    }
+
+    /**
+     * A single-item MCP operation has no routed item URI (Mcp\Routing\IriConverter returns null),
+     * so the output schema must advertise `gen_id` as false to drop the required `@id`.
+     */
+    public function testSingleItemMcpOperationForcesGenIdFalse(): void
+    {
+        foreach ([new McpTool(class: \stdClass::class), new McpResource(uri: 'app://dummy', class: \stdClass::class)] as $operation) {
+            $captured = null;
+            $inner = $this->createMock(SchemaFactoryInterface::class);
+            $inner->method('buildSchema')->willReturnCallback(function (...$args) use (&$captured) {
+                $captured = $args[5] ?? null;
+
+                return $this->emptyObjectSchema();
+            });
+
+            $factory = new SchemaFactory($inner);
+            $factory->buildSchema('App\\Dummy', 'jsonld', Schema::TYPE_OUTPUT, $operation);
+
+            $this->assertFalse($captured['gen_id'] ?? null, $operation::class.' must force gen_id to false');
+        }
+    }
+
+    public function testMcpToolCollectionDoesNotForceGenIdFalse(): void
+    {
+        $captured = 'untouched';
+        $inner = $this->createMock(SchemaFactoryInterface::class);
+        $inner->method('buildSchema')->willReturnCallback(function (...$args) use (&$captured) {
+            $captured = $args[5] ?? null;
+
+            return $this->emptyObjectSchema();
+        });
+
+        $factory = new SchemaFactory($inner);
+        $factory->buildSchema('App\\Dummy', 'jsonld', Schema::TYPE_OUTPUT, new McpToolCollection(class: \stdClass::class));
+
+        $this->assertNull($captured);
+    }
+
+    public function testInputSchemaDoesNotForceGenIdFalse(): void
+    {
+        $captured = 'untouched';
+        $inner = $this->createMock(SchemaFactoryInterface::class);
+        $inner->method('buildSchema')->willReturnCallback(function (...$args) use (&$captured) {
+            $captured = $args[5] ?? null;
+
+            return $this->emptyObjectSchema();
+        });
+
+        $factory = new SchemaFactory($inner);
+        $factory->buildSchema('App\\Dummy', 'json', Schema::TYPE_INPUT, new McpTool(class: \stdClass::class));
+
+        $this->assertNull($captured);
+    }
+
+    private function emptyObjectSchema(): Schema
+    {
+        $schema = new Schema(Schema::VERSION_JSON_SCHEMA);
+        unset($schema['$schema']);
+        $schema->getDefinitions()['Dummy'] = new \ArrayObject(['type' => 'object']);
+        $schema['$ref'] = '#/definitions/Dummy';
+
+        return $schema;
     }
 }


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | -   |
| License       | MIT |
| Doc PR        | -   |

## What

For a single-item `McpTool`/`McpResource` with `structuredContent` enabled, the advertised JSON-LD `outputSchema` no longer marks `@id` as required. `@type` stays required; `McpToolCollection` members keep requiring `@id`.

## Why

A single-item MCP operation has no routed item URI, so `Mcp\Routing\IriConverter::getIriFromResource()` returns `null` and the serializer omits `@id` from the `structuredContent`. The schema still required `@id`, so a strict MCP client (validating the payload against the `outputSchema` from `tools/list`) rejected the response with `/<root>: The required properties (@id) are missing`.

The fix mirrors the `IriConverter` null-`@id` behaviour on the schema side: `Hydra\JsonSchema\SchemaFactory` now selects the existing `HydraItemBaseSchemaWithoutId` base (already used when `gen_id` is `false`) for non-collection MCP output schemas. A `McpToolCollection` is excluded — its members get an IRI because member normalization sets `item_uri_template` — so the collection case is unaffected.
