### PR TITLE
fix(test): remove stale phpstan ignores in CollectionNormalizerTest

### DIFF
--- a/src/Hal/Tests/Serializer/CollectionNormalizerTest.php
+++ b/src/Hal/Tests/Serializer/CollectionNormalizerTest.php
@@ -125,8 +125,8 @@ class CollectionNormalizerTest extends TestCase
         $paginator->method('current')->willReturn('foo'); // @phpstan-ignore-line
 
         if (!$partial) {
-            $paginator->method('getLastPage')->willReturn(7.); // @phpstan-ignore-line
-            $paginator->method('getTotalItems')->willReturn(1312.); // @phpstan-ignore-line
+            $paginator->method('getLastPage')->willReturn(7.);
+            $paginator->method('getTotalItems')->willReturn(1312.);
         } else {
             $paginator->method('count')->willReturn(12);
         }


### PR DESCRIPTION
## The failure

The PHPStan CI job (PHP 8.5) on `4.3` fails:

```
src/Hal/Tests/Serializer/CollectionNormalizerTest.php
  128  No error to ignore is reported on line 128.  ignore.unmatchedLine (non-ignorable)
  129  No error to ignore is reported on line 129.  ignore.unmatchedLine (non-ignorable)
[ERROR] Found 2 errors
```

## Root cause

`composer.lock` pins `phpstan/phpstan` to `2.2.3`. That version improved conditional-type narrowing: inside the `if (!$partial)` branch of `normalizePaginator()`, PHPStan now correctly infers that `$paginator` is a `PaginatorInterface` (which declares `getLastPage()` / `getTotalItems()`), because it correlates the `$partial` bool used to select the mocked interface with the later `if (!$partial)` guard.

Earlier PHPStan (2.1.x) lost that correlation and emitted a `phpunit.mockMethod` error ("Trying to mock an undefined method getLastPage() on ... PartialPaginatorInterface"), which the `// @phpstan-ignore-line` comments on lines 128-129 suppressed.

Now that the underlying error is no longer reported, those ignores are unmatched, and `reportUnmatchedIgnoredErrors` (PHPStan default) turns them into non-ignorable hard failures.

## Fix

Remove the two stale `// @phpstan-ignore-line` comments. The code is untouched. The adjacent `valid()` / `current()` ignores just above (lines 124-125) are still matched and left in place.

Verified with PHPStan 2.2.3 (the exact locked version): `[OK] No errors`. php-cs-fixer clean.