### PR TITLE
fix(serializer): preserve denormalization errors for nullable object properties

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -51,6 +51,7 @@ use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\CompositeTypeInterface;
+use Symfony\Component\TypeInfo\Type\EnumType;
 use Symfony\Component\TypeInfo\Type\NullableType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
@@ -1445,6 +1446,32 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
 
         if ($denormalizationException) {
             if ($type instanceof Type && $type->isSatisfiedBy(static fn ($type) => $type instanceof BuiltinType) && !$type->isSatisfiedBy($typeIsResourceClass)) {
+                // When the union contains an object member that is not a resource class (e.g. a nullable
+                // Uuid), the exception stashed while denormalizing it comes from its dedicated normalizer
+                // and carries the expected types actually accepted on the wire (e.g. ["string"]) plus a
+                // hint that is safe to expose to the user. Rebuilding the error from the PHP type union
+                // would report unactionable expected types such as "Uuid|null" instead, so re-throw it,
+                // only extending its expected types with "null" when the property also accepts null.
+                // Enum members are deliberately not re-thrown here: their violations are rendered from
+                // the rebuilt exception below, whose expected types are mapped to the enum backing type
+                // downstream (see DeserializeProvider).
+                foreach ($types as $memberType) {
+                    while ($memberType instanceof WrappingTypeInterface && !$memberType instanceof CollectionType) {
+                        $memberType = $memberType->getWrappedType();
+                    }
+
+                    if (!$memberType instanceof ObjectType || $memberType instanceof EnumType || $this->resourceClassResolver->isResourceClass($memberType->getClassName())) {
+                        continue;
+                    }
+
+                    $expectedTypes = $denormalizationException->getExpectedTypes();
+                    if ($type->isNullable() && $expectedTypes && !\in_array('null', $expectedTypes, true)) {
+                        throw NotNormalizableValueException::createForUnexpectedDataType($denormalizationException->getMessage(), $value, [...$expectedTypes, 'null'], $denormalizationException->getPath() ?? $context['deserialization_path'] ?? null, $denormalizationException->canUseMessageForUser(), $denormalizationException->getCode(), $denormalizationException);
+                    }
+
+                    throw $denormalizationException;
+                }
+
                 // If the exception came from object denormalization (e.g. BackedEnumNormalizer for a
                 // nullable backed enum), preserve its more specific message and its user-facing hint flag;
                 // the expected types still carry the object/enum class so the failure stays recognizable

--- a/src/Serializer/Tests/AbstractItemNormalizerTest.php
+++ b/src/Serializer/Tests/AbstractItemNormalizerTest.php
@@ -1387,6 +1387,84 @@ class AbstractItemNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $actual);
     }
 
+    public function testDenormalizeWrongTypedValueForNullableObjectPropertyPreservesNormalizerException(): void
+    {
+        // Nullable object types (NullableType wrapping ObjectType) only exist in the native TypeInfo system.
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
+        }
+
+        // What Symfony's DateTimeNormalizer throws for a value it cannot parse.
+        $normalizerException = NotNormalizableValueException::createForUnexpectedDataType('The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.', false, ['string'], 'dummyDate', true);
+
+        $normalizer = $this->createNormalizerForObjectProperty('dummyDate', Type::nullable(Type::object(\DateTimeImmutable::class)), \DateTimeImmutable::class, $normalizerException);
+
+        try {
+            $normalizer->denormalize(['dummyDate' => false], Dummy::class);
+            $this->fail('Expected a NotNormalizableValueException to be thrown.');
+        } catch (NotNormalizableValueException $exception) {
+            $this->assertSame(['string', 'null'], $exception->getExpectedTypes());
+            $this->assertTrue($exception->canUseMessageForUser());
+            $this->assertSame($normalizerException->getMessage(), $exception->getMessage());
+            $this->assertSame('dummyDate', $exception->getPath());
+        }
+    }
+
+    public function testDenormalizeWrongTypedValueForNonNullableObjectPropertyPreservesNormalizerException(): void
+    {
+        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
+            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
+        }
+
+        $normalizerException = NotNormalizableValueException::createForUnexpectedDataType('The data is either not an string, an empty string, or null; you should pass a string that can be parsed with the passed format or a valid DateTime string.', false, ['string'], 'dummyDate', true);
+
+        $normalizer = $this->createNormalizerForObjectProperty('dummyDate', Type::object(\DateTimeImmutable::class), \DateTimeImmutable::class, $normalizerException);
+
+        try {
+            $normalizer->denormalize(['dummyDate' => false], Dummy::class);
+            $this->fail('Expected a NotNormalizableValueException to be thrown.');
+        } catch (NotNormalizableValueException $exception) {
+            $this->assertSame(['string'], $exception->getExpectedTypes());
+            $this->assertTrue($exception->canUseMessageForUser());
+            $this->assertSame($normalizerException->getMessage(), $exception->getMessage());
+            $this->assertSame('dummyDate', $exception->getPath());
+        }
+    }
+
+    private function createNormalizerForObjectProperty(string $attribute, Type $nativeType, string $className, NotNormalizableValueException $normalizerException): AbstractItemNormalizer
+    {
+        $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection([$attribute]));
+
+        $propertyMetadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->method('create')->willReturn(
+            (new ApiProperty())
+                ->withNativeType($nativeType)
+                ->withWritable(true)
+        );
+
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturnMap([
+            [Dummy::class, true],
+            [$className, false],
+        ]);
+        $resourceClassResolver->method('getResourceClass')->willReturnMap([
+            [null, Dummy::class, Dummy::class],
+        ]);
+
+        $propertyAccessor = $this->createStub(PropertyAccessorInterface::class);
+        $iriConverter = $this->createStub(IriConverterInterface::class);
+
+        $serializerProphecy = $this->prophesize(SerializerInterface::class);
+        $serializerProphecy->willImplement(DenormalizerInterface::class);
+        $serializerProphecy->denormalize(false, $className, null, Argument::type('array'))->willThrow($normalizerException);
+
+        $normalizer = new class($propertyNameCollectionFactory, $propertyMetadataFactory, $iriConverter, $resourceClassResolver, $propertyAccessor, null, null, [], null, null) extends AbstractItemNormalizer {};
+        $normalizer->setSerializer($serializerProphecy->reveal());
+
+        return $normalizer;
+    }
+
     public function testTypeConfusionGuardPreservesPathAndExpectedType(): void
     {
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -119,8 +119,10 @@ final class ValidationTest extends ApiTestCase
         if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
             $this->assertSame('This value should be of type uuid.', $violationUuid['message']);
         } else {
-            $this->assertSame('This value should be of type UuidInterface|null.', $violationUuid['message']);
+            $this->assertSame('This value should be of type uuid|null.', $violationUuid['message']);
         }
