### PR TITLE
fix(doctrine): use PHP property name in DQL for modern filters with name converter

### DIFF
--- a/src/Doctrine/Odm/NestedPropertyHelperTrait.php
+++ b/src/Doctrine/Odm/NestedPropertyHelperTrait.php
@@ -39,7 +39,7 @@ trait NestedPropertyHelperTrait
         $nestedInfo = ($extraProperties['nested_properties_info'] ?? []) ? reset($extraProperties['nested_properties_info']) : null;
 
         if (!$nestedInfo) {
-            return $property;
+            return $extraProperties['query_property'] ?? $property;
         }
 
         $odmSegments = $nestedInfo['odm_segments'] ?? [];

--- a/src/Doctrine/Orm/NestedPropertyHelperTrait.php
+++ b/src/Doctrine/Orm/NestedPropertyHelperTrait.php
@@ -43,7 +43,7 @@ trait NestedPropertyHelperTrait
         $nestedInfo = ($extraProperties['nested_properties_info'] ?? []) ? reset($extraProperties['nested_properties_info']) : null;
 
         if (!$nestedInfo) {
-            return [$alias, $property];
+            return [$alias, $extraProperties['query_property'] ?? $property];
         }
 
         $relationClasses = $nestedInfo['relation_classes'] ?? [];

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -405,7 +405,10 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             // Skip name conversion if we already have nested property info
             $paramExtraProps = $parameter->getExtraProperties();
             if (!isset($paramExtraProps['nested_properties_info'])) {
-                $parameter = $parameter->withProperty($this->nameConverter->normalize($property));
+                // Keep the original (non name-converted) property to build the query while the public property matches the API naming convention.
+                $parameter = $parameter
+                    ->withExtraProperties([...$paramExtraProps, 'query_property' => $property])
+                    ->withProperty($this->nameConverter->normalize($property));
             }
         }
 

--- a/tests/Fixtures/TestBundle/Document/ConvertedFilterParameter.php
+++ b/tests/Fixtures/TestBundle/Document/ConvertedFilterParameter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Document;
+
+use ApiPlatform\Doctrine\Odm\Filter\ExactFilter;
+use ApiPlatform\Doctrine\Odm\Filter\SortFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/**
+ * Tests that modern parameter filters (ExactFilter, SortFilter) work with
+ * QueryParameter on a multi-word property when a nameConverter is configured
+ * (issue #8380).
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'nameConverted' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'nameConverted',
+                ),
+                'orderNameConverted' => new QueryParameter(
+                    filter: new SortFilter(),
+                    property: 'nameConverted',
+                ),
+            ],
+        ),
+    ],
+)]
+#[ODM\Document]
+class ConvertedFilterParameter
+{
+    #[ODM\Id(strategy: 'INCREMENT', type: 'int')]
+    private ?int $id = null;
+
+    #[ODM\Field(type: 'string')]
+    public string $nameConverted = '';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/ConvertedFilterParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/ConvertedFilterParameter.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
+use ApiPlatform\Doctrine\Orm\Filter\SortFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Tests that modern parameter filters (ExactFilter, SortFilter) work with
+ * QueryParameter on a multi-word property when a nameConverter is configured
+ * (issue #8380).
+ */
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'nameConverted' => new QueryParameter(
+                    filter: new ExactFilter(),
+                    property: 'nameConverted',
+                ),
+                'orderNameConverted' => new QueryParameter(
+                    filter: new SortFilter(),
+                    property: 'nameConverted',
+                ),
+            ],
+        ),
+    ],
+)]
+#[ORM\Entity]
+class ConvertedFilterParameter
+{
+    #[ORM\Column(type: 'integer', nullable: true)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'string')]
+    public string $nameConverted = '';
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+}

