### PR TITLE
feat(doctrine): standalone Date/Exists filters, ComparisonFilter [between], deprecate RangeFilter

### DIFF
--- a/src/Doctrine/Common/Filter/NameConverterAwareTrait.php
+++ b/src/Doctrine/Common/Filter/NameConverterAwareTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Filter;
+
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+/**
+ * Holds an optional name converter and (de)normalizes property names through it.
+ *
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+trait NameConverterAwareTrait
+{
+    private ?NameConverterInterface $nameConverter = null;
+
+    public function hasNameConverter(): bool
+    {
+        return $this->nameConverter instanceof NameConverterInterface;
+    }
+
+    public function getNameConverter(): ?NameConverterInterface
+    {
+        return $this->nameConverter;
+    }
+
+    public function setNameConverter(NameConverterInterface $nameConverter): void
+    {
+        $this->nameConverter = $nameConverter;
+    }
+
+    protected function denormalizePropertyName(string|int $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return (string) $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->denormalize(...), explode('.', (string) $property)));
+    }
+
+    protected function normalizePropertyName(string $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->normalize(...), explode('.', $property)));
+    }
+}

--- a/src/Doctrine/Common/Filter/PropertyAwareFilterTrait.php
+++ b/src/Doctrine/Common/Filter/PropertyAwareFilterTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Common\Filter;
+
+/**
+ * @author Antoine Bluchet <soyuka@gmail.com>
+ */
+trait PropertyAwareFilterTrait
+{
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $properties = null;
+
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
+    }
+}

--- a/src/Doctrine/Odm/Filter/ComparisonFilter.php
+++ b/src/Doctrine/Odm/Filter/ComparisonFilter.php
@@ -45,6 +45,12 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
         'ne' => 'notEqual',
     ];
 
+    /**
+     * Friendly range syntax: `?price[between]=10..100`. MongoDB has no BETWEEN keyword, so a range
+     * is expressed as the native `gte`/`lte` pair on the field.
+     */
+    public const OPERATOR_BETWEEN = 'between';
+
     public function __construct(private readonly FilterInterface $filter)
     {
     }
@@ -74,6 +80,12 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
                 continue;
             }
 
+            if (self::OPERATOR_BETWEEN === $operator) {
+                $this->applyBetween($aggregationBuilder, $resourceClass, $operation, $context, $parameter, $value);
+
+                continue;
+            }
+
             if (isset(self::OPERATORS[$operator])) {
                 $this->applyOperator($aggregationBuilder, $resourceClass, $operation, $context, $parameter, self::OPERATORS[$operator], $value);
             }
@@ -91,6 +103,7 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
             new OpenApiParameter(name: "{$key}[lt]", in: $in),
             new OpenApiParameter(name: "{$key}[lte]", in: $in),
             new OpenApiParameter(name: "{$key}[ne]", in: $in),
+            new OpenApiParameter(name: "{$key}[between]", in: $in),
         ];
     }
 
@@ -109,6 +122,7 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
                 'lt' => $innerSchema,
                 'lte' => $innerSchema,
                 'ne' => $innerSchema,
+                'between' => ['type' => 'string'],
             ],
         ];
     }
@@ -130,5 +144,26 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
         if (isset($newContext['match'])) {
             $context['match'] = $newContext['match'];
         }
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @param-out array<string, mixed> $context
+     */
+    private function applyBetween(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation, array &$context, Parameter $parameter, mixed $value): void
+    {
+        if (!\is_string($value)) {
+            return;
+        }
+
+        $bounds = explode('..', $value, 2);
+        if (2 !== \count($bounds) || !is_numeric($bounds[0]) || !is_numeric($bounds[1])) {
+            return;
+        }
+
+        // MongoDB range = native gte/lte pair (coerce bounds to numbers)
+        $this->applyOperator($aggregationBuilder, $resourceClass, $operation, $context, $parameter, 'gte', $bounds[0] + 0);
+        $this->applyOperator($aggregationBuilder, $resourceClass, $operation, $context, $parameter, 'lte', $bounds[1] + 0);
     }
 }

