### PR TITLE
fix(ci): link monorepo root in laravel e2e so siblings resolve from working tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1187,7 +1187,7 @@ jobs:
       - name: Install api-platform/laravel
         run: |
           composer require laravel/framework:"^13.0" --no-update
-          composer global link ../src/Laravel --permanent
+          composer global link ../ --working-directory=$(pwd) --permanent
           composer config minimum-stability dev
           composer config prefer-stable true
           composer require api-platform/laravel:"@dev" -W


### PR DESCRIPTION
## Problem

The `Laravel E2E installation` job fails on the 5.0 line with:

```
PHP Fatal error: Uncaught Error: Interface "ApiPlatform\Metadata\SortFilterInterface"
not found in src/Laravel/Eloquent/Filter/OrderFilter.php:26
```

The install resolves `api-platform/metadata` (and other siblings) to the stale stable `v4.3.15`, which predates `SortFilterInterface`.

## Root cause

The install step ran `composer global link ../src/Laravel`, pointing pmu at the **laravel subdir**. pmu discovers monorepo packages from the directory it's given, so it found **only** `api-platform/laravel` and registered a path repo for it alone.

The sibling packages had no path repo, so they resolved from packagist. pmu's `link` rewrites inter-package constraints to `@dev`, and `@dev` + `prefer-stable` makes composer pick the highest **stable** version — `v4.3.15` — which lacks `SortFilterInterface`.

`api-platform/laravel` itself came from the working tree (the failing log shows `5.0.x-dev 369bb2c`, composer's path-repo reference), which is why the runtime crash hit the working-tree `OrderFilter` against 4.3.15 metadata.

## Fix

Link the monorepo **root** instead. pmu then registers path repos for every split package, and path repositories win over packagist even under `prefer-stable`, so all `api-platform/*` resolve from the working tree while the Laravel ecosystem stays on stable releases.

```diff
- composer global link ../src/Laravel --permanent
+ composer global link ../ --working-directory=$(pwd) --permanent
```

## Verification

Reproduced both the failure and the fix locally (composer dry-run) against an untagged checkout (PR-like), confirming source resolution:

| package | before (link subdir) | after (link root) |
|---|---|---|
| api-platform/laravel | `5.0.x-dev` (working tree) | `dev-main` (working tree) |
| api-platform/metadata | **`v4.3.15`** (packagist) | `dev-main` (working tree) |
| api-platform/state | **`v4.3.15`** (packagist) | `dev-main` (working tree) |
| laravel/framework | stable | stable |

Targets `4.3` to propagate up to `4.4` and `main`. pmu needs no change — the job linked the wrong directory.