### PR TITLE
fix(openapi): correct parameter name when QueryParameter remaps a filter property

### DIFF
--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -346,7 +346,10 @@ final class OpenApiFactory implements OpenApiFactoryInterface
                     if ($d = $filter->getDescription($entityClass)) {
                         foreach ($d as $name => $description) {
                             if ($prop = $p->getProperty()) {
-                                $name = str_replace($prop, $key, $name);
+                                if (($description['property'] ?? null) !== $prop) {
+                                    continue;
+                                }
+                                $name = $key;
                             }
 
                             $openapiParameters[] = $this->getFilterParameter($name, $description, $operation->getShortName(), $f);

--- a/tests/Fixtures/TestBundle/Entity/ProductWithQueryParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/ProductWithQueryParameter.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
 use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
 use ApiPlatform\Doctrine\Orm\Filter\OrderFilter;
 use ApiPlatform\Doctrine\Orm\Filter\PartialSearchFilter;
+use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\QueryParameter;
@@ -23,6 +24,7 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
+#[ApiFilter(OrderFilter::class, alias: 'product_order_filter', properties: ['rating'])]
 #[ApiResource(
     operations: [
         new GetCollection(
@@ -45,6 +47,10 @@ use Doctrine\ORM\Mapping as ORM;
                 'order[:property]' => new QueryParameter(
                     filter: new OrderFilter(),
                     properties: ['rating']
+                ),
+                'order[sort_by]' => new QueryParameter(
+                    filter: 'product_order_filter',
+                    property: 'rating',
                 ),
                 'exactBrand' => new QueryParameter(
                     filter: new ExactFilter(),

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -470,4 +470,27 @@ final class DoctrineTest extends ApiTestCase
             ],
         ];
     }
+
+    public function testQueryParameterPropertyRemapOpenApiParameterName(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('Not tested with mongodb.');
+        }
+
+        $resource = ProductWithQueryParameter::class;
+        $this->recreateSchema([$resource]);
+
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $openApiDoc = $response->toArray();
+
+        $parameters = $openApiDoc['paths']['/product_with_query_parameters']['get']['parameters'];
+        $parameterNames = array_column($parameters, 'name');
+
+        $this->assertContains('order[sort_by]', $parameterNames, 'Parameter order[sort_by] should be present');
+        $this->assertNotContains('order[order[sort_by]]', $parameterNames, 'Parameter name should not be double-wrapped as order[order[sort_by]]');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | None
| License       | MIT
| Doc PR        | None

When a QueryParameter uses `property` to remap a filter's property name (e.g. `order[sort_by]` mapped to property `rating`), OpenApiFactory used `str_replace(, , )` to rewrite the filter description key. Because both the description key (`order[rating]`) and the replacement key (`order[sort_by]`) share the `order[...]` wrapper, the naive str_replace produced `order[order[sort_by]]`.

The fix is to skip filter description entries that don't match the mapped property and use the QueryParameter key directly as the parameter name.

# Workaround

Register two `#[ApiFilter]` attributes per resource:

1. One without alias — enters the operation's filter list and generates correct OpenAPI/Hydra docs via the standard path
2. One with alias — referenced by the QueryParameter for actual filter invocation

The QueryParameter sets `openApi: false` and `hydra: false` to suppress the auto-generated entries.