--- a/src/Doctrine/Odm/Filter/DateFilter.php
+++ b/src/Doctrine/Odm/Filter/DateFilter.php
@@ -15,6 +15,13 @@ namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\DateFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\DateFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterTrait;
+use ApiPlatform\Doctrine\Odm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
@@ -23,6 +30,10 @@ use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Doctrine\ODM\MongoDB\Aggregation\Builder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * The date filter allows to filter a collection by date intervals.
@@ -120,20 +131,59 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
- *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating the `[before]`/`[strictly_before]`/`[after]`/`[strictly_after]` syntax) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
-final class DateFilter extends AbstractFilter implements DateFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
+final class DateFilter implements DateFilterInterface, FilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface, OpenApiParameterFilterInterface, PropertyAwareFilterInterface
 {
     use DateFilterTrait;
+    use ManagerRegistryAwareTrait;
+    use MongoDbOdmPropertyHelperTrait;
+    use NameConverterAwareTrait;
+    use PropertyAwareFilterTrait;
 
     public const DOCTRINE_DATE_TYPES = [
         'date' => true,
         'date_immutable' => true,
     ];
 
+    private LoggerInterface $logger;
+
     /**
-     * {@inheritdoc}
+     * @param array<string, mixed>|null $properties
+     */
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->logger = $logger ?? new NullLogger();
+        $this->properties = $properties;
+        $this->nameConverter = $nameConverter;
+    }
+
+    public function apply(Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
+    {
+        foreach ($context['filters'] ?? [] as $property => $value) {
+            $this->filterProperty($this->denormalizePropertyName($property), $value, $aggregationBuilder, $resourceClass, $operation, $context);
+        }
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    protected function isPropertyEnabled(string $property, string $resourceClass): bool
+    {
+        if (null === $this->properties) {
+            // to ensure sanity, nested properties must still be explicitly enabled
+            return !$this->isPropertyNested($property, $resourceClass);
+        }
+
+        return \array_key_exists($property, $this->properties);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @param-out array<string, mixed> $context
      */
     protected function filterProperty(string $property, mixed $value, Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {

--- a/src/Doctrine/Odm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Odm/Filter/ExistsFilter.php
@@ -18,7 +18,9 @@ use ApiPlatform\Doctrine\Common\Filter\ExistsFilterTrait;
 use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
 use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterTrait;
 use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
 use ApiPlatform\Doctrine\Odm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
 use ApiPlatform\Metadata\JsonSchemaFilterInterface;
@@ -122,6 +124,8 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
     use ExistsFilterTrait;
     use ManagerRegistryAwareTrait;
     use MongoDbOdmPropertyHelperTrait;
+    use NameConverterAwareTrait;
+    use PropertyAwareFilterTrait;
     use PropertyPlaceholderOpenApiParameterTrait;
 
     private LoggerInterface $logger;
@@ -129,38 +133,12 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
     /**
      * @param array<string, mixed>|null $properties
      */
-    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, private ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, private ?NameConverterInterface $nameConverter = null)
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, ?NameConverterInterface $nameConverter = null)
     {
         $this->managerRegistry = $managerRegistry;
         $this->logger = $logger ?? new NullLogger();
         $this->existsParameterName = $existsParameterName;
-    }
-
-    public function getProperties(): ?array
-    {
-        return $this->properties;
-    }
-
-    /**
-     * @param array<string, mixed> $properties
-     */
-    public function setProperties(array $properties): void
-    {
         $this->properties = $properties;
-    }
-
-    public function hasNameConverter(): bool
-    {
-        return $this->nameConverter instanceof NameConverterInterface;
-    }
-
-    public function getNameConverter(): ?NameConverterInterface
-    {
-        return $this->nameConverter;
-    }
-
-    public function setNameConverter(NameConverterInterface $nameConverter): void
-    {
         $this->nameConverter = $nameConverter;
     }
 
@@ -177,24 +155,6 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
         }
 
         return \array_key_exists($property, $this->properties);
-    }
-
-    protected function denormalizePropertyName(string|int $property): string
-    {
-        if (!$this->nameConverter instanceof NameConverterInterface) {
-            return (string) $property;
-        }
-
-        return implode('.', array_map($this->nameConverter->denormalize(...), explode('.', (string) $property)));
-    }
-
-    protected function normalizePropertyName(string $property): string
-    {
-        if (!$this->nameConverter instanceof NameConverterInterface) {
-            return $property;
-        }
-
-        return implode('.', array_map($this->nameConverter->normalize(...), explode('.', $property)));
     }
 
     /**
@@ -215,7 +175,9 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
     }
 
     /**
-     * {@inheritdoc}
+     * @param array<string, mixed> $context
+     *
+     * @param-out array<string, mixed> $context
      */
     protected function filterProperty(string $property, mixed $value, Builder $aggregationBuilder, string $resourceClass, ?Operation $operation = null, array &$context = []): void
     {

--- a/src/Doctrine/Odm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Odm/Filter/ExistsFilter.php
@@ -15,7 +15,12 @@ namespace ApiPlatform\Doctrine\Odm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\ExistsFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\ExistsFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
+use ApiPlatform\Doctrine\Odm\PropertyHelperTrait as MongoDbOdmPropertyHelperTrait;
 use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
@@ -24,6 +29,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
 use Doctrine\Persistence\ManagerRegistry;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
@@ -110,19 +116,85 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
- *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone filter (reading its value from the QueryParameter instead of the legacy `context['filters']` lookup) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
-final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
+final class ExistsFilter implements ExistsFilterInterface, FilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface, OpenApiParameterFilterInterface, PropertyAwareFilterInterface
 {
     use ExistsFilterTrait;
+    use ManagerRegistryAwareTrait;
+    use MongoDbOdmPropertyHelperTrait;
     use PropertyPlaceholderOpenApiParameterTrait;
 
-    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, ?NameConverterInterface $nameConverter = null)
-    {
-        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
+    private LoggerInterface $logger;
 
+    /**
+     * @param array<string, mixed>|null $properties
+     */
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, private ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, private ?NameConverterInterface $nameConverter = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->logger = $logger ?? new NullLogger();
         $this->existsParameterName = $existsParameterName;
+    }
+
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
+    }
+
+    public function hasNameConverter(): bool
+    {
+        return $this->nameConverter instanceof NameConverterInterface;
+    }
+
+    public function getNameConverter(): ?NameConverterInterface
+    {
+        return $this->nameConverter;
+    }
+
+    public function setNameConverter(NameConverterInterface $nameConverter): void
+    {
+        $this->nameConverter = $nameConverter;
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    protected function isPropertyEnabled(string $property, string $resourceClass): bool
+    {
+        if (null === $this->properties) {
+            // to ensure sanity, nested properties must still be explicitly enabled
+            return !$this->isPropertyNested($property, $resourceClass);
+        }
+
+        return \array_key_exists($property, $this->properties);
+    }
+
+    protected function denormalizePropertyName(string|int $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return (string) $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->denormalize(...), explode('.', (string) $property)));
+    }
+
+    protected function normalizePropertyName(string $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->normalize(...), explode('.', $property)));
     }
 
     /**

--- a/src/Doctrine/Odm/Filter/RangeFilter.php
+++ b/src/Doctrine/Odm/Filter/RangeFilter.php
@@ -108,7 +108,7 @@ use Doctrine\ODM\MongoDB\Aggregation\Builder;
  * @author Lee Siong Chan <ahlee2326@me.com>
  * @author Alan Poulain <contact@alanpoulain.eu>
  *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating `[between]=X..Y` to `[gte]=X` + `[lte]=Y`, passing through `[gt]`/`[gte]`/`[lt]`/`[lte]`) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
+ * @deprecated since API Platform 4.4: use {@see ComparisonFilter} instead, which now covers the full range syntax (`[gt]`/`[gte]`/`[lt]`/`[lte]` and `[between]=X..Y`). This filter is removed in 6.0; the upgrade codemod rewrites it to a QueryParameter declared with `ComparisonFilter`.
  */
 final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {

--- a/src/Doctrine/Orm/Filter/ComparisonFilter.php
+++ b/src/Doctrine/Orm/Filter/ComparisonFilter.php
@@ -48,6 +48,12 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
 
     public const ALLOWED_DQL_OPERATORS = ['=', '>', '>=', '<', '<=', '!=', '<>'];
 
+    /**
+     * Friendly range syntax: `?price[between]=10..100`. Translates to a single BETWEEN clause
+     * (or `=` when both bounds are equal), letting the SQL optimizer treat it as a bounded range.
+     */
+    public const OPERATOR_BETWEEN = 'between';
+
     public function __construct(private readonly FilterInterface $filter)
     {
     }
@@ -74,6 +80,12 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
                 continue;
             }
 
