### PR TITLE
chore(metadata): remove stale 3.0 TODO in IdentifiersExtractor

### DIFF
--- a/src/Metadata/IdentifiersExtractor.php
+++ b/src/Metadata/IdentifiersExtractor.php
@@ -177,11 +177,6 @@ final class IdentifiersExtractor implements IdentifiersExtractorInterface
         throw new RuntimeException('Not able to retrieve identifiers.');
     }
 
-    /**
-     * TODO: in 3.0 this method just uses $identifierValue instanceof \Stringable and we remove the weird behavior.
-     *
-     * @param mixed|\Stringable $identifierValue
-     */
     private function resolveIdentifierValue(mixed $identifierValue, string $parameterName): float|bool|int|string
     {
         if (null === $identifierValue) {


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | main |
| Bug fix?      | no  |
| New feature?  | no  |
| Deprecations? | no  |
| Tickets       | n/a |
| License       | MIT |

`IdentifiersExtractor::resolveIdentifierValue()` already resolves identifiers via `instanceof \Stringable` (plus scalar and `BackedEnum`). The docblock `TODO` referencing a "3.0" cleanup of "the weird behavior" is obsolete — that cleanup already happened. Removing the stale comment; no behavioral change.