### PR TITLE
fix(openapi): don't apply the global name converter to the generated document

### DIFF
--- a/src/Symfony/Bundle/Resources/config/openapi.php
+++ b/src/Symfony/Bundle/Resources/config/openapi.php
@@ -29,8 +29,14 @@ use Symfony\Component\Serializer\Serializer;
 return function (ContainerConfigurator $container) {
     $services = $container->services();
 
+    // A name converter built from the class metadata factory only (no globally configured fallback),
+    // so the OpenAPI document is not run through e.g. CamelCaseToSnakeCaseNameConverter while still
+    // honoring #[SerializedName('$ref')] on Reference::getRef(). See #8306/#8360.
+    $services->set('api_platform.openapi.name_converter')
+        ->parent('serializer.name_converter.metadata_aware.abstract');
+
     $services->set('api_platform.openapi.normalizer', OpenApiNormalizer::class)
-        ->args([inline_service(Serializer::class)->arg(0, [inline_service(ObjectNormalizer::class)->arg(0, service('serializer.mapping.class_metadata_factory'))->arg(1, service('serializer.name_converter.metadata_aware'))->arg(2, service('api_platform.property_accessor'))->arg(3, service('api_platform.property_info'))])->arg(1, [service('serializer.encoder.json')])])
+        ->args([inline_service(Serializer::class)->arg(0, [inline_service(ObjectNormalizer::class)->arg(0, service('serializer.mapping.class_metadata_factory'))->arg(1, service('api_platform.openapi.name_converter'))->arg(2, service('api_platform.property_accessor'))->arg(3, service('api_platform.property_info'))])->arg(1, [service('serializer.encoder.json')])])
         ->tag('serializer.normalizer', ['priority' => -795]);
 
     $services->alias(OpenApiNormalizer::class, 'api_platform.openapi.normalizer');

--- a/src/Symfony/Bundle/Resources/config/openapi.php
+++ b/src/Symfony/Bundle/Resources/config/openapi.php
@@ -29,9 +29,6 @@ use Symfony\Component\Serializer\Serializer;
 return function (ContainerConfigurator $container) {
     $services = $container->services();
 
-    // A name converter built from the class metadata factory only (no globally configured fallback),
-    // so the OpenAPI document is not run through e.g. CamelCaseToSnakeCaseNameConverter while still
-    // honoring #[SerializedName('$ref')] on Reference::getRef(). See #8306/#8360.
     $services->set('api_platform.openapi.name_converter')
         ->parent('serializer.name_converter.metadata_aware.abstract');
 

--- a/tests/Functional/OpenApiNameConverterTest.php
+++ b/tests/Functional/OpenApiNameConverterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue8143\ReferenceResponse;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class OpenApiNameConverterAppKernel extends \AppKernel
+{
+    public function getCacheDir(): string
+    {
+        return parent::getCacheDir().'/openapi_name_converter';
+    }
+
+    public function getLogDir(): string
+    {
+        return parent::getLogDir().'/openapi_name_converter';
+    }
+
+    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    {
+        parent::configureContainer($c, $loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            $container->loadFromExtension('framework', [
+                'serializer' => [
+                    'name_converter' => 'serializer.name_converter.camel_case_to_snake_case',
+                ],
+            ]);
+        });
+    }
+}
+
+final class OpenApiNameConverterTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [ReferenceResponse::class];
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return OpenApiNameConverterAppKernel::class;
+    }
+
+    public function testGlobalNameConverterDoesNotLeakIntoOpenApiDocument(): void
+    {
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $json = $response->toArray();
+        $content = $response->getContent();
+
+        // OpenAPI keys must stay camelCase even when a global name converter is configured.
+        $this->assertStringContainsString('"operationId"', $content);
+        $this->assertStringNotContainsString('"operation_id"', $content);
+        $this->assertStringNotContainsString('"extension_properties"', $content);
+        $this->assertStringNotContainsString('"external_docs"', $content);
+        $this->assertStringNotContainsString('"request_bodies"', $content);
+        $this->assertStringNotContainsString('"security_schemes"', $content);
+
+        // The #[SerializedName('$ref')] metadata must still be honored.
+        $responses = $json['paths']['/issue8143_reference_response']['post']['responses'];
+        $this->assertArrayHasKey('$ref', $responses['401']);
+        $this->assertSame('#/components/responses/401', $responses['401']['$ref']);
+    }
+}


### PR DESCRIPTION
## Problem

#8306 fixed `Reference` serialization (`$ref`) by wiring `serializer.mapping.class_metadata_factory` and `serializer.name_converter.metadata_aware` into the OpenAPI serializer's inline `ObjectNormalizer`, so that `#[SerializedName('$ref')]` on `Reference::getRef()` is honored.

Side effect (reported by @thomas-hiron in #8306): `serializer.name_converter.metadata_aware` carries `framework.serializer.name_converter` as its **fallback** converter (see `FrameworkExtension`, which sets argument 1 of that service to the configured name converter). So a project configured with:

```yaml
framework:
    serializer:
        name_converter: serializer.name_converter.camel_case_to_snake_case
```

now gets the **whole OpenAPI document** run through that converter, producing snake_case keys: `operation_id`, `extension_properties`, `request_bodies`, `security_schemes`, `authorization_url`… which break `openapi-generator-cli`:

```
-attribute paths.'/api/article'(get).extension_properties is unexpected
```

## Fix

`Reference::getRef()`'s `#[SerializedName('$ref')]` is the only serialization metadata the OpenAPI models rely on. Use a dedicated `MetadataAwareNameConverter` built with the class metadata factory **only** (no fallback). `SerializedName` is still honored; the globally configured converter no longer leaks into the document.

## Tests

New `tests/Functional/OpenApiNameConverterTest.php` boots a kernel configuring the global `camelCase_to_snake_case` converter and asserts:
- OpenAPI keys stay camelCase (`operationId`, no `operation_id` / `extension_properties` / `request_bodies` / `security_schemes`)
- `#[SerializedName('$ref')]` still emits `$ref`

Verified failing on the buggy wiring, passing with the fix. Full `OpenApiTest` + `OpenApiNormalizerTest` suites green (28 tests, 268 assertions).