+            if (self::OPERATOR_BETWEEN === $operator) {
+                $this->applyBetween($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context, $parameter, $value);
+
+                continue;
+            }
+
             if (isset(self::OPERATORS[$operator])) {
                 $this->applyOperator($queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context, $parameter, self::OPERATORS[$operator], $value);
             }
@@ -91,6 +103,7 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
             new OpenApiParameter(name: "{$key}[lt]", in: $in),
             new OpenApiParameter(name: "{$key}[lte]", in: $in),
             new OpenApiParameter(name: "{$key}[ne]", in: $in),
+            new OpenApiParameter(name: "{$key}[between]", in: $in),
         ];
     }
 
@@ -109,6 +122,7 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
                 'lt' => $innerSchema,
                 'lte' => $innerSchema,
                 'ne' => $innerSchema,
+                'between' => ['type' => 'string'],
             ],
         ];
     }
@@ -129,6 +143,31 @@ final class ComparisonFilter implements FilterInterface, OpenApiParameterFilterI
             $resourceClass,
             $operation,
             ['operator' => $operator, 'parameter' => $subParameter] + $context
+        );
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    private function applyBetween(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation, array $context, Parameter $parameter, mixed $value): void
+    {
+        if (!\is_string($value)) {
+            return;
+        }
+
+        $bounds = explode('..', $value, 2);
+        if (2 !== \count($bounds) || !is_numeric($bounds[0]) || !is_numeric($bounds[1])) {
+            return;
+        }
+
+        // coerce to int|float so the bound is bound as a number, not a string
+        $subParameter = (clone $parameter)->setValue([$bounds[0] + 0, $bounds[1] + 0]);
+        $this->filter->apply(
+            $queryBuilder,
+            $queryNameGenerator,
+            $resourceClass,
+            $operation,
+            ['operator' => self::OPERATOR_BETWEEN, 'parameter' => $subParameter] + $context
         );
     }
 }

