### PR TITLE
fix(openapi): don't inherit name converter from a possibly-missing Symfony parent

### DIFF
--- a/src/Symfony/Bundle/Resources/config/openapi.php
+++ b/src/Symfony/Bundle/Resources/config/openapi.php
@@ -23,14 +23,17 @@ use ApiPlatform\OpenApi\Serializer\OpenApiNormalizer;
 use ApiPlatform\OpenApi\Serializer\SerializerContextBuilder;
 use ApiPlatform\OpenApi\State\OpenApiProvider;
 use ApiPlatform\Serializer\JsonEncoder;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
 
 return function (ContainerConfigurator $container) {
     $services = $container->services();
 
-    $services->set('api_platform.openapi.name_converter')
-        ->parent('serializer.name_converter.metadata_aware.abstract');
+    // A metadata-aware name converter isolated from Symfony's global one so the generated
+    // document only honors serializer metadata (e.g. #[SerializedName]) without the global name converter.
+    $services->set('api_platform.openapi.name_converter', MetadataAwareNameConverter::class)
+        ->args([service('serializer.mapping.class_metadata_factory')]);
 
     $services->set('api_platform.openapi.normalizer', OpenApiNormalizer::class)
         ->args([inline_service(Serializer::class)->arg(0, [inline_service(ObjectNormalizer::class)->arg(0, service('serializer.mapping.class_metadata_factory'))->arg(1, service('api_platform.openapi.name_converter'))->arg(2, service('api_platform.property_accessor'))->arg(3, service('api_platform.property_info'))])->arg(1, [service('serializer.encoder.json')])])

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -32,9 +32,11 @@ use Doctrine\ORM\OptimisticLockException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 
 class ApiPlatformExtensionTest extends TestCase
 {
@@ -299,6 +301,19 @@ class ApiPlatformExtensionTest extends TestCase
         ];
 
         $this->assertContainerHas($services);
+    }
+
+    public function testOpenApiNameConverterDoesNotDependOnMissingSymfonyParent(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['enable_swagger'] = true;
+
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $definition = $this->container->getDefinition('api_platform.openapi.name_converter');
+
+        $this->assertNotInstanceOf(ChildDefinition::class, $definition, 'The OpenAPI name converter must not depend on Symfony\'s "serializer.name_converter.metadata_aware.abstract" parent, which does not exist when no name converter is configured.');
+        $this->assertSame(MetadataAwareNameConverter::class, $definition->getClass());
     }
 
     public function testReDocEnabledWithSwaggerUiDisabledConfiguration(): void


### PR DESCRIPTION
| Q             | A
|-------------- | ---
| Branch?       | 4.3
| Tickets       | Fixes #8385
| License       | MIT
| Doc PR        | N/A

#8360 defined `api_platform.openapi.name_converter` as a child of Symfony's `serializer.name_converter.metadata_aware.abstract`. That abstract parent does not exist when no name converter is configured, so the container fails to compile:

```
Service "api_platform.openapi.name_converter": Parent definition "serializer.name_converter.metadata_aware.abstract" does not exist.
```

Define the service directly as a `MetadataAwareNameConverter` with only the class metadata factory, keeping the same intent as #8360 (metadata-aware, isolated from the global name converter) without depending on an internal, version-dependent Symfony abstract definition.

Added a DI extension test asserting the service is a concrete `MetadataAwareNameConverter` definition and not a child of the missing parent.