### PR TITLE
fix(serializer): denormalize nullable collections of enums/objects

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -1299,11 +1299,19 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
                 }
             }
 
+            // A nullable collection value type (e.g. an array of a nullable BackedEnum/object) is represented
+            // as a NullableType wrapping the real ObjectType, so it must be unwrapped before the instanceof
+            // check below; nested CollectionType wrapping is left untouched to keep union/collection detection intact.
+            $unwrappedCollectionValueType = $collectionValueType;
+            while ($unwrappedCollectionValueType instanceof WrappingTypeInterface && !$unwrappedCollectionValueType instanceof CollectionType) {
+                $unwrappedCollectionValueType = $unwrappedCollectionValueType->getWrappedType();
+            }
+
             if (
-                ($t instanceof CollectionType && $collectionValueType instanceof ObjectType)
+                ($t instanceof CollectionType && $unwrappedCollectionValueType instanceof ObjectType)
                 || ($t instanceof LegacyType && $t->isCollection() && null !== $collectionValueType && null !== $collectionValueType->getClassName())
             ) {
-                $className = $collectionValueType->getClassName();
+                $className = $unwrappedCollectionValueType instanceof ObjectType ? $unwrappedCollectionValueType->getClassName() : $collectionValueType->getClassName();
                 if (!$this->serializer instanceof DenormalizerInterface) {
                     throw new LogicException(\sprintf('The injected serializer must be an instance of "%s".', DenormalizerInterface::class));
                 }

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -40,6 +40,7 @@ use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\DummyTableInheritanceRelat
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\DummyWithMultipleRequiredConstructorArgs;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\DummyWithNullableConstructorArg;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\NonCloneableDummy;
+use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\NotificationType;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\PropertyCollectionIriOnly;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\PropertyCollectionIriOnlyRelation;
 use ApiPlatform\Serializer\Tests\Fixtures\ApiResource\RelatedDummy;
@@ -1329,6 +1330,57 @@ class AbstractItemNormalizerTest extends TestCase
 
         $normalizer = new class($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, null, null, [], null, null) extends AbstractItemNormalizer {};
         $normalizer->setSerializer($serializer);
+
+        $actual = $normalizer->denormalize($data, Dummy::class);
+
+        $this->assertInstanceOf(Dummy::class, $actual);
+    }
+
+    public function testDenormalizeNullableCollectionOfBackedEnums(): void
+    {
+        // Nullable collection value types (NullableType wrapping ObjectType/BackedEnumType) only exist
+        // in the native TypeInfo system.
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
+        }
+
+        $data = ['notificationType' => ['email']];
+
+        $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection(['notificationType']));
+
+        // Mirrors what Symfony\Bridge\Doctrine\PropertyInfo\DoctrineExtractor produces for a nullable
+        // Doctrine SIMPLE_ARRAY column mapped with "enumType": both the collection and its value type
+        // end up wrapped in a NullableType.
+        $propertyMetadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->method('create')->willReturn(
+            (new ApiProperty())
+                ->withNativeType(Type::nullable(Type::list(Type::nullable(Type::enum(NotificationType::class)))))
+                ->withWritable(true)
+        );
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturnMap([
+            [Dummy::class, true],
+            [NotificationType::class, false],
+        ]);
+        $resourceClassResolver->method('getResourceClass')->willReturnMap([
+            [null, Dummy::class, Dummy::class],
+        ]);
+
+        $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
+        $propertyAccessor->expects($this->once())
+            ->method('setValue')
+            ->with($this->isInstanceOf(Dummy::class), 'notificationType', [NotificationType::Email]);
+
+        $iriConverter = $this->createStub(IriConverterInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+        $serializerProphecy->denormalize(['email'], NotificationType::class.'[]', null, Argument::type('array'))->willReturn([NotificationType::Email]);
+
+        $normalizer = new class($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializerProphecy->reveal());
 
         $actual = $normalizer->denormalize($data, Dummy::class);
 

--- a/src/Serializer/Tests/Fixtures/ApiResource/NotificationType.php
+++ b/src/Serializer/Tests/Fixtures/ApiResource/NotificationType.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\ApiResource;
+
+enum NotificationType: string
+{
+    case Email = 'email';
+    case Sms = 'sms';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fixes #8379
| License       | MIT

## Problem

Nullable arrays/collections of BackedEnums or objects fail to deserialize on POST/PATCH: the elements are left as raw strings instead of being denormalized into enum/object instances, which later triggers a Doctrine error such as:

```
Doctrine\ORM\Mapping\ReflectionEnumProperty::getValue(): Argument #1 ($item) must be of type BackedEnum, string given
```

## Root cause

Symfony's TypeInfo represents a **nullable** collection value type as a `NullableType` wrapping the real `ObjectType`/`BackedEnumType`. For a nullable Doctrine `SIMPLE_ARRAY` column mapped with `enumType`, `DoctrineExtractor` produces `list<Enum|null>|null`, i.e. the collection value type is `NullableType(ObjectType)`.

`AbstractItemNormalizer::createAndValidateAttributeValue()` checked `$collectionValueType instanceof ObjectType` directly. Since `NullableType` does not extend `ObjectType`, that check evaluated to `false`, the collection-of-objects branch was skipped, and the items were never handed off to the serializer for enum/object denormalization.

## Fix

Unwrap the collection value type through `WrappingTypeInterface` before the `instanceof ObjectType` check, mirroring the existing unwrap loop already used later in the same method for the item type. Nested `CollectionType` wrapping is deliberately left untouched so a collection-of-collections is not misdetected as a collection-of-objects.

## Tests

Added `AbstractItemNormalizerTest::testDenormalizeNullableCollectionOfBackedEnums`, which reproduces the `NullableType(ObjectType)` collection value type (as `DoctrineExtractor` emits it) and asserts the items are denormalized into enum instances. The test fails on `4.3` before the fix (items stay raw strings) and passes after.

Gates: php-cs-fixer clean, PHPStan clean on changed files, full `src/Serializer/Tests` suite green.
