### PR TITLE
fix(serializer): forward DiscriminatorMap defaultType in PropertyMetadataLoader

### DIFF
--- a/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
+++ b/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
@@ -71,7 +71,8 @@ final class PropertyMetadataLoader implements LoaderInterface
             if ($attribute instanceof DiscriminatorMap) {
                 $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
                     method_exists($attribute, 'getTypeProperty') ? $attribute->getTypeProperty() : $attribute->typeProperty,
-                    method_exists($attribute, 'getMapping') ? $attribute->getMapping() : $attribute->mapping
+                    method_exists($attribute, 'getMapping') ? $attribute->getMapping() : $attribute->mapping,
+                    method_exists($attribute, 'getDefaultType') ? $attribute->getDefaultType() : ($attribute->defaultType ?? null),
                 ));
                 continue;
             }

--- a/src/Serializer/Tests/Fixtures/Model/AbstractWithDiscriminator.php
+++ b/src/Serializer/Tests/Fixtures/Model/AbstractWithDiscriminator.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'discr', mapping: ['concrete' => ConcreteWithDiscriminator::class], defaultType: 'concrete')]
+abstract class AbstractWithDiscriminator
+{
+}

--- a/src/Serializer/Tests/Fixtures/Model/ConcreteWithDiscriminator.php
+++ b/src/Serializer/Tests/Fixtures/Model/ConcreteWithDiscriminator.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+class ConcreteWithDiscriminator extends AbstractWithDiscriminator
+{
+}

--- a/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
+++ b/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
@@ -16,9 +16,11 @@ namespace ApiPlatform\Serializer\Tests\Mapping\Loader;
 use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Serializer\Mapping\Loader\PropertyMetadataLoader;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\AbstractWithDiscriminator;
 use ApiPlatform\Serializer\Tests\Fixtures\Model\HasRelation;
 use ApiPlatform\Serializer\Tests\Fixtures\Model\Relation;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 
 final class PropertyMetadataLoaderTest extends TestCase
@@ -54,5 +56,22 @@ final class PropertyMetadataLoaderTest extends TestCase
         }
         $this->assertArrayHasKey('name', $attributesMetadata);
         $this->assertEquals(['read'], $attributesMetadata['name']->getGroups());
+    }
+
+    public function testForwardsDiscriminatorDefaultType(): void
+    {
+        if (!method_exists(ClassDiscriminatorMapping::class, 'getDefaultType')) { // @phpstan-ignore-line
+            $this->markTestSkipped('ClassDiscriminatorMapping::getDefaultType() requires symfony/serializer 7.1+.');
+        }
+
+        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $coll->method('create')->willReturn(new PropertyNameCollection([]));
+        $loader = new PropertyMetadataLoader($coll);
+        $classMetadata = new ClassMetadata(AbstractWithDiscriminator::class);
+        $loader->loadClassMetadata($classMetadata);
+
+        $mapping = $classMetadata->getClassDiscriminatorMapping();
+        $this->assertNotNull($mapping);
+        $this->assertSame('concrete', $mapping->getDefaultType());
     }
 }


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Tickets       | Fixes #8345 |
| License       | MIT |
| Doc           | n/a |

`PropertyMetadataLoader` rebuilds Symfony's `ClassDiscriminatorMapping` from the `#[DiscriminatorMap]` attribute but only forwards `typeProperty` and `mapping` — it silently drops the 3rd constructor argument `defaultType` (added in Symfony Serializer 7.1).

The bug only surfaces with a **warmed** serializer mapping cache (`cache:warmup` in prod). In dev/test the metadata is built lazily through Symfony's `AttributeLoader`, which forwards `defaultType`, so it stays invisible there. With the default lost, `AbstractItemNormalizer::getClassDiscriminatorResolvedClass()` sees `defaultType === null` and throws:

> Type property "discr" not found for the abstract object "App\Entity\MyAbstractResource".

This forwards the third argument, guarded so it stays compatible with `symfony/serializer ^6.4` where the attribute exposes no `defaultType`.

Test `testForwardsDiscriminatorDefaultType` is skipped on `symfony/serializer < 7.1` (where `ClassDiscriminatorMapping::getDefaultType()` does not exist).