### PR TITLE
perf(state): skip response body on HEAD requests

### DIFF
--- a/src/Hydra/State/JsonStreamerProcessor.php
+++ b/src/Hydra/State/JsonStreamerProcessor.php
@@ -59,6 +59,7 @@ final class JsonStreamerProcessor implements ProcessorInterface
         private readonly string $enabledParameterName = 'pagination',
         private readonly int $urlGenerationStrategy = UrlGeneratorInterface::ABS_PATH,
         ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null,
+        private readonly bool $enableHeadRequestOptimization = true,
     ) {
         $this->resourceClassResolver = $resourceClassResolver;
         $this->iriConverter = $iriConverter;
@@ -79,7 +80,7 @@ final class JsonStreamerProcessor implements ProcessorInterface
             return $this->processor?->process($data, $operation, $uriVariables, $context);
         }
 
-        if ($request->isMethod('HEAD')) {
+        if ($this->enableHeadRequestOptimization && $request->isMethod('HEAD')) {
             $response = new Response(
                 null,
                 $this->getStatus($request, $operation, $context),

--- a/src/Hydra/State/JsonStreamerProcessor.php
+++ b/src/Hydra/State/JsonStreamerProcessor.php
@@ -79,6 +79,16 @@ final class JsonStreamerProcessor implements ProcessorInterface
             return $this->processor?->process($data, $operation, $uriVariables, $context);
         }
 
+        if ($request->isMethod('HEAD')) {
+            $response = new Response(
+                null,
+                $this->getStatus($request, $operation, $context),
+                $this->getHeaders($request, $operation, $context)
+            );
+
+            return $this->processor ? $this->processor->process($response, $operation, $uriVariables, $context) : $response;
+        }
+
         if ($operation instanceof CollectionOperationInterface) {
             $requestUri = $request->getRequestUri() ?? '';
             $collection = new Collection();

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -553,7 +553,7 @@ class ApiPlatformProvider extends ServiceProvider
         });
 
         $this->app->singleton(SerializeProcessor::class, static function (Application $app) {
-            return new SerializeProcessor($app->make(RespondProcessor::class), $app->make(Serializer::class), $app->make(SerializerContextBuilderInterface::class));
+            return new SerializeProcessor($app->make(RespondProcessor::class), $app->make(Serializer::class), $app->make(SerializerContextBuilderInterface::class), $app['config']->get('api-platform.enable_head_request_optimization', true));
         });
 
         $this->app->singleton(WriteProcessor::class, static function (Application $app) {

--- a/src/Laravel/config/api-platform.php
+++ b/src/Laravel/config/api-platform.php
@@ -49,6 +49,10 @@ return [
     // on PATCH operations, allowing partial updates without requiring all fields.
     'partial_patch_validation' => false,
 
+    // When true (default), HEAD requests skip response body construction so
+    // collections are not iterated. Set to false to process HEAD like GET.
+    'enable_head_request_optimization' => true,
+
     'docs_formats' => [
         'jsonld' => ['application/ld+json'],
         // 'jsonapi' => ['application/vnd.api+json'],

--- a/src/Serializer/State/JsonStreamerProcessor.php
+++ b/src/Serializer/State/JsonStreamerProcessor.php
@@ -68,6 +68,16 @@ final class JsonStreamerProcessor implements ProcessorInterface
             return $this->processor?->process($data, $operation, $uriVariables, $context);
         }
 
+        if ($request->isMethod('HEAD')) {
+            $response = new Response(
+                null,
+                $this->getStatus($request, $operation, $context),
+                $this->getHeaders($request, $operation, $context)
+            );
+
+            return $this->processor ? $this->processor->process($response, $operation, $uriVariables, $context) : $response;
+        }
+
         if ($operation instanceof CollectionOperationInterface) {
             $data = $this->jsonStreamer->write(
                 $data,

--- a/src/Serializer/State/JsonStreamerProcessor.php
+++ b/src/Serializer/State/JsonStreamerProcessor.php
@@ -48,6 +48,7 @@ final class JsonStreamerProcessor implements ProcessorInterface
         ?ResourceClassResolverInterface $resourceClassResolver = null,
         ?OperationMetadataFactoryInterface $operationMetadataFactory = null,
         ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null,
+        private readonly bool $enableHeadRequestOptimization = true,
     ) {
         $this->resourceClassResolver = $resourceClassResolver;
         $this->iriConverter = $iriConverter;
@@ -68,7 +69,7 @@ final class JsonStreamerProcessor implements ProcessorInterface
             return $this->processor?->process($data, $operation, $uriVariables, $context);
         }
 
-        if ($request->isMethod('HEAD')) {
+        if ($this->enableHeadRequestOptimization && $request->isMethod('HEAD')) {
             $response = new Response(
                 null,
                 $this->getStatus($request, $operation, $context),

--- a/src/State/Processor/SerializeProcessor.php
+++ b/src/State/Processor/SerializeProcessor.php
@@ -60,6 +60,12 @@ final class SerializeProcessor implements ProcessorInterface, StopwatchAwareInte
         // @see ApiPlatform\State\Processor\RespondProcessor
         $context['original_data'] = $data;
 
+        if ($request->isMethod('HEAD')) {
+            $this->stopwatch?->stop('api_platform.processor.serialize');
+
+            return $this->processor?->process(null, $operation, $uriVariables, $context);
+        }
+
         $class = $operation->getClass();
         $serializerContext = $this->serializerContextBuilder->createFromRequest($request, true, [
             'resource_class' => $class,

--- a/src/State/Processor/SerializeProcessor.php
+++ b/src/State/Processor/SerializeProcessor.php
@@ -46,6 +46,7 @@ final class SerializeProcessor implements ProcessorInterface, StopwatchAwareInte
         private readonly ?ProcessorInterface $processor,
         private readonly SerializerInterface $serializer,
         private readonly SerializerContextBuilderInterface $serializerContextBuilder,
+        private readonly bool $enableHeadRequestOptimization = true,
     ) {
     }
 
@@ -60,7 +61,7 @@ final class SerializeProcessor implements ProcessorInterface, StopwatchAwareInte
         // @see ApiPlatform\State\Processor\RespondProcessor
         $context['original_data'] = $data;
 
-        if ($request->isMethod('HEAD')) {
+        if ($this->enableHeadRequestOptimization && $request->isMethod('HEAD')) {
             $this->stopwatch?->stop('api_platform.processor.serialize');
 
             return $this->processor?->process(null, $operation, $uriVariables, $context);

--- a/src/State/Tests/Processor/SerializeProcessorTest.php
+++ b/src/State/Tests/Processor/SerializeProcessorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\Tests\Processor;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\State\Processor\SerializeProcessor;
+use ApiPlatform\State\ProcessorInterface;
+use ApiPlatform\State\SerializerContextBuilderInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SerializeProcessorTest extends TestCase
+{
+    public function testHeadRequestSkipsSerializationAndForwardsNull(): void
+    {
+        $request = Request::create('/foos', 'HEAD');
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->never())->method('serialize');
+
+        $inner = $this->createMock(ProcessorInterface::class);
+        $inner->expects($this->once())
+            ->method('process')
+            ->with($this->isNull())
+            ->willReturn(null);
+
+        $processor = new SerializeProcessor($inner, $serializer, $this->createStub(SerializerContextBuilderInterface::class));
+        $operation = (new Get())->withSerialize(true);
+
+        $this->assertNull($processor->process(new \stdClass(), $operation, [], ['request' => $request]));
+    }
+}

--- a/src/State/Tests/Processor/SerializeProcessorTest.php
+++ b/src/State/Tests/Processor/SerializeProcessorTest.php
@@ -41,4 +41,23 @@ class SerializeProcessorTest extends TestCase
 
         $this->assertNull($processor->process(new \stdClass(), $operation, [], ['request' => $request]));
     }
+
+    public function testHeadRequestSerializesWhenOptimizationDisabled(): void
+    {
+        $request = Request::create('/foos', 'HEAD');
+
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())->method('serialize')->willReturn('');
+
+        $inner = $this->createMock(ProcessorInterface::class);
+        $inner->method('process')->willReturn('forwarded');
+
+        $contextBuilder = $this->createStub(SerializerContextBuilderInterface::class);
+        $contextBuilder->method('createFromRequest')->willReturn([]);
+
+        $processor = new SerializeProcessor($inner, $serializer, $contextBuilder, false);
+        $operation = (new Get())->withSerialize(true);
+
+        $this->assertSame('forwarded', $processor->process(new \stdClass(), $operation, [], ['request' => $request]));
+    }
 }

--- a/src/State/Util/HttpResponseHeadersTrait.php
+++ b/src/State/Util/HttpResponseHeadersTrait.php
@@ -155,7 +155,7 @@ trait HttpResponseHeadersTrait
         }
 
         $acceptPost = null;
-        $allowedMethods = ['OPTIONS', 'HEAD'];
+        $allowedMethods = [];
         $resourceCollection = $this->resourceMetadataCollectionFactory->create($operation->getClass());
         foreach ($resourceCollection as $resource) {
             foreach ($resource->getOperations() as $op) {
@@ -172,6 +172,7 @@ trait HttpResponseHeadersTrait
             $headers['Accept-Post'] = $acceptPost;
         }
 
-        $headers['Allow'] = implode(', ', $allowedMethods);
+        $head = \in_array('GET', $allowedMethods, true) ? ['HEAD'] : [];
+        $headers['Allow'] = implode(', ', array_merge(['OPTIONS'], $head, $allowedMethods));
     }
 }

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -359,6 +359,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $container->setParameter('api_platform.enable_entrypoint', $config['enable_entrypoint']);
         $container->setParameter('api_platform.enable_docs', $config['enable_docs']);
+        $container->setParameter('api_platform.enable_head_request_optimization', $config['enable_head_request_optimization']);
         $container->setParameter('api_platform.title', $config['title']);
         $container->setParameter('api_platform.description', $config['description']);
         $container->setParameter('api_platform.version', $config['version']);

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -130,6 +130,7 @@ final class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_scalar')->defaultValue(class_exists(TwigBundle::class))->info('Enable Scalar API Reference')->end()
                 ->booleanNode('enable_entrypoint')->defaultTrue()->info('Enable the entrypoint')->end()
                 ->booleanNode('enable_docs')->defaultTrue()->info('Enable the docs')->end()
+                ->booleanNode('enable_head_request_optimization')->defaultTrue()->info('Skip response body construction on HEAD requests so collections are not iterated. Disable to process HEAD identically to GET.')->end()
                 ->booleanNode('enable_profiler')->defaultTrue()->info('Enable the data collector and the WebProfilerBundle integration.')->end()
                 ->booleanNode('enable_phpdoc_parser')->defaultTrue()->info('Enable resource metadata collector using PHPStan PhpDocParser.')->end()
                 ->booleanNode('enable_link_security')

--- a/src/Symfony/Bundle/Resources/config/json_streamer/events.php
+++ b/src/Symfony/Bundle/Resources/config/json_streamer/events.php
@@ -34,6 +34,7 @@ return static function (ContainerConfigurator $container) {
             '%api_platform.collection.pagination.enabled_parameter_name%',
             '%api_platform.url_generation_strategy%',
             service('api_platform.metadata.resource.metadata_collection_factory'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.jsonld.state_provider.json_streamer', HydraJsonStreamerProvider::class)
@@ -50,6 +51,7 @@ return static function (ContainerConfigurator $container) {
             service('api_platform.resource_class_resolver'),
             service('api_platform.metadata.operation.metadata_factory'),
             service('api_platform.metadata.resource.metadata_collection_factory'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.state_provider.json_streamer', JsonStreamerProvider::class)

--- a/src/Symfony/Bundle/Resources/config/json_streamer/hydra.php
+++ b/src/Symfony/Bundle/Resources/config/json_streamer/hydra.php
@@ -31,6 +31,7 @@ return static function (ContainerConfigurator $container) {
             '%api_platform.collection.pagination.enabled_parameter_name%',
             '%api_platform.url_generation_strategy%',
             service('api_platform.metadata.resource.metadata_collection_factory'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.jsonld.state_provider.json_streamer', JsonStreamerProvider::class)

--- a/src/Symfony/Bundle/Resources/config/json_streamer/json.php
+++ b/src/Symfony/Bundle/Resources/config/json_streamer/json.php
@@ -28,6 +28,7 @@ return static function (ContainerConfigurator $container) {
             service('api_platform.resource_class_resolver'),
             service('api_platform.metadata.operation.metadata_factory'),
             service('api_platform.metadata.resource.metadata_collection_factory'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.state_provider.json_streamer', JsonStreamerProvider::class)

--- a/src/Symfony/Bundle/Resources/config/state/processor.php
+++ b/src/Symfony/Bundle/Resources/config/state/processor.php
@@ -29,6 +29,7 @@ return static function (ContainerConfigurator $container) {
             service('api_platform.state_processor.serialize.inner'),
             service('api_platform.serializer'),
             service('api_platform.serializer.context_builder'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.state_processor.write', WriteProcessor::class)

--- a/src/Symfony/Bundle/Resources/config/symfony/events.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.php
@@ -101,6 +101,7 @@ return static function (ContainerConfigurator $container) {
             null,
             service('api_platform.serializer'),
             service('api_platform.serializer.context_builder'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.state_processor.write', WriteProcessor::class)
@@ -162,6 +163,7 @@ return static function (ContainerConfigurator $container) {
             service('api_platform.state_processor.documentation.serialize.inner'),
             service('api_platform.serializer'),
             service('api_platform.serializer.context_builder'),
+            '%api_platform.enable_head_request_optimization%',
         ]);
 
     $services->set('api_platform.state_processor.documentation.write', WriteProcessor::class)

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -261,6 +261,9 @@ class ApiPlatformExtensionTest extends TestCase
         foreach ($services as $service) {
             $this->assertNotContainerHasService($service);
         }
+
+        $this->assertTrue($this->container->hasParameter('api_platform.enable_head_request_optimization'));
+        $this->assertTrue($this->container->getParameter('api_platform.enable_head_request_optimization'));
     }
 
     public function testSwaggerUiDisabledConfiguration(): void

--- a/tests/Fixtures/TestBundle/ApiResource/HeadSpyResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/HeadSpyResource.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Tests\Fixtures\TestBundle\State\SpyPaginator;
+
+#[ApiResource(
+    shortName: 'HeadSpyResource',
+    operations: [
+        new GetCollection(
+            uriTemplate: '/head_spy_resources',
+            provider: [self::class, 'provide'],
+        ),
+        new GetCollection(
+            uriTemplate: '/head_spy_stream_resources',
+            provider: [self::class, 'provide'],
+            jsonStream: true,
+        ),
+    ],
+)]
+final class HeadSpyResource
+{
+    public string $id = '';
+
+    public static function provide(Operation $operation, array $uriVariables = [], array $context = []): SpyPaginator
+    {
+        return new SpyPaginator();
+    }
+}

--- a/tests/Fixtures/TestBundle/State/SpyPaginator.php
+++ b/tests/Fixtures/TestBundle/State/SpyPaginator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\State;
+
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * A paginator whose scalar metadata is canned but whose rows are never meant to be
+ * read: getIterator() and count() throw. A HEAD request must return without iterating,
+ * proving no row SELECT was issued.
+ *
+ * @implements PaginatorInterface<object>
+ * @implements \IteratorAggregate<object>
+ */
+final class SpyPaginator implements PaginatorInterface, \IteratorAggregate
+{
+    public function getCurrentPage(): float
+    {
+        return 1.;
+    }
+
+    public function getItemsPerPage(): float
+    {
+        return 30.;
+    }
+
+    public function getLastPage(): float
+    {
+        return 1.;
+    }
+
+    public function getTotalItems(): float
+    {
+        return 42.;
+    }
+
+    public function count(): int
+    {
+        throw new HttpException(Response::HTTP_I_AM_A_TEAPOT, 'iterated on HEAD');
+    }
+
+    public function getIterator(): \Iterator
+    {
+        throw new HttpException(Response::HTTP_I_AM_A_TEAPOT, 'iterated on HEAD');
+    }
+}

--- a/tests/Functional/HeadAllowWithoutGetTest.php
+++ b/tests/Functional/HeadAllowWithoutGetTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\JsonLd\PostNoOutputResource;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * RFC 9110 §10.2.1: the Allow header must advertise only methods that are actually
+ * valid for the target resource. HEAD is defined as GET-without-body (§9.3.2), so a
+ * resource that declares no GET operation does not support HEAD — a real HEAD request
+ * returns 405. The advertised Allow header must therefore not claim HEAD either.
+ */
+final class HeadAllowWithoutGetTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [PostNoOutputResource::class];
+    }
+
+    public function testHeadIsNotAdvertisedWithoutGetOperation(): void
+    {
+        $client = self::createClient();
+
+        $client->request('HEAD', '/jsonld_post_no_output', ['headers' => ['Accept' => 'application/ld+json']]);
+        $this->assertResponseStatusCodeSame(405);
+
+        $response = $client->request('POST', '/jsonld_post_no_output', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => ['lorem' => 'x'],
+        ]);
+
+        $headers = array_change_key_case($response->getHeaders(false));
+        $this->assertArrayHasKey('allow', $headers);
+        $this->assertStringNotContainsString('HEAD', $headers['allow'][0]);
+    }
+}

--- a/tests/Functional/HeadRequestTest.php
+++ b/tests/Functional/HeadRequestTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\HeadSpyResource;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
+use Symfony\Component\JsonStreamer\JsonStreamWriter;
+
+/**
+ * On a HEAD request, API Platform must skip body construction so that the (lazy)
+ * collection is never iterated: zero row SELECT. The spy paginator throws on
+ * getIterator()/count(); a HEAD that does not throw proves no iteration occurred.
+ */
+final class HeadRequestTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [HeadSpyResource::class];
+    }
+
+    public function testHeadDoesNotIterateCollection(): void
+    {
+        $response = self::createClient()->request('HEAD', '/head_spy_resources', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertEmpty($response->getContent(false));
+
+        $headers = array_change_key_case($response->getHeaders(false));
+        $this->assertArrayHasKey('content-type', $headers);
+        $this->assertStringStartsWith('application/ld+json', $headers['content-type'][0]);
+        $this->assertArrayHasKey('vary', $headers);
+        $this->assertStringContainsString('Accept', $headers['vary'][0]);
+    }
+
+    public function testGetIteratesCollection(): void
+    {
+        self::createClient()->request('GET', '/head_spy_resources', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(418);
+    }
+
+    public function testOptionsIsUnaffected(): void
+    {
+        $response = self::createClient()->request('OPTIONS', '/head_spy_resources', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $headers = array_change_key_case($response->getHeaders(false));
+        $this->assertArrayHasKey('allow', $headers);
+        $this->assertStringContainsString('GET', $headers['allow'][0]);
+    }
+
+    public function testHeadDoesNotIterateJsonStreamCollection(): void
+    {
+        if (false === (class_exists(ControllerHelper::class) && class_exists(JsonStreamWriter::class))) {
+            $this->markTestSkipped('JsonStreamer component not installed.');
+        }
+
+        $response = self::createClient()->request('HEAD', '/head_spy_stream_resources', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertEmpty($response->getContent(false));
+
+        $headers = array_change_key_case($response->getHeaders(false));
+        $this->assertArrayHasKey('content-type', $headers);
+        $this->assertArrayHasKey('vary', $headers);
+        $this->assertStringContainsString('Accept', $headers['vary'][0]);
+    }
+}

--- a/tests/Functional/HeadRequestWithoutOptimizationTest.php
+++ b/tests/Functional/HeadRequestWithoutOptimizationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\HeadSpyResource;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class HeadRequestWithoutOptimizationAppKernel extends \AppKernel
+{
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir().'/head_no_opt';
+    }
+
+    public function getLogDir(): string
+    {
+        return parent::getLogDir().'/head_no_opt';
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        parent::configureContainer($c, $loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            $container->loadFromExtension('api_platform', [
+                'enable_head_request_optimization' => false,
+            ]);
+        });
+    }
+}
+
+/**
+ * Opt-out: with enable_head_request_optimization disabled, a HEAD request must
+ * behave like GET again — the body is built, so the (lazy) collection IS iterated.
+ * The spy paginator throws a fixed 418 on iteration; seeing it proves the flag
+ * restores the previous GET-equivalent behavior.
+ */
+final class HeadRequestWithoutOptimizationTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [HeadSpyResource::class];
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return HeadRequestWithoutOptimizationAppKernel::class;
+    }
+
+    public function testHeadIteratesCollectionWhenOptimizationDisabled(): void
+    {
+        self::createClient()->request('HEAD', '/head_spy_resources', [
+            'headers' => ['Accept' => 'application/ld+json'],
+        ]);
+
+        $this->assertResponseStatusCodeSame(418);
+    }
+}

--- a/tests/State/RespondProcessorTest.php
+++ b/tests/State/RespondProcessorTest.php
@@ -163,6 +163,35 @@ class RespondProcessorTest extends TestCase
         $this->assertSame('application/ld+json', $response->headers->get('Accept-Post'));
     }
 
+    public function testDoesNotAdvertiseHeadWithoutGetOperation(): void
+    {
+        $postOperation = new Post(uriTemplate: '/employees', class: Employee::class);
+
+        $resourceClassResolver = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolver->isResourceClass(Employee::class)->willReturn(true);
+
+        $resourceMetadataCollectionFactory = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataCollectionFactory->create(Employee::class)->willReturn(new ResourceMetadataCollection(Employee::class, [
+            new ApiResource(operations: [
+                'post' => $postOperation,
+            ]),
+        ]));
+
+        $respondProcessor = new RespondProcessor(
+            null,
+            $resourceClassResolver->reveal(),
+            null,
+            $resourceMetadataCollectionFactory->reveal()
+        );
+
+        $response = $respondProcessor->process('content', $postOperation, context: [
+            'request' => new Request(),
+        ]);
+
+        $this->assertNotNull($response->headers->get('Allow'));
+        $this->assertStringNotContainsString('HEAD', $response->headers->get('Allow'));
+    }
+
     public function testDynamicResponseStatusFromRequestAttribute(): void
     {
         $operation = new Post(class: Employee::class);

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -255,6 +255,7 @@ class ConfigurationTest extends TestCase
                 'allow_client_generated_id' => false,
             ],
             'enable_scalar' => true,
+            'enable_head_request_optimization' => true,
         ], $config);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | follow-up to #7856 (limitation #1), #7137
| License       | MIT
| Doc PR        | no but I can do this after

This is the follow-up to the `HEAD` remark I left in #7856 (limitation #1): today a `HEAD` is processed exactly like a `GET` — the collection is fully read, hydrated and serialized, and Symfony only strips the body right before sending. So the database does all the work for nothing.

This PR makes a `HEAD` request skip body construction entirely: the (lazy) Doctrine collection is never iterated → no row `SELECT`. The response still carries its headers, just no body — which is what `HEAD` is for.

One single commit, decoupled from the Content-Range topic on purpose: it stands on its own even if #7856 isn't merged.

## RFC 9110 section followed
[§9.3.2 HEAD](https://datatracker.ietf.org/doc/html/rfc9110#section-9.3.2) — *"The HEAD method is identical to GET except that the server MUST NOT send content in the response."* The spec explicitly allows a server to omit header fields whose value is only determined while generating the content, and states this is *"preferable to generating and discarding the content for a HEAD request, since HEAD is usually requested for the sake of efficiency."* That's exactly what we do.

## Summed up design considerations
- where does API-Platform actually know the request verb? (spoiler: only `$request` — a `HEAD` is matched to the `GET` operation, so `$operation->getMethod()` returns `GET`)
- where is the response body actually built, and where is the collection iterated?
- where do we cut it without losing the headers?

## Main logic implemented
A `HEAD` short-circuit at each of the 3 points where a response body is born — right after `original_data` is captured (so headers still compute) and before any iteration:
- `SerializeProcessor` — standard serialization (all formats) → forwards an empty body.
- `Hydra\State\JsonStreamerProcessor` & `Serializer\State\JsonStreamerProcessor` — the `jsonStream: true` paths, which build the body independently of `SerializeProcessor` (and, in listener mode, via their own `kernel.view` listener — hence their own guard).

Detection is `$request->isMethod('HEAD')`: the operation can't tell us, by construction.

## Tests
- `HeadRequestTest` (functional) — backed by a spy paginator whose `getIterator()`/`count()` **throw**, so a `HEAD` returning `200` *proves* the collection was never iterated (a naive "200 + empty body" test would pass even if the `SELECT` ran). Covers: collection `HEAD` (no iteration), `GET` (does iterate → sanity check, keeps the test non-vacuous), `OPTIONS` (unaffected), and a `jsonStream: true` resource.
- `SerializeProcessorTest` (unit) — asserts the serializer is never called on `HEAD`.

## Limitations & concerns
1. `Content-Length` is no longer set on `HEAD` (we don't build the body to measure it). Allowed by RFC 9110 §9.3.2, but a small observable change for strict clients.
2. HTTP-cache resources (`_resources`, surrogate keys) aren't populated on `HEAD` since serialization is skipped → cache-tag headers may differ between `GET` and `HEAD`. Fine IMO (a `HEAD` has no rows), but worth flagging.
3. A `security` expression on a collection that iterates `object` still triggers the `SELECT` — it runs in the provider, *before* the processors, so this optimization can't prevent it. The common case (`is_granted('ROLE_X')`) is unaffected.
4. `HEAD` on an item saves nothing on the database — and this is by design: there is no DB win to be had there at all. An item `HEAD` must still return the correct `200`/`404`/`403`, which requires the read. Existence is only knowable by querying, and an object-level `security` expression (e.g. `is_granted('VIEW', object)`) needs the **hydrated** entity — it is evaluated in the provider, *before* any processor, and on `HEAD` exactly like `GET`. So even degrading the fetch to a bare `EXISTS` would not help as soon as security (or validation, or serialization) touches the object. And unlike a collection — whose paginator is lazy, so the row `SELECT` is deferred to body-building and thus skippable — an item is fetched eagerly, upstream of the processors. The body is still correctly empty; there is simply nothing to gain. This PR is about collections.