--- a/tests/Functional/Parameters/NameConverterModernFilterTest.php
+++ b/tests/Functional/Parameters/NameConverterModernFilterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\ConvertedFilterParameter as ConvertedFilterParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ConvertedFilterParameter;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Tests that modern parameter filters (ExactFilter, SortFilter) work with
+ * QueryParameter on a multi-word property when a nameConverter is configured.
+ *
+ * @see https://github.com/api-platform/core/issues/8380
+ */
+final class NameConverterModernFilterTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [ConvertedFilterParameter::class];
+    }
+
+    protected function setUp(): void
+    {
+        $entityClass = $this->isMongoDB() ? ConvertedFilterParameterDocument::class : ConvertedFilterParameter::class;
+
+        $this->recreateSchema([$entityClass]);
+        $this->loadFixtures($entityClass);
+    }
+
+    public function testExactFilterWithNameConverter(): void
+    {
+        $response = self::createClient()->request('GET', '/converted_filter_parameters?nameConverted=bar');
+        $this->assertResponseIsSuccessful();
+        $members = $response->toArray()['hydra:member'];
+        $this->assertCount(1, $members);
+        $this->assertSame('bar', $members[0]['name_converted']);
+    }
+
+    public function testSortFilterWithNameConverter(): void
+    {
+        $response = self::createClient()->request('GET', '/converted_filter_parameters?orderNameConverted=desc');
+        $this->assertResponseIsSuccessful();
+        $members = $response->toArray()['hydra:member'];
+        $names = array_map(static fn (array $m): string => $m['name_converted'], $members);
+        $this->assertSame(['foo', 'baz', 'bar'], $names);
+    }
+
+    /**
+     * @param class-string $entityClass
+     */
+    private function loadFixtures(string $entityClass): void
+    {
+        $manager = $this->getManager();
+
+        foreach (['bar', 'baz', 'foo'] as $name) {
+            $entity = new $entityClass();
+            $entity->nameConverted = $name;
+            $manager->persist($entity);
+        }
+
+        $manager->flush();
+    }
+}


### PR DESCRIPTION
Fixes #8380

## Problem

Modern parameter filters (`ExactFilter`, `SortFilter`, `ComparisonFilter`, `PartialSearchFilter`) use `Parameter::getProperty()` verbatim to build the DQL/aggregation query. When an `api_platform.name_converter` (e.g. `CamelCaseToSnakeCaseNameConverter`) is configured, `ParameterResourceMetadataCollectionFactory::setDefaults()` normalizes the property (`createdAt` -> `created_at`) so the public/OpenAPI parameter name matches the API's naming convention. But Doctrine still knows the entity field by its PHP name, so every request filtering/sorting on a multi-word property fails with HTTP 500:

```
[Semantical Error] ... Class App\Entity\Book has no field or association named created_at
```

Single-word properties (`status`, `name`, ...) are unaffected because camelCase == snake_case for them, which is why the bug is easy to miss.

This is a follow-up to #7866 / #7877, which fixed the equivalent problem for the legacy `AbstractFilter`-based filters. The docs currently recommend the modern filters as the fix for the legacy filters' name-converter issues, but on this setup they fail harder (500 instead of a silently ignored filter).

## Fix

The public parameter name and the internal query field name legitimately diverge: the Hydra IRI template mapping and OpenAPI docs read `getProperty()` and must expose the converted (`created_at`) name, while the query must use the PHP field (`createdAt`).

- `ParameterResourceMetadataCollectionFactory::setDefaults()`: before normalizing, stash the original PHP property name as a `query_property` extra-property on the `Parameter` — only when a name converter runs and there is no `nested_properties_info` (nested paths already skip normalization and keep their existing handling; the no-name-converter path is untouched).
- ORM `NestedPropertyHelperTrait::addNestedParameterJoins()` and ODM `NestedPropertyHelperTrait::addNestedParameterLookups()`: on the flat (non-nested) return, prefer `$extraProperties['query_property'] ?? $property`. This is the single chokepoint every modern ORM/ODM filter routes through. `ComparisonFilter` delegates to its inner filter (e.g. `ExactFilter`), so it is covered transitively.

## Test

New functional test `NameConverterModernFilterTest` (ORM + ODM), using the test app's existing `CustomConverter` (same infra as the #7877 `NameConverterFilterTest`), with `QueryParameter(filter: new ExactFilter(), property: 'nameConverted')` and a `SortFilter` case. Verified it fails before the fix with the exact reported `has no field or association named name_converted` 500, and passes after.