### PR TITLE
docs(jsonld): drop misleading @type TODO, document intentional behavior

### DIFF
--- a/src/JsonLd/Serializer/ItemNormalizer.php
+++ b/src/JsonLd/Serializer/ItemNormalizer.php
@@ -158,12 +158,9 @@ final class ItemNormalizer extends AbstractItemNormalizer
 
         $types = $operation instanceof HttpOperation ? $operation->getTypes() : null;
         if (null === $types) {
-            // TODO: 5.x break on this as this looks wrong, CollectionReferencingItem returns an IRI that point through
-            // ItemReferencedInCollection but it returns a CollectionReferencingItem therefore we should use the current
-            // object's class Type and not rely on operation ?
             if (isset($context['item_uri_template'])) {
-                // When the operation comes from item_uri_template, use its shortName directly
-                // as $resourceClass refers to the collection resource, not the item resource
+                // The members carry the item resource's @type to match their @id, which dereferences
+                // to the item_uri_template operation rather than to the collection's own resource.
                 $types = [$operation->getShortName()];
             } else {
                 // Use resource-level shortName to avoid operation-specific overrides


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | ∅
| License       | MIT
| Doc PR        | ∅

The `// TODO: 5.x break on this...` block in `JsonLd\Serializer\ItemNormalizer::resolveType()` claimed that, for `item_uri_template` collections, the member `@type` should be derived from the object's class instead of the operation. The comment hedged itself ("this looks wrong ... ?").

After investigation the premise is wrong: members deliberately carry the **item resource's** `@type` so it matches their `@id`, which dereferences to the `item_uri_template` operation rather than to the collection's own resource. Two functional tests rely on exactly this:

- `ItemUriTemplateCollectionTest` — `RecipeCollection` (shortName `CollectionRecipe`) members expose `@type: Recipe`.
- `ItemUriTemplateHydraTest::testCollectionReferencingAnotherResource` — `CollectionReferencingItem` members expose `@type: ItemReferencedInCollection`.

Both have object class ≠ item resource, and both assert the **item operation's** shortName. PR #7764 added this branch precisely to restore that behavior. Switching to the object's class would break `RecipeCollection`.

No behavioral change: this drops the misleading TODO and replaces the inner comment with one explaining the invariant.