### PR TITLE
fix(serializer): preserve deserialization path and expected type on IRI type-confusion guard

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -773,7 +773,7 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 : is_a($item, $resourceClass);
 
             if (!$matchesType) {
-                throw new NotNormalizableValueException(\sprintf('The iri "%s" does not reference the correct resource.', $data));
+                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Invalid IRI "%s".', $data), $data, [$resourceClass], $context['deserialization_path'] ?? null, true);
             }
 
             return $item;

--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -773,7 +773,26 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 : is_a($item, $resourceClass);
 
             if (!$matchesType) {
-                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Invalid IRI "%s".', $data), $data, [$resourceClass], $context['deserialization_path'] ?? null, true);
+                // Keep this a NotNormalizableValueException so union/intersection denormalization can fall
+                // through to the next member (see testUnionType*), but build it through the factory so the
+                // deserialization path and expected type are preserved on the resulting violation. For a
+                // union/intersection relation, report every accepted class rather than only the one currently
+                // being attempted.
+                $expectedTypes = [$resourceClass];
+                if ($relationType instanceof Type) {
+                    $classNames = [];
+                    foreach ($relationType instanceof CompositeTypeInterface ? $relationType->getTypes() : [$relationType] as $relationMember) {
+                        if ($relationMember instanceof ObjectType) {
+                            $classNames[] = $relationMember->getClassName();
+                        }
+                    }
+
+                    if ($classNames) {
+                        $expectedTypes = $classNames;
+                    }
+                }
+
+                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Invalid IRI "%s".', $data), $data, $expectedTypes, $context['deserialization_path'] ?? null, true);
             }
 
             return $item;

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1364,6 +1364,41 @@ class AbstractItemNormalizerTest extends TestCase
         }
     }
 
+    public function testTypeConfusionGuardReportsAllUnionMemberTypes(): void
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+
+        // The IRI resolves to a Dummy while the relation is declared as RelatedDummy|SecuredDummy.
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getResourceFromIri(Argument::cetera())->willReturn(new Dummy());
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+
+        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        try {
+            $normalizer->denormalize('/dummies/1', RelatedDummy::class, null, [
+                'not_normalizable_value_exceptions' => [],
+                'deserialization_path' => 'relation',
+                'relation_native_type' => Type::union(Type::object(RelatedDummy::class), Type::object(SecuredDummy::class)),
+            ]);
+            $this->fail('Expected a NotNormalizableValueException to be thrown.');
+        } catch (NotNormalizableValueException $exception) {
+            // A union relation must report every accepted class, not just the first one attempted.
+            $this->assertSame([RelatedDummy::class, SecuredDummy::class], $exception->getExpectedTypes());
+        }
+    }
+
     public function testDenormalizeRelationNotFoundReturnsNull(): void
     {
         $data = [

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1329,6 +1329,41 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $actual);
     }
 
+    public function testTypeConfusionGuardPreservesPathAndExpectedType(): void
+    {
+        $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
+
+        $propertyMetadataFactoryProphecy = $this->prophesize(PropertyMetadataFactoryInterface::class);
+
+        // The IRI resolves to a Dummy while a RelatedDummy is expected: the type-confusion guard must reject it.
+        $iriConverterProphecy = $this->prophesize(IriConverterInterface::class);
+        $iriConverterProphecy->getResourceFromIri(Argument::cetera())->willReturn(new Dummy());
+
+        $resourceClassResolverProphecy = $this->prophesize(ResourceClassResolverInterface::class);
+        $resourceClassResolverProphecy->getResourceClass(null, RelatedDummy::class)->willReturn(RelatedDummy::class);
+        $resourceClassResolverProphecy->isResourceClass(RelatedDummy::class)->willReturn(true);
+
+        $propertyAccessorProphecy = $this->prophesize(PropertyAccessorInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+
+        $normalizer = new class($propertyNameCollectionFactoryProphecy->reveal(), $propertyMetadataFactoryProphecy->reveal(), $iriConverterProphecy->reveal(), $resourceClassResolverProphecy->reveal(), $propertyAccessorProphecy->reveal(), null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        try {
+            $normalizer->denormalize('/dummies/1', RelatedDummy::class, null, [
+                'not_normalizable_value_exceptions' => [],
+                'deserialization_path' => 'relatedDummy',
+            ]);
+            $this->fail('Expected a NotNormalizableValueException to be thrown.');
+        } catch (NotNormalizableValueException $exception) {
+            $this->assertSame('Invalid IRI "/dummies/1".', $exception->getMessage());
+            $this->assertSame('relatedDummy', $exception->getPath());
+            $this->assertSame([RelatedDummy::class], $exception->getExpectedTypes());
+        }
+    }
+
     public function testDenormalizeRelationNotFoundReturnsNull(): void
     {
         $data = [


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Tickets       | Closes #8352 |
| License       | MIT |

## Problem

The type-confusion guard in `AbstractItemNormalizer::getResourceFromIri()` throws a bare `NotNormalizableValueException`, which carries neither the deserialization path nor the expected type:

```php
if (!$matchesType) {
    throw new NotNormalizableValueException(\sprintf('The iri "%s" does not reference the correct resource.', $data));
}
```

When `COLLECT_DENORMALIZATION_ERRORS` is enabled (the default for `DeserializeProvider`), `DeserializeProvider::createViolationFromException()` then builds a `ConstraintViolation` with an **empty property path** and an **empty expected type**, so the user-facing violation degrades to `This value should be of type .` with no property name.

Before #8333 the guard threw an `InvalidArgumentException`, which was caught a few lines below and re-thrown via `NotNormalizableValueException::createForUnexpectedDataType(...)` — preserving both the path and the expected type. #8333 changed the throw to a `NotNormalizableValueException` (so union/intersection denormalization can fall through to the next member) but stopped going through the factory, dropping that metadata for the single-type case. This is a regression vs 4.3.13.

POST a valid IRI that points to a resource of the wrong type for a relation:

```
POST /books
{ "title": "t", "printingHouse": "/publishing-houses/1" }
```

- 4.3.13: `propertyPath: "printingHouse"`, `Invalid IRI "/publishing-houses/1".`
- 4.3.14: `propertyPath: ""`, `This value should be of type .`

## Fix

Keep the exception a `NotNormalizableValueException` (so the union/intersection fallback from #8333 / #8339 still works), but build it through `createForUnexpectedDataType()` so the deserialization path and expected type are preserved on the resulting violation.

## Tests

- Unit: `AbstractItemNormalizerTest::testTypeConfusionGuardPreservesPathAndExpectedType` — denormalizes a wrong-type IRI and asserts the thrown `NotNormalizableValueException` keeps its message, path and expected type. Full `AbstractItemNormalizerTest` suite green (46 tests), including the `testUnionType*` fallback tests from #8333 / #8339.

> Note: the functional harness wouldn't boot in my local sandbox (kernel warmup fails on an unrelated `mcp` config in the fixture app). The unit test covers the precise denormalization path; CI validates the functional suite.
