### PR TITLE
fix: clone Parameters before mutation in security and validator providers

### DIFF
--- a/src/State/Provider/SecurityParameterProvider.php
+++ b/src/State/Provider/SecurityParameterProvider.php
@@ -52,7 +52,8 @@ final class SecurityParameterProvider implements ProviderInterface
 
         $operation = $request?->attributes->get('_api_operation') ?? $operation;
 
-        $parameters = $operation->getParameters() ?? new Parameters();
+        $existingParameters = $operation->getParameters();
+        $parameters = $existingParameters ? clone $existingParameters : new Parameters();
 
         if ($operation instanceof HttpOperation) {
             foreach ($operation->getUriVariables() ?? [] as $key => $uriVariable) {

--- a/src/State/Tests/Provider/SecurityParameterProviderTest.php
+++ b/src/State/Tests/Provider/SecurityParameterProviderTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\State\Tests\Provider;
 
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Parameters;
 use ApiPlatform\Metadata\ResourceAccessCheckerInterface;
 use ApiPlatform\State\Provider\SecurityParameterProvider;
 use ApiPlatform\State\ProviderInterface;
@@ -28,9 +29,10 @@ final class SecurityParameterProviderTest extends TestCase
     {
         $obj = new \stdClass();
         $barObj = new \stdClass();
+        $sharedParams = new Parameters();
         $operation = new GetCollection(uriVariables: [
             'barId' => new Link(toProperty: 'bar', fromClass: 'Bar', security: 'is_granted("some_voter", "bar")'),
-        ], class: \stdClass::class);
+        ], class: \stdClass::class, parameters: $sharedParams);
         $decorated = $this->createMock(ProviderInterface::class);
         $decorated->method('provide')->willReturn($obj);
         $request = new Request(attributes: ['bar' => $barObj]);
@@ -38,6 +40,7 @@ final class SecurityParameterProviderTest extends TestCase
         $resourceAccessChecker->expects($this->once())->method('isGranted')->with('Bar', 'is_granted("some_voter", "bar")', ['object' => $obj, 'previous_object' => null, 'request' => $request, 'bar' => $barObj, 'barId' => 1, 'operation' => $operation])->willReturn(true);
         $accessChecker = new SecurityParameterProvider($decorated, $resourceAccessChecker);
         $accessChecker->provide($operation, ['barId' => 1], ['request' => $request]);
+        $this->assertCount(0, $sharedParams, 'provide() must not mutate the Parameters object stored on the cached operation');
     }
 
     public function testIsNotGrantedLink(): void

--- a/src/Symfony/Validator/State/ParameterValidatorProvider.php
+++ b/src/Symfony/Validator/State/ParameterValidatorProvider.php
@@ -52,7 +52,8 @@ final class ParameterValidatorProvider implements ProviderInterface
         }
 
         $constraintViolationList = new ConstraintViolationList();
-        $parameters = $operation->getParameters() ?? new Parameters();
+        $existingParameters = $operation->getParameters();
+        $parameters = $existingParameters ? clone $existingParameters : new Parameters();
 
         if ($operation instanceof HttpOperation) {
             foreach ($operation->getUriVariables() ?? [] as $key => $uriVariable) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | 
| License       | MIT
| Doc PR        | 

Calling $parameters->add() on the Parameters object was mutating shared state. In long-running processes this caused uri-variable Links added at request time to leak into subsequent metadata reads, producing a phantom in:query parameter in the OpenAPI output in my case, resulting most obviously in flaky tests in my case