--- a/src/Doctrine/Orm/Filter/DateFilter.php
+++ b/src/Doctrine/Orm/Filter/DateFilter.php
@@ -15,6 +15,13 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\DateFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\DateFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterTrait;
+use ApiPlatform\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\JsonSchemaFilterInterface;
@@ -25,8 +32,15 @@ use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model\Parameter as OpenApiParameter;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata as LegacyClassMetadata;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
  * The date filter allows to filter a collection by date intervals.
@@ -124,12 +138,13 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Théo FIDRY <theo.fidry@gmail.com>
- *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating the `[before]`/`[strictly_before]`/`[after]`/`[strictly_after]` syntax) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
-final class DateFilter extends AbstractFilter implements DateFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
+final class DateFilter implements DateFilterInterface, FilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface, OpenApiParameterFilterInterface, PropertyAwareFilterInterface
 {
     use DateFilterTrait;
+    use ManagerRegistryAwareTrait;
+    use NameConverterAwareTrait;
+    use PropertyAwareFilterTrait;
 
     public const DOCTRINE_DATE_TYPES = [
         Types::DATE_MUTABLE => true,
@@ -141,6 +156,85 @@ final class DateFilter extends AbstractFilter implements DateFilterInterface, Js
         Types::DATETIMETZ_IMMUTABLE => true,
         Types::TIME_IMMUTABLE => true,
     ];
+
+    private LoggerInterface $logger;
+
+    /**
+     * Resolved from the QueryBuilder in apply(); metadata is read from it so the active filter path
+     * never touches the injected ManagerRegistry (kept only for the deprecated getDescription() and
+     * for BC injection through ManagerRegistryAwareInterface).
+     */
+    private ?EntityManagerInterface $entityManager = null;
+
+    /**
+     * @param array<string, mixed>|null $properties
+     */
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, ?NameConverterInterface $nameConverter = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->logger = $logger ?? new NullLogger();
+        $this->properties = $properties;
+        $this->nameConverter = $nameConverter;
+    }
+
+    public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
+    {
+        $this->entityManager = $queryBuilder->getEntityManager();
+
+        foreach ($context['filters'] ?? [] as $property => $value) {
+            $this->filterProperty($this->denormalizePropertyName($property), $value, $queryBuilder, $queryNameGenerator, $resourceClass, $operation, $context);
+        }
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    protected function isPropertyEnabled(string $property, string $resourceClass): bool
+    {
+        if (null === $this->properties) {
+            // to ensure sanity, nested properties must still be explicitly enabled
+            return !$this->isPropertyNested($property, $resourceClass);
+        }
+
+        return \array_key_exists($property, $this->properties);
+    }
+
+    protected function getClassMetadata(string $resourceClass): LegacyClassMetadata
+    {
+        if ($this->entityManager instanceof EntityManagerInterface) {
+            return $this->entityManager->getClassMetadata($resourceClass);
+        }
+
+        // Legacy getDescription() runs without a QueryBuilder: fall back to the injected registry.
+        if ($this->hasManagerRegistry() && ($manager = $this->getManagerRegistry()->getManagerForClass($resourceClass))) {
+            return $manager->getClassMetadata($resourceClass);
+        }
+
+        return new ClassMetadata($resourceClass);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string[]}
+     */
+    protected function addJoinsForNestedProperty(string $property, string $rootAlias, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $joinType): array
+    {
+        $propertyParts = $this->splitPropertyParts($property, $resourceClass);
+        $parentAlias = $rootAlias;
+        $alias = null;
+
+        foreach ($propertyParts['associations'] as $association) {
+            $alias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $parentAlias, $association, $joinType);
+            $parentAlias = $alias;
+        }
+
+        if (null === $alias) {
+            throw new InvalidArgumentException(\sprintf('Cannot add joins for property "%s" - property is not nested.', $property));
+        }
+
+        return [$alias, $propertyParts['field'], $propertyParts['associations']];
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Doctrine/Orm/Filter/ExactFilter.php
+++ b/src/Doctrine/Orm/Filter/ExactFilter.php
@@ -46,6 +46,24 @@ final class ExactFilter implements FilterInterface, OpenApiParameterFilterInterf
 
         [$alias, $property] = $this->addNestedParameterJoins($property, $alias, $queryBuilder, $queryNameGenerator, $parameter);
 
+        if (ComparisonFilter::OPERATOR_BETWEEN === ($context['operator'] ?? null)) {
+            $whereClause = $context['whereClause'] ?? 'andWhere';
+
+            // equal bounds collapse to an equality so the optimizer skips the range scan
+            if ($value[0] === $value[1]) {
+                $queryBuilder->{$whereClause}(\sprintf('%s.%s = :%s', $alias, $property, $parameterName))
+                    ->setParameter($parameterName, $value[0]);
+
+                return;
+            }
+
+            $queryBuilder->{$whereClause}(\sprintf('%1$s.%2$s BETWEEN :%3$s_1 AND :%3$s_2', $alias, $property, $parameterName))
+                ->setParameter($parameterName.'_1', $value[0])
+                ->setParameter($parameterName.'_2', $value[1]);
+
+            return;
+        }
+
         if (\is_array($value)) {
             $queryBuilder
                 ->{$context['whereClause'] ?? 'andWhere'}(\sprintf('%s.%s IN (:%s)', $alias, $property, $parameterName));

--- a/src/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Orm/Filter/ExistsFilter.php
@@ -18,7 +18,9 @@ use ApiPlatform\Doctrine\Common\Filter\ExistsFilterTrait;
 use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
 use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterTrait;
 use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
@@ -129,6 +131,8 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
 {
     use ExistsFilterTrait;
     use ManagerRegistryAwareTrait;
+    use NameConverterAwareTrait;
+    use PropertyAwareFilterTrait;
     use PropertyPlaceholderOpenApiParameterTrait;
 
     private LoggerInterface $logger;
@@ -143,38 +147,12 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
     /**
      * @param array<string, mixed>|null $properties
      */
-    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, private ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, private ?NameConverterInterface $nameConverter = null)
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, ?NameConverterInterface $nameConverter = null)
     {
         $this->managerRegistry = $managerRegistry;
         $this->logger = $logger ?? new NullLogger();
         $this->existsParameterName = $existsParameterName;
-    }
-
-    public function getProperties(): ?array
-    {
-        return $this->properties;
-    }
-
-    /**
-     * @param array<string, mixed> $properties
-     */
-    public function setProperties(array $properties): void
-    {
         $this->properties = $properties;
-    }
-
-    public function hasNameConverter(): bool
-    {
-        return $this->nameConverter instanceof NameConverterInterface;
-    }
-
-    public function getNameConverter(): ?NameConverterInterface
-    {
-        return $this->nameConverter;
-    }
-
-    public function setNameConverter(NameConverterInterface $nameConverter): void
-    {
         $this->nameConverter = $nameConverter;
     }
 
@@ -191,24 +169,6 @@ final class ExistsFilter implements ExistsFilterInterface, FilterInterface, Json
         }
 
         return \array_key_exists($property, $this->properties);
