### PR TITLE
feat(openapi): support OpenAPI 3.2.0

### DIFF
--- a/src/OpenApi/Model/Components.php
+++ b/src/OpenApi/Model/Components.php
@@ -30,8 +30,9 @@ final class Components
      * @param \ArrayObject<string, Link>|\ArrayObject<string, Reference>                                   $links
      * @param \ArrayObject<string, array<string, PathItem>>|\ArrayObject<string, array<string, Reference>> $callbacks
      * @param \ArrayObject<string, PathItem>|\ArrayObject<string, Reference>                               $pathItems
+     * @param \ArrayObject<string, MediaType>|\ArrayObject<string, Reference>                              $mediaTypes
      */
-    public function __construct(?\ArrayObject $schemas = null, private ?\ArrayObject $responses = null, private ?\ArrayObject $parameters = null, private ?\ArrayObject $examples = null, private ?\ArrayObject $requestBodies = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $securitySchemes = null, private ?\ArrayObject $links = null, private ?\ArrayObject $callbacks = null, private ?\ArrayObject $pathItems = null)
+    public function __construct(?\ArrayObject $schemas = null, private ?\ArrayObject $responses = null, private ?\ArrayObject $parameters = null, private ?\ArrayObject $examples = null, private ?\ArrayObject $requestBodies = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $securitySchemes = null, private ?\ArrayObject $links = null, private ?\ArrayObject $callbacks = null, private ?\ArrayObject $pathItems = null, private ?\ArrayObject $mediaTypes = null)
     {
         $schemas?->ksort();
 
@@ -86,6 +87,11 @@ final class Components
     public function getPathItems(): ?\ArrayObject
     {
         return $this->pathItems;
+    }
+
+    public function getMediaTypes(): ?\ArrayObject
+    {
+        return $this->mediaTypes;
     }
 
     public function withSchemas(\ArrayObject $schemas): self
@@ -164,6 +170,14 @@ final class Components
     {
         $clone = clone $this;
         $clone->pathItems = $pathItems;
+
+        return $clone;
+    }
+
+    public function withMediaTypes(\ArrayObject $mediaTypes): self
+    {
+        $clone = clone $this;
+        $clone->mediaTypes = $mediaTypes;
 
         return $clone;
     }

--- a/src/OpenApi/Model/Encoding.php
+++ b/src/OpenApi/Model/Encoding.php
@@ -17,7 +17,10 @@ final class Encoding
 {
     use ExtensionTrait;
 
-    public function __construct(private string $contentType = '', private ?\ArrayObject $headers = null, private string $style = '', private bool $explode = false, private bool $allowReserved = false)
+    /**
+     * @param array<int, Encoding>|null $prefixEncoding
+     */
+    public function __construct(private string $contentType = '', private ?\ArrayObject $headers = null, private string $style = '', private bool $explode = false, private bool $allowReserved = false, private ?\ArrayObject $encoding = null, private ?array $prefixEncoding = null, private ?self $itemEncoding = null)
     {
     }
 
@@ -56,6 +59,24 @@ final class Encoding
         return $this->allowReserved;
     }
 
+    public function getEncoding(): ?\ArrayObject
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * @return array<int, Encoding>|null
+     */
+    public function getPrefixEncoding(): ?array
+    {
+        return $this->prefixEncoding;
+    }
+
+    public function getItemEncoding(): ?self
+    {
+        return $this->itemEncoding;
+    }
+
     public function withContentType(string $contentType): self
     {
         $clone = clone $this;
@@ -92,6 +113,33 @@ final class Encoding
     {
         $clone = clone $this;
         $clone->allowReserved = $allowReserved;
+
+        return $clone;
+    }
+
+    public function withEncoding(?\ArrayObject $encoding): self
+    {
+        $clone = clone $this;
+        $clone->encoding = $encoding;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<int, Encoding>|null $prefixEncoding
+     */
+    public function withPrefixEncoding(?array $prefixEncoding): self
+    {
+        $clone = clone $this;
+        $clone->prefixEncoding = $prefixEncoding;
+
+        return $clone;
+    }
+
+    public function withItemEncoding(self $itemEncoding): self
+    {
+        $clone = clone $this;
+        $clone->itemEncoding = $itemEncoding;
 
         return $clone;
     }

--- a/src/OpenApi/Model/Example.php
+++ b/src/OpenApi/Model/Example.php
@@ -17,7 +17,7 @@ final class Example
 {
     use ExtensionTrait;
 
-    public function __construct(private ?string $summary = null, private ?string $description = null, private mixed $value = null, private ?string $externalValue = null)
+    public function __construct(private ?string $summary = null, private ?string $description = null, private mixed $value = null, private ?string $externalValue = null, private mixed $dataValue = null, private ?string $serializedValue = null)
     {
     }
 
@@ -69,6 +69,32 @@ final class Example
     {
         $clone = clone $this;
         $clone->externalValue = $externalValue;
+
+        return $clone;
+    }
+
+    public function getDataValue(): mixed
+    {
+        return $this->dataValue;
+    }
+
+    public function withDataValue(mixed $dataValue): self
+    {
+        $clone = clone $this;
+        $clone->dataValue = $dataValue;
+
+        return $clone;
+    }
+
+    public function getSerializedValue(): ?string
+    {
+        return $this->serializedValue;
+    }
+
+    public function withSerializedValue(string $serializedValue): self
+    {
+        $clone = clone $this;
+        $clone->serializedValue = $serializedValue;
 
         return $clone;
     }

--- a/src/OpenApi/Model/MediaType.php
+++ b/src/OpenApi/Model/MediaType.php
@@ -17,7 +17,10 @@ final class MediaType
 {
     use ExtensionTrait;
 
-    public function __construct(private ?\ArrayObject $schema = null, private mixed $example = null, private ?\ArrayObject $examples = null, private ?Encoding $encoding = null)
+    /**
+     * @param array<int, Encoding>|null $prefixEncoding
+     */
+    public function __construct(private ?\ArrayObject $schema = null, private mixed $example = null, private ?\ArrayObject $examples = null, private ?Encoding $encoding = null, private ?\ArrayObject $itemSchema = null, private ?array $prefixEncoding = null, private ?Encoding $itemEncoding = null)
     {
     }
 
@@ -39,6 +42,24 @@ final class MediaType
     public function getEncoding(): ?Encoding
     {
         return $this->encoding;
+    }
+
+    public function getItemSchema(): ?\ArrayObject
+    {
+        return $this->itemSchema;
+    }
+
+    /**
+     * @return array<int, Encoding>|null
+     */
+    public function getPrefixEncoding(): ?array
+    {
+        return $this->prefixEncoding;
+    }
+
+    public function getItemEncoding(): ?Encoding
+    {
+        return $this->itemEncoding;
     }
 
     public function withSchema(\ArrayObject $schema): self
@@ -69,6 +90,33 @@ final class MediaType
     {
         $clone = clone $this;
         $clone->encoding = $encoding;
+
+        return $clone;
+    }
+
+    public function withItemSchema(\ArrayObject $itemSchema): self
+    {
+        $clone = clone $this;
+        $clone->itemSchema = $itemSchema;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<int, Encoding>|null $prefixEncoding
+     */
+    public function withPrefixEncoding(?array $prefixEncoding): self
+    {
+        $clone = clone $this;
+        $clone->prefixEncoding = $prefixEncoding;
+
+        return $clone;
+    }
+
+    public function withItemEncoding(Encoding $itemEncoding): self
+    {
+        $clone = clone $this;
+        $clone->itemEncoding = $itemEncoding;
 
         return $clone;
     }

--- a/src/OpenApi/Model/OAuthFlow.php
+++ b/src/OpenApi/Model/OAuthFlow.php
@@ -17,7 +17,7 @@ final class OAuthFlow
 {
     use ExtensionTrait;
 
-    public function __construct(private ?string $authorizationUrl = null, private ?string $tokenUrl = null, private ?string $refreshUrl = null, private ?\ArrayObject $scopes = null)
+    public function __construct(private ?string $authorizationUrl = null, private ?string $tokenUrl = null, private ?string $refreshUrl = null, private ?\ArrayObject $scopes = null, private ?string $deviceAuthorizationUrl = null)
     {
     }
 
@@ -39,6 +39,11 @@ final class OAuthFlow
     public function getScopes(): \ArrayObject
     {
         return $this->scopes;
+    }
+
+    public function getDeviceAuthorizationUrl(): ?string
+    {
+        return $this->deviceAuthorizationUrl;
     }
 
     public function withAuthorizationUrl(string $authorizationUrl): self
@@ -69,6 +74,14 @@ final class OAuthFlow
     {
         $clone = clone $this;
         $clone->scopes = $scopes;
+
+        return $clone;
+    }
+
+    public function withDeviceAuthorizationUrl(string $deviceAuthorizationUrl): self
+    {
+        $clone = clone $this;
+        $clone->deviceAuthorizationUrl = $deviceAuthorizationUrl;
 
         return $clone;
     }

--- a/src/OpenApi/Model/OAuthFlows.php
+++ b/src/OpenApi/Model/OAuthFlows.php
@@ -17,7 +17,7 @@ final class OAuthFlows
 {
     use ExtensionTrait;
 
-    public function __construct(private ?OAuthFlow $implicit = null, private ?OAuthFlow $password = null, private ?OAuthFlow $clientCredentials = null, private ?OAuthFlow $authorizationCode = null)
+    public function __construct(private ?OAuthFlow $implicit = null, private ?OAuthFlow $password = null, private ?OAuthFlow $clientCredentials = null, private ?OAuthFlow $authorizationCode = null, private ?OAuthFlow $deviceAuthorization = null)
     {
     }
 
@@ -39,6 +39,11 @@ final class OAuthFlows
     public function getAuthorizationCode(): ?OAuthFlow
     {
         return $this->authorizationCode;
+    }
+
+    public function getDeviceAuthorization(): ?OAuthFlow
+    {
+        return $this->deviceAuthorization;
     }
 
     public function withImplicit(OAuthFlow $implicit): self
@@ -69,6 +74,14 @@ final class OAuthFlows
     {
         $clone = clone $this;
         $clone->authorizationCode = $authorizationCode;
+
+        return $clone;
+    }
+
+    public function withDeviceAuthorization(OAuthFlow $deviceAuthorization): self
+    {
+        $clone = clone $this;
+        $clone->deviceAuthorization = $deviceAuthorization;
 
         return $clone;
     }

--- a/src/OpenApi/Model/PathItem.php
+++ b/src/OpenApi/Model/PathItem.php
@@ -19,7 +19,7 @@ final class PathItem
 
     public static array $methods = ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'TRACE'];
 
-    public function __construct(private ?string $ref = null, private ?string $summary = null, private ?string $description = null, private ?Operation $get = null, private ?Operation $put = null, private ?Operation $post = null, private ?Operation $delete = null, private ?Operation $options = null, private ?Operation $head = null, private ?Operation $patch = null, private ?Operation $trace = null, private ?array $servers = null, private ?array $parameters = null)
+    public function __construct(private ?string $ref = null, private ?string $summary = null, private ?string $description = null, private ?Operation $get = null, private ?Operation $put = null, private ?Operation $post = null, private ?Operation $delete = null, private ?Operation $options = null, private ?Operation $head = null, private ?Operation $patch = null, private ?Operation $trace = null, private ?array $servers = null, private ?array $parameters = null, private ?Operation $query = null, private ?array $additionalOperations = null)
     {
     }
 
@@ -86,6 +86,19 @@ final class PathItem
     public function getParameters(): ?array
     {
         return $this->parameters;
+    }
+
+    public function getQuery(): ?Operation
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return array<string, Operation>|null
+     */
+    public function getAdditionalOperations(): ?array
+    {
+        return $this->additionalOperations;
     }
 
     public function withRef(string $ref): self
@@ -188,6 +201,25 @@ final class PathItem
     {
         $clone = clone $this;
         $clone->parameters = $parameters;
+
+        return $clone;
+    }
+
+    public function withQuery(?Operation $query): self
+    {
+        $clone = clone $this;
+        $clone->query = $query;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, Operation>|null $additionalOperations
+     */
+    public function withAdditionalOperations(?array $additionalOperations = null): self
+    {
+        $clone = clone $this;
+        $clone->additionalOperations = $additionalOperations;
 
         return $clone;
     }

--- a/src/OpenApi/Model/Response.php
+++ b/src/OpenApi/Model/Response.php
@@ -17,7 +17,7 @@ final class Response
 {
     use ExtensionTrait;
 
-    public function __construct(private ?string $description = null, private ?\ArrayObject $content = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $links = null)
+    public function __construct(private ?string $description = null, private ?\ArrayObject $content = null, private ?\ArrayObject $headers = null, private ?\ArrayObject $links = null, private ?string $summary = null)
     {
     }
 
@@ -39,6 +39,11 @@ final class Response
     public function getLinks(): ?\ArrayObject
     {
         return $this->links;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
     }
 
     public function withDescription(string $description): self
@@ -69,6 +74,14 @@ final class Response
     {
         $clone = clone $this;
         $clone->links = $links;
+
+        return $clone;
+    }
+
+    public function withSummary(string $summary): self
+    {
+        $clone = clone $this;
+        $clone->summary = $summary;
 
         return $clone;
     }

--- a/src/OpenApi/Model/SecurityScheme.php
+++ b/src/OpenApi/Model/SecurityScheme.php
@@ -17,7 +17,7 @@ final class SecurityScheme
 {
     use ExtensionTrait;
 
-    public function __construct(private ?string $type = null, private string $description = '', private ?string $name = null, private ?string $in = null, private ?string $scheme = null, private ?string $bearerFormat = null, private ?OAuthFlows $flows = null, private ?string $openIdConnectUrl = null)
+    public function __construct(private ?string $type = null, private string $description = '', private ?string $name = null, private ?string $in = null, private ?string $scheme = null, private ?string $bearerFormat = null, private ?OAuthFlows $flows = null, private ?string $openIdConnectUrl = null, private ?string $oauth2MetadataUrl = null, private ?bool $deprecated = null)
     {
     }
 
@@ -59,6 +59,16 @@ final class SecurityScheme
     public function getOpenIdConnectUrl(): ?string
     {
         return $this->openIdConnectUrl;
+    }
+
+    public function getOauth2MetadataUrl(): ?string
+    {
+        return $this->oauth2MetadataUrl;
+    }
+
+    public function getDeprecated(): ?bool
+    {
+        return $this->deprecated;
     }
 
     public function withType(string $type): self
@@ -121,6 +131,22 @@ final class SecurityScheme
     {
         $clone = clone $this;
         $clone->openIdConnectUrl = $openIdConnectUrl;
+
+        return $clone;
+    }
+
+    public function withOauth2MetadataUrl(string $oauth2MetadataUrl): self
+    {
+        $clone = clone $this;
+        $clone->oauth2MetadataUrl = $oauth2MetadataUrl;
+
+        return $clone;
+    }
+
+    public function withDeprecated(bool $deprecated): self
+    {
+        $clone = clone $this;
+        $clone->deprecated = $deprecated;
 
         return $clone;
     }

--- a/src/OpenApi/Model/Server.php
+++ b/src/OpenApi/Model/Server.php
@@ -17,7 +17,7 @@ final class Server
 {
     use ExtensionTrait;
 
-    public function __construct(private string $url, private string $description = '', private ?\ArrayObject $variables = null)
+    public function __construct(private string $url, private string $description = '', private ?\ArrayObject $variables = null, private ?string $name = null)
     {
     }
 
@@ -34,6 +34,11 @@ final class Server
     public function getVariables(): ?\ArrayObject
     {
         return $this->variables;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
     }
 
     public function withUrl(string $url): self
@@ -56,6 +61,14 @@ final class Server
     {
         $clone = clone $this;
         $clone->variables = $variables;
+
+        return $clone;
+    }
+
+    public function withName(string $name): self
+    {
+        $clone = clone $this;
+        $clone->name = $name;
 
         return $clone;
     }

--- a/src/OpenApi/Model/Tag.php
+++ b/src/OpenApi/Model/Tag.php
@@ -17,7 +17,7 @@ final class Tag
 {
     use ExtensionTrait;
 
-    public function __construct(private string $name, private ?string $description = null, private ?string $externalDocs = null)
+    public function __construct(private string $name, private ?string $description = null, private ?string $externalDocs = null, private ?string $summary = null, private ?string $parent = null, private ?string $kind = null)
     {
     }
 
@@ -56,6 +56,45 @@ final class Tag
     {
         $clone = clone $this;
         $clone->externalDocs = $externalDocs;
+
+        return $clone;
+    }
+
+    public function getSummary(): ?string
+    {
+        return $this->summary;
+    }
+
+    public function withSummary(string $summary): self
+    {
+        $clone = clone $this;
+        $clone->summary = $summary;
+
+        return $clone;
+    }
+
+    public function getParent(): ?string
+    {
+        return $this->parent;
+    }
+
+    public function withParent(string $parent): self
+    {
+        $clone = clone $this;
+        $clone->parent = $parent;
+
+        return $clone;
+    }
+
+    public function getKind(): ?string
+    {
+        return $this->kind;
+    }
+
+    public function withKind(string $kind): self
+    {
+        $clone = clone $this;
+        $clone->kind = $kind;
 
         return $clone;
     }

--- a/src/OpenApi/OpenApi.php
+++ b/src/OpenApi/OpenApi.php
@@ -17,12 +17,13 @@ use ApiPlatform\OpenApi\Model\Components;
 use ApiPlatform\OpenApi\Model\ExtensionTrait;
 use ApiPlatform\OpenApi\Model\Info;
 use ApiPlatform\OpenApi\Model\Paths;
+use Symfony\Component\Serializer\Attribute\SerializedName;
 
 final class OpenApi
 {
     use ExtensionTrait;
 
-    public const VERSION = '3.1.0';
+    public const VERSION = '3.2.0';
 
     private string $openapi = self::VERSION;
     private Components $components;
@@ -30,7 +31,7 @@ final class OpenApi
     /**
      * @param array|null $externalDocs
      */
-    public function __construct(private Info $info, private array $servers, private Paths $paths, ?Components $components = null, private array $security = [], private array $tags = [], private $externalDocs = null, private ?string $jsonSchemaDialect = null, private readonly ?\ArrayObject $webhooks = null)
+    public function __construct(private Info $info, private array $servers, private Paths $paths, ?Components $components = null, private array $security = [], private array $tags = [], private $externalDocs = null, private ?string $jsonSchemaDialect = null, private readonly ?\ArrayObject $webhooks = null, private ?string $self = null)
     {
         $this->components = $components ?? new Components();
     }
@@ -83,6 +84,12 @@ final class OpenApi
     public function getWebhooks(): ?\ArrayObject
     {
         return $this->webhooks;
+    }
+
+    #[SerializedName('$self')]
+    public function getSelf(): ?string
+    {
+        return $this->self;
     }
 
     public function withOpenapi(string $openapi): self
@@ -153,6 +160,14 @@ final class OpenApi
     {
         $clone = clone $this;
         $clone->jsonSchemaDialect = $jsonSchemaDialect;
+
+        return $clone;
+    }
+
+    public function withSelf(?string $self): self
+    {
+        $clone = clone $this;
+        $clone->self = $self;
 
         return $clone;
     }

--- a/src/OpenApi/Serializer/LegacyOpenApiNormalizer.php
+++ b/src/OpenApi/Serializer/LegacyOpenApiNormalizer.php
@@ -24,7 +24,7 @@ final class LegacyOpenApiNormalizer implements NormalizerInterface
     private const SCHEMA_NESTED_KEYS = ['items', 'additionalProperties', 'not', 'contains', 'propertyNames', 'if', 'then', 'else'];
 
     private array $defaultContext = [
-        self::SPEC_VERSION => '3.1.0',
+        self::SPEC_VERSION => '3.2.0',
     ];
 
     public function __construct(private readonly NormalizerInterface $decorated, array $defaultContext = [])

--- a/tests/Functional/DocumentationActionTest.php
+++ b/tests/Functional/DocumentationActionTest.php
@@ -98,7 +98,7 @@ final class DocumentationActionTest extends ApiTestCase
 
         $client->request('GET', '/docs.jsonopenapi', ['headers' => ['Accept' => 'application/vnd.openapi+json']]);
         $this->assertResponseIsSuccessful();
-        $this->assertJsonContains(['openapi' => '3.1.0']);
+        $this->assertJsonContains(['openapi' => '3.2.0']);
         $this->assertJsonContains(['info' => ['title' => 'My Dummy API']]);
     }
 
@@ -163,7 +163,7 @@ final class DocumentationActionTest extends ApiTestCase
 
         $client->request('GET', '/docs.jsonopenapi', ['headers' => ['Accept' => 'application/vnd.openapi+json']]);
         $this->assertResponseIsSuccessful();
-        $this->assertJsonContains(['openapi' => '3.1.0']);
+        $this->assertJsonContains(['openapi' => '3.2.0']);
         $this->assertJsonContains(['info' => ['title' => 'My Dummy API']]);
     }
 

--- a/tests/Functional/OpenApiTest.php
+++ b/tests/Functional/OpenApiTest.php
@@ -332,7 +332,7 @@ class OpenApiTest extends ApiTestCase
         $json = $response->toArray();
 
         // Context
-        $this->assertSame('3.1.0', $json['openapi']);
+        $this->assertSame('3.2.0', $json['openapi']);
         // Root properties
         $this->assertSame('My Dummy API', $json['info']['title']);
         $this->assertStringContainsString('This is a test API.', $json['info']['description']);
@@ -565,7 +565,7 @@ class OpenApiTest extends ApiTestCase
         $json = $response->toArray();
 
         // Context
-        $this->assertSame('3.1.0', $json['openapi']);
+        $this->assertSame('3.2.0', $json['openapi']);
         // Root properties
         $this->assertSame('My Dummy API', $json['info']['title']);
         $this->assertStringContainsString('This is a test API.', $json['info']['description']);


### PR DESCRIPTION
## Summary

Adds the model-level fields introduced by [OpenAPI 3.2.0](https://spec.openapis.org/oas/v3.2.0.html) and bumps the declared version from `3.1.0` to `3.2.0`.

Sourced from the official 3.2 JSON Schema (`spec.openapis.org/oas/3.2/schema/2025-09-17`).

### New fields by object

| Object | New in 3.2 |
|---|---|
| `OpenApi` (root) | `$self` |
| `Server` | `name` |
| `Tag` | `summary`, `parent`, `kind` |
| `PathItem` | `query` (QUERY method), `additionalOperations` |
| `MediaType` | `itemSchema`, `prefixEncoding`, `itemEncoding` (streaming) |
| `Encoding` | `encoding`, `prefixEncoding`, `itemEncoding` |
| `Response` | `summary` |
| `Example` | `dataValue`, `serializedValue` |
| `Components` | `mediaTypes` |
| `SecurityScheme` | `oauth2MetadataUrl`, `deprecated` |
| `OAuthFlows` | `deviceAuthorization` |
| `OAuthFlow` | `deviceAuthorizationUrl` |

`Parameter` needs no code change — `in` (`querystring`) and `style` (`cookie`) are already free strings.
`Info.summary` already existed.

### Version bump

Default declared version is now `3.2.0` for every generated document. `$self` serializes via `#[SerializedName('$self')]`, same proven pattern as `Reference::$ref`.

Downgrade is unchanged: `?spec_version=3.0.0` still emits a 3.0.0 document via `LegacyOpenApiNormalizer`. 3.1↔3.2 is purely additive, so a 3.1 consumer reading a 3.2-declared doc that uses no 3.2-only fields is unaffected.

### BC notes

- All model additions are new constructor params at the **end** with `null` defaults. Classes are `final` (no subclass-override BC). With `SKIP_NULL_VALUES` in `OpenApiNormalizer`, new fields never appear in output unless populated.
- The one behavior change visible to all users: the `openapi:` field now reads `3.2.0`. Downstream tooling that doesn't yet support 3.2 can pin lower via the `spec_version` option / decoration.

### Tests

- New `OpenApi32Test` covering every added field (getter + wither), TDD-first.
- Updated functional version assertions in `OpenApiTest` / `DocumentationActionTest` to `3.2.0`.
- Full OpenApi component suite green except the pre-existing `OpenApiFactoryTest::testInvoke` failure (unrelated 422 description, identical on `main`).