### PR TITLE
test(functional): skip union-collection IRI test on legacy property-info

### DIFF
--- a/tests/Functional/UnionIriCollectionTest.php
+++ b/tests/Functional/UnionIriCollectionTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Bar;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Container;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Foo;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 
 final class UnionIriCollectionTest extends ApiTestCase
 {
@@ -35,6 +36,12 @@ final class UnionIriCollectionTest extends ApiTestCase
 
     public function testDenormalizeCollectionAcceptsIriOfEachUnionMember(): void
     {
+        // The union-collection IRI guard relies on the native type; the legacy
+        // property-info path (< 7.1) only keeps the first collection value type.
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
+        }
+
         $response = self::createClient()->request('POST', '/union_iri_collection_containers', [
             'headers' => ['Content-Type' => 'application/ld+json', 'Accept' => 'application/ld+json'],
             'json' => ['attachments' => ['/union_iri_collection_foos/1', '/union_iri_collection_bars/2']],


### PR DESCRIPTION
## Problem

The **Symfony lowest** CI job fails on `tests/Functional/UnionIriCollectionTest::testDenormalizeCollectionAcceptsIriOfEachUnionMember` — the POST returns **400** instead of **201**:

```
The iri "/union_iri_collection_bars/2" does not reference the correct resource.
```

## Root cause

The Symfony lowest job downgrades **symfony/property-info to 6.4.31**, which has no `PropertyInfoExtractor::getType()`. `AbstractItemNormalizer` then takes the legacy `getBuiltinTypes()` path:

- reads collection value types via `getCollectionValueTypes()[0]` — keeping only the **first** union member;
- never sets `relation_native_type` (legacy `PropertyInfo\Type` is not a `TypeInfo\Type`).

`getResourceFromIri` then falls back to the single-class `is_a()` check and rejects the second union member, so denormalization fails.

This is the same root cause as #8355, surfaced end-to-end through the functional suite. The union-collection IRI feature relies on native types and has **no legacy equivalent**.

## Fix

Skip the functional test on the legacy property-info path, mirroring the unit-level skip from #8355.

## Verification

- high env → test passes (201);
- legacy path → `method_exists(PropertyInfoExtractor::class, 'getType')` is false (verified in #8355 against property-info 6.4) → test skipped.