-    }
-
-    protected function denormalizePropertyName(string|int $property): string
-    {
-        if (!$this->nameConverter instanceof NameConverterInterface) {
-            return (string) $property;
-        }
-
-        return implode('.', array_map($this->nameConverter->denormalize(...), explode('.', (string) $property)));
-    }
-
-    protected function normalizePropertyName(string $property): string
-    {
-        if (!$this->nameConverter instanceof NameConverterInterface) {
-            return $property;
-        }
-
-        return implode('.', array_map($this->nameConverter->normalize(...), explode('.', $property)));
     }
 
     protected function getClassMetadata(string $resourceClass): LegacyClassMetadata

--- a/src/Doctrine/Orm/Filter/ExistsFilter.php
+++ b/src/Doctrine/Orm/Filter/ExistsFilter.php
@@ -15,13 +15,19 @@ namespace ApiPlatform\Doctrine\Orm\Filter;
 
 use ApiPlatform\Doctrine\Common\Filter\ExistsFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\ExistsFilterTrait;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
+use ApiPlatform\Doctrine\Common\Filter\NameConverterAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyPlaceholderOpenApiParameterTrait;
 use ApiPlatform\Doctrine\Orm\Util\QueryBuilderHelper;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Metadata\JsonSchemaFilterInterface;
 use ApiPlatform\Metadata\OpenApiParameterFilterInterface;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Parameter;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