+        $this->assertArrayHasKey('hint', $violationUuid);
+        $this->assertSame('Invalid UUID string: y', $violationUuid['hint']);
 
         $violationRelatedDummy = $findViolation('relatedDummy');
         $this->assertNotNull($violationRelatedDummy);


### PR DESCRIPTION
Fixes #8392.

Built on top of #8389, whose commit is included in this branch; **only the last commit is new here**. I will rebase once #8389 merges. Related to #8388 (the backed enum flavor of the same regression, fixed by #8389); this PR covers the remaining nullable object types.

## Description

When a value of the wrong type is sent for a **nullable** object typed property (`?Uuid`, `?Ulid`, `?DateTimeImmutable`, `?DateInterval`, `?UuidInterface`, `?\BcMath\Number`, ...), the 422 violation collected with `collectDenormalizationErrors: true` reports the property's PHP type union as the expected type, with no hint:

```json
{ "propertyPath": "ulid", "message": "This value should be of type Ulid|null." }
```

`Ulid|null` is the internal PHP type: it appears nowhere in the JSON Schema / OpenAPI output (which documents `string` plus a `format`), it cannot be sent over JSON, and it does not tell the consumer what to send.

The trigger is nullability alone. The non-nullable version of the same property yields the correct error from the dedicated normalizer (`This value should be of type string.` plus a hint), and 4.1.x produced the correct message for nullable properties too; this is a regression from the TypeInfo migration (#6979).

## Root cause

In `AbstractItemNormalizer::createAndValidateAttributeValue()`, a nullable property type is a composite (`NullableType`), so the `NotNormalizableValueException` thrown by the dedicated normalizer (`UidNormalizer`, `DateTimeNormalizer`, `DateIntervalNormalizer`, API Platform's Ramsey `UuidDenormalizer`, ...) is stashed while the remaining union members are tried. Once they all fail, the error is rebuilt with `expectedTypes = array_map(strval(...), $types)`, the stringified PHP union members. `DeserializeProvider::createViolationFromException()` renders the violation message from `getExpectedTypes()` and only surfaces the exception message as the `hint`, so the normalizer's accurate expected types (e.g. `["string"]`) are lost, and the rebuild also passes `false` for `useMessageForUser`, so the hint disappears as well. Fixing only the message string would change nothing visible.

For a non-nullable property the union has a single member and the same exception is re-thrown unchanged, which is why nullability alone flips the result.

## Change

When the union contains an object member that is neither a resource class nor an enum, re-throw the stashed normalizer exception with its expected types, message, hint and `canUseMessageForUser()` intact, extending the expected types with `null` when the property also accepts null:

| property | before | after |
| --- | --- | --- |
| `?Ulid` / `?DateTimeImmutable` | `This value should be of type Ulid\|null.` (no hint) | `This value should be of type string\|null.` plus the normalizer hint |
| `?UuidInterface` (ramsey/uuid) | `This value should be of type UuidInterface\|null.` (no hint) | `This value should be of type uuid\|null.` plus hint `Invalid UUID string: y` |

The label comes from whatever the dedicated normalizer reports as its accepted input types, matching the 4.1.x output extended with `null`. (For Ramsey UUIDs that label is `uuid`, a preexisting choice of `UuidDenormalizer` also visible on non-nullable properties; aligning it with the schema type `string` would be a separate change.)

Enum members are deliberately excluded from the re-throw: their violations keep flowing through the rebuilt exception that #8389 renders via the enum backing type, and #8389's `EnumDenormalizationValidationTest` passes on top of this change. Pure scalar unions (`?string`, `?int`, ...) and resource relations are untouched.

## Tests

- Unit: nullable and non-nullable `?DateTimeImmutable` parity tests asserting the surfaced exception keeps the normalizer's expected types (plus `null` for the nullable case), message, hint flag and path.
- Functional: `ValidationTest` now asserts `This value should be of type uuid|null.` plus the `Invalid UUID string: y` hint on the native TypeInfo path; the legacy property-info path keeps `This value should be of type uuid.`.
