### PR TITLE
test(serializer): skip union-collection IRI test on legacy property-info

### DIFF
--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1287,6 +1287,12 @@ class AbstractItemNormalizerTest extends TestCase
 
     public function testUnionTypeCollectionDenormalizationAcceptsAnyMember(): void
     {
+        // The union-collection IRI guard relies on the native type; the legacy
+        // property-info path (< 7.1) only keeps the first collection value type.
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
+        }
+
         $data = ['attachments' => ['/related_dummies/1']];
         $relatedDummy = new RelatedDummy();
 


### PR DESCRIPTION
## Problem

The `api-platform/serializer` **lowest** CI job fails on `AbstractItemNormalizerTest::testUnionTypeCollectionDenormalizationAcceptsAnyMember`:

```
Symfony\Component\Serializer\Exception\NotNormalizableValueException:
The iri "/related_dummies/1" does not reference the correct resource.
AbstractItemNormalizer.php:776
```

## Root cause

The lowest install pulls **symfony/property-info 6.4.0** (and type-info 7.3.0). property-info < 7.1 has no `PropertyInfoExtractor::getType()`, so `AbstractItemNormalizer` takes the legacy `getBuiltinTypes()` path (`:1186`). That path:

- reads collection value types via `getCollectionValueTypes()[0]` — keeping **only the first** member (`Dummy`);
- never sets `relation_native_type`, because the legacy `PropertyInfo\Type` is not a `TypeInfo\Type` (`:1239-1240`).

`getResourceFromIri` then falls back to the single-class check `is_a($item, $resourceClass)` = `is_a(RelatedDummy, Dummy)` = `false` and throws.

The union-collection IRI guard relies on native types; it has **no legacy equivalent**. type-info version is not involved (verified: 7.3.0 `isSatisfiedBy` on the union returns `true`).

## Fix

Skip the test on the legacy property-info path, matching the existing `method_exists(PropertyInfoExtractor::class, 'getType')` branching already used in this file.

## Verification

Reproduced the exact CI lowest install (`cd src/Serializer && composer update --prefer-lowest --prefer-source`):

- lowest env → test skipped; full serializer suite: **107 tests, 0 errors, 3 skipped** (was 1 error);
- high env → test passes (5 assertions).