@@ -29,7 +35,9 @@ use Doctrine\ORM\Mapping\ToOneOwningSideMapping;
 use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata as LegacyClassMetadata;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 
 /**
@@ -116,19 +124,126 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  * Given that the collection endpoint is `/books`, you can filter books with the following query: `/books?exists[comment]=true`.
  *
  * @author Teoh Han Hui <teohhanhui@gmail.com>
- *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone filter (reading its value from the QueryParameter instead of the legacy `context['filters']` lookup) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
  */
-final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface, JsonSchemaFilterInterface, OpenApiParameterFilterInterface
+final class ExistsFilter implements ExistsFilterInterface, FilterInterface, JsonSchemaFilterInterface, ManagerRegistryAwareInterface, NameConverterAwareInterface, OpenApiParameterFilterInterface, PropertyAwareFilterInterface
 {
     use ExistsFilterTrait;
+    use ManagerRegistryAwareTrait;
     use PropertyPlaceholderOpenApiParameterTrait;
 
-    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, ?NameConverterInterface $nameConverter = null)
-    {
-        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
+    private LoggerInterface $logger;
 
+    /**
+     * Resolved from the QueryBuilder in apply(); metadata is read from it so the active filter path
+     * never touches the injected ManagerRegistry (kept only for the deprecated getDescription() and
+     * for BC injection through ManagerRegistryAwareInterface).
+     */
+    private ?EntityManagerInterface $entityManager = null;
+
+    /**
+     * @param array<string, mixed>|null $properties
+     */
+    public function __construct(?ManagerRegistry $managerRegistry = null, ?LoggerInterface $logger = null, private ?array $properties = null, string $existsParameterName = self::QUERY_PARAMETER_KEY, private ?NameConverterInterface $nameConverter = null)
+    {
+        $this->managerRegistry = $managerRegistry;
+        $this->logger = $logger ?? new NullLogger();
         $this->existsParameterName = $existsParameterName;
+    }
+
+    public function getProperties(): ?array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    public function setProperties(array $properties): void
+    {
+        $this->properties = $properties;
+    }
+
+    public function hasNameConverter(): bool
+    {
+        return $this->nameConverter instanceof NameConverterInterface;
+    }
+
+    public function getNameConverter(): ?NameConverterInterface
+    {
+        return $this->nameConverter;
+    }
+
+    public function setNameConverter(NameConverterInterface $nameConverter): void
+    {
+        $this->nameConverter = $nameConverter;
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    protected function isPropertyEnabled(string $property, string $resourceClass): bool
+    {
+        if (null === $this->properties) {
+            // to ensure sanity, nested properties must still be explicitly enabled
+            return !$this->isPropertyNested($property, $resourceClass);
+        }
+
+        return \array_key_exists($property, $this->properties);
+    }
+
+    protected function denormalizePropertyName(string|int $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return (string) $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->denormalize(...), explode('.', (string) $property)));
+    }
+
+    protected function normalizePropertyName(string $property): string
+    {
+        if (!$this->nameConverter instanceof NameConverterInterface) {
+            return $property;
+        }
+
+        return implode('.', array_map($this->nameConverter->normalize(...), explode('.', $property)));
+    }
+
+    protected function getClassMetadata(string $resourceClass): LegacyClassMetadata
+    {
+        if ($this->entityManager instanceof EntityManagerInterface) {
+            return $this->entityManager->getClassMetadata($resourceClass);
+        }
+
+        // Legacy getDescription() runs without a QueryBuilder: fall back to the injected registry.
+        if ($this->hasManagerRegistry() && ($manager = $this->getManagerRegistry()->getManagerForClass($resourceClass))) {
+            return $manager->getClassMetadata($resourceClass);
+        }
+
+        return new ClassMetadata($resourceClass);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string[]}
+     */
+    protected function addJoinsForNestedProperty(string $property, string $rootAlias, QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, string $joinType): array
+    {
+        $propertyParts = $this->splitPropertyParts($property, $resourceClass);
+        $parentAlias = $rootAlias;
+        $alias = null;
+
+        foreach ($propertyParts['associations'] as $association) {
+            $alias = QueryBuilderHelper::addJoinOnce($queryBuilder, $queryNameGenerator, $parentAlias, $association, $joinType);
+            $parentAlias = $alias;
+        }
+
+        if (null === $alias) {
+            throw new InvalidArgumentException(\sprintf('Cannot add joins for property "%s" - property is not nested.', $property));
+        }
+
+        return [$alias, $propertyParts['field'], $propertyParts['associations']];
     }
 
     /**
@@ -136,6 +251,7 @@ final class ExistsFilter extends AbstractFilter implements ExistsFilterInterface
      */
     public function apply(QueryBuilder $queryBuilder, QueryNameGeneratorInterface $queryNameGenerator, string $resourceClass, ?Operation $operation = null, array $context = []): void
     {
+        $this->entityManager = $queryBuilder->getEntityManager();
         $parameter = $context['parameter'] ?? null;
         $propertyKey = $parameter?->getProperty();
 

--- a/src/Doctrine/Orm/Filter/RangeFilter.php
+++ b/src/Doctrine/Orm/Filter/RangeFilter.php
@@ -109,7 +109,7 @@ use Doctrine\ORM\QueryBuilder;
  *
  * @author Lee Siong Chan <ahlee2326@me.com>
  *
- * @deprecated since API Platform 4.4: extending {@see AbstractFilter} is deprecated. In 5.0 this filter is rewritten as a standalone overlay over {@see ComparisonFilter} (translating `[between]=X..Y` to `[gte]=X` + `[lte]=Y`, passing through `[gt]`/`[gte]`/`[lt]`/`[lte]`) — same class name, same URL syntax, drop-in. Declare it through a QueryParameter to migrate.
+ * @deprecated since API Platform 4.4: use {@see ComparisonFilter} instead, which now covers the full range syntax (`[gt]`/`[gte]`/`[lt]`/`[lte]` and `[between]=X..Y`). This filter is removed in 6.0; the upgrade codemod rewrites it to a QueryParameter declared with `ComparisonFilter`.
  */
 final class RangeFilter extends AbstractFilter implements RangeFilterInterface, OpenApiParameterFilterInterface
 {

--- a/tests/Fixtures/TestBundle/Document/FilteredRangeParameter.php
+++ b/tests/Fixtures/TestBundle/Document/FilteredRangeParameter.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
 
-use ApiPlatform\Doctrine\Odm\Filter\RangeFilter;
+use ApiPlatform\Doctrine\Odm\Filter\ComparisonFilter;
+use ApiPlatform\Doctrine\Odm\Filter\ExactFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
@@ -25,11 +26,11 @@ use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
     paginationItemsPerPage: 5,
     parameters: [
         'quantity' => new QueryParameter(
-            filter: new RangeFilter(),
+            filter: new ComparisonFilter(new ExactFilter()),
             openApi: new Parameter('quantity', 'query', allowEmptyValue: true)
         ),
         'amount' => new QueryParameter(
-            filter: new RangeFilter(),
+            filter: new ComparisonFilter(new ExactFilter()),
             property: 'quantity',
             openApi: new Parameter('amount', 'query', allowEmptyValue: true)
         ),

--- a/tests/Fixtures/TestBundle/Entity/FilteredRangeParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/FilteredRangeParameter.php
@@ -13,7 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 
-use ApiPlatform\Doctrine\Orm\Filter\RangeFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ComparisonFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
@@ -25,11 +26,11 @@ use Doctrine\ORM\Mapping as ORM;
     paginationItemsPerPage: 5,
     parameters: [
         'quantity' => new QueryParameter(
-            filter: new RangeFilter(),
+            filter: new ComparisonFilter(new ExactFilter()),
             openApi: new Parameter('quantity', 'query', allowEmptyValue: true)
         ),
         'amount' => new QueryParameter(
-            filter: new RangeFilter(),
+            filter: new ComparisonFilter(new ExactFilter()),
             property: 'quantity',
             openApi: new Parameter('amount', 'query', allowEmptyValue: true)
         ),

--- a/tests/Functional/Parameters/DateFilterTest.php
+++ b/tests/Functional/Parameters/DateFilterTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Functional\Parameters;
 
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredDateParameter as FilteredDateParameterDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredDateParameter;
@@ -34,6 +36,15 @@ final class DateFilterTest extends ApiTestCase
     public static function getResources(): array
     {
         return [FilteredDateParameter::class];
+    }
+
+    public function testDateFilterIsStandalone(): void
+    {
+        self::assertNotContains(
+            AbstractFilter::class,
+            class_parents(DateFilter::class) ?: [],
+            'DateFilter must not extend the deprecated AbstractFilter (5.0 standalone rewrite).'
+        );
     }
 
     /**

--- a/tests/Functional/Parameters/ExistsFilterTest.php
+++ b/tests/Functional/Parameters/ExistsFilterTest.php
@@ -54,8 +54,9 @@ final class ExistsFilterTest extends ApiTestCase
 
     public function testExistsFilterIsStandalone(): void
     {
-        self::assertFalse(
-            is_subclass_of(ExistsFilter::class, AbstractFilter::class),
+        self::assertNotContains(
+            AbstractFilter::class,
+            class_parents(ExistsFilter::class) ?: [],
             'ExistsFilter must not extend the deprecated AbstractFilter (5.0 standalone rewrite).'
         );
     }

--- a/tests/Functional/Parameters/ExistsFilterTest.php
+++ b/tests/Functional/Parameters/ExistsFilterTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Tests\Functional\Parameters;
 
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExistsFilter;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\FilteredExistsParameter as FilteredExistsParameterDocument;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilteredExistsParameter;
@@ -48,6 +50,14 @@ final class ExistsFilterTest extends ApiTestCase
 
         $this->recreateSchema([$entityClass]);
         $this->loadFixtures($entityClass);
+    }
+
+    public function testExistsFilterIsStandalone(): void
+    {
+        self::assertFalse(
+            is_subclass_of(ExistsFilter::class, AbstractFilter::class),
+            'ExistsFilter must not extend the deprecated AbstractFilter (5.0 standalone rewrite).'
+        );
     }
 
     #[DataProvider('existsFilterScenariosProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main (5.0)
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Targets 5.0. Completes the standalone-filter work: the three filters that still extended the deprecated `AbstractFilter` are decoupled from it, and `RangeFilter` is folded into `ComparisonFilter`.

### `ExistsFilter` standalone (ORM + ODM)

Both stop extending `AbstractFilter`. The inherited helpers (constructor, property accessors, `isPropertyEnabled`, name-converter handling, logger) are inlined. `apply()` still reads its value from `$context['filters']`, so the legacy declaration paths (`Operation::$filters` services, `#[ApiFilter]`) — which never produce a `Parameter` — keep working until 6.0. The ORM filter reads class metadata from `$queryBuilder->getEntityManager()` instead of the injected `ManagerRegistry`; ODM keeps the registry since its aggregation `Builder` exposes no `DocumentManager`. `ManagerRegistryAwareInterface` is retained for BC injection and the deprecated `getDescription()`.

### `ComparisonFilter` gains `[between]`, `RangeFilter` deprecated

`ComparisonFilter` now parses `[between]=X..Y` alongside `gt/gte/lt/lte/ne`, emitting a single `BETWEEN` clause on ORM (`X..X` collapses to `=`) and the native `gte`/`lte` pair on ODM. `ExactFilter` gains the matching `BETWEEN` branch on the ORM path; it only fires for the `between` operator, leaving normal usage untouched.

This gives `ComparisonFilter` full parity with `RangeFilter`, whose operators are now a strict subset. `RangeFilter` is therefore deprecated (removed in 6.0; codemod rewrites it to `ComparisonFilter`). The `[between]` URL syntax is preserved, so there is **no consumer-facing breaking change** to the query API.

### `DateFilter` standalone (ORM + ODM)

The last of the three survivors stops extending `AbstractFilter`. It stays a genuine survivor rather than a `ComparisonFilter` overlay: its date semantics — `isDateField`, `\DateTime`/`\DateTimeImmutable` coercion by column immutability, typed `setParameter`, and `INCLUDE_NULL_*` null-management — are not expressible through `ComparisonFilter`. The `AbstractFilter::apply()` loop is reintroduced locally (driving `filterProperty` over `$context['filters']`), and the inherited helpers are inlined as above.

### Tests

ORM functional suites green locally (`ExistsFilterTest`, `DateFilterTest`, `ComparisonFilterTest`, `RangeFilterTest` — 102 tests). ODM covered by CI.
