### PR TITLE
feat!: core 5.0 cleanups (getProperties interface, json:api status string)

### DIFF
--- a/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
+++ b/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
@@ -14,11 +14,7 @@ declare(strict_types=1);
 namespace ApiPlatform\Doctrine\Common\Filter;
 
 /**
- * TODO: 5.x uncomment method.
- *
  * @author Antoine Bluchet <soyuka@gmail.com>
- *
- * @method array<string>|null getProperties()
  */
 interface PropertyAwareFilterInterface
 {
@@ -27,8 +23,8 @@ interface PropertyAwareFilterInterface
      */
     public function setProperties(array $properties): void;
 
-    // /**
-    //  * @return string[]
-    //  */
-    // public function getProperties(): ?array;
+    /**
+     * @return string[]
+     */
+    public function getProperties(): ?array;
 }

--- a/src/Doctrine/Common/ParameterExtensionTrait.php
+++ b/src/Doctrine/Common/ParameterExtensionTrait.php
@@ -51,11 +51,7 @@ trait ParameterExtensionTrait
         }
 
         if ($filter instanceof PropertyAwareFilterInterface) {
-            $properties = [];
-            // Check if the filter has getProperties method (e.g., if it's an AbstractFilter)
-            if (method_exists($filter, 'getProperties')) { // @phpstan-ignore-line todo 5.x remove this check @see interface
-                $properties = $filter->getProperties() ?? [];
-            }
+            $properties = $filter->getProperties() ?? [];
 
             $propertyKey = $parameter->getProperty() ?? $parameter->getKey();
             foreach ($parameter->getProperties() ?? [$propertyKey] as $property) {

--- a/src/JsonApi/Serializer/ErrorNormalizer.php
+++ b/src/JsonApi/Serializer/ErrorNormalizer.php
@@ -45,10 +45,9 @@ final class ErrorNormalizer implements NormalizerInterface
             $error['code'] = $data->getId();
         }
 
-        // TODO: change this 5.x
-        // if (isset($error['status'])) {
-        //     $error['status'] = (string) $error['status'];
-        // }
+        if (isset($error['status'])) {
+            $error['status'] = (string) $error['status'];
+        }
 
         if (!isset($error['violations'])) {
             return ['errors' => [$error]];

--- a/src/Laravel/State/ValidateProvider.php
+++ b/src/Laravel/State/ValidateProvider.php
@@ -115,12 +115,6 @@ final class ValidateProvider implements ProviderInterface
             return $v;
         }
 
-        // hopefully this path never gets used, its there for BC-layer only
-        // TODO: remove in 5.0
-        if ($s = json_encode($body)) {
-            return json_decode($s, true);
-        }
-
         throw new RuntimeException('Could not transform the denormalized body in an array for validation');
     }
 }

--- a/src/Laravel/Tests/JsonApiTest.php
+++ b/src/Laravel/Tests/JsonApiTest.php
@@ -250,13 +250,13 @@ class JsonApiTest extends TestCase
                 [
                     'detail' => 'The prop field is required.',
                     'title' => 'Validation Error',
-                    'status' => 422,
+                    'status' => '422',
                     'code' => '58350900e0fc6b8e/prop',
                 ],
                 [
                     'detail' => 'The max field must be less than 2.',
                     'title' => 'Validation Error',
-                    'status' => 422,
+                    'status' => '422',
                     'code' => '58350900e0fc6b8e/max',
                 ],
             ],
@@ -294,7 +294,7 @@ class JsonApiTest extends TestCase
         $this->assertJsonContains([
             'links' => ['type' => '/errors/404'],
             'title' => 'An error occurred',
-            'status' => 404,
+            'status' => '404',
             'detail' => 'Not Found',
         ], $response->json()['errors'][0]);
     }

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -212,13 +212,7 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
         }
 
         if (($filter = $this->getFilterInstance($parameter->getFilter())) && $filter instanceof PropertyAwareFilterInterface) {
-            if (!method_exists($filter, 'getProperties')) { // todo 5.x remove this check
-                trigger_deprecation('api-platform/core', 'In API Platform 5.0 "%s" will implement a method named "getProperties"', PropertyAwareFilterInterface::class);
-                $refl = new \ReflectionClass($filter);
-                $filterProperties = $refl->hasProperty('properties') ? $refl->getProperty('properties')->getValue($filter) : [];
-            } else {
-                $filterProperties = array_keys($filter->getProperties() ?? []);
-            }
+            $filterProperties = array_keys($filter->getProperties() ?? []);
 
             foreach ($filterProperties as $prop) {
                 if (!\in_array($prop, $propertyNames, true)) {

--- a/tests/Functional/JsonApi/ErrorTest.php
+++ b/tests/Functional/JsonApi/ErrorTest.php
@@ -43,8 +43,7 @@ class ErrorTest extends ApiTestCase
         $this->assertJsonContains([
             'errors' => [
                 [
-                    // TODO: change this to '400' in 5.x
-                    'status' => 400,
+                    'status' => '400',
                     'detail' => 'Resource "nonexistent" not found.',
                 ],
             ],
@@ -91,7 +90,7 @@ class ErrorTest extends ApiTestCase
         $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
         $body = $response->toArray(false);
         $this->assertSame('An error occurred', $body['errors'][0]['title']);
-        $this->assertSame(400, $body['errors'][0]['status']);
+        $this->assertSame('400', $body['errors'][0]['status']);
         $this->assertArrayHasKey('detail', $body['errors'][0]);
         $this->assertArrayHasKey('type', $body['errors'][0]);
     }
@@ -110,7 +109,7 @@ class ErrorTest extends ApiTestCase
         $this->assertResponseHeaderSame('content-type', 'application/vnd.api+json; charset=utf-8');
         $body = $response->toArray(false);
         $this->assertSame('An error occurred', $body['errors'][0]['title']);
-        $this->assertSame(404, $body['errors'][0]['status']);
+        $this->assertSame('404', $body['errors'][0]['status']);
         $this->assertArrayHasKey('detail', $body['errors'][0]);
         $this->assertArrayHasKey('type', $body['errors'][0]);
     }


### PR DESCRIPTION
Removes several BC layers slated for 5.0 (TODO bucket B.2).

## Changes
- **`PropertyAwareFilterInterface`** now declares `getProperties(): ?array`. The `method_exists()` guards + reflection fallback in `ParameterResourceMetadataCollectionFactory` and `ParameterExtensionTrait` are dropped. All shipped implementers already provide it (via `PropertyAwareFilterTrait` or `AbstractFilter`); third-party implementers were warned via a 4.x deprecation.
- **JsonApi `ErrorNormalizer`** casts error `status` to a string, per the JSON:API spec. Core (`ErrorTest`) and Laravel (`JsonApiTest`) expectations updated.
- **Laravel `ValidateProvider`** drops the `json_encode`/`json_decode` BC fallback; the normalizer path is the only one.

## BC break
- `status` in JSON:API error documents is now a string (`"404"` instead of `404`).
- Custom `PropertyAwareFilterInterface` implementers must declare `getProperties()`.

| Q | A |
|---|---|
| Branch? | main |
| BC breaks? | yes (5.0) |
| Tickets | - |
| License | MIT |
| Doc PR | - |