### PR TITLE
chore: remove @experimental from stabilized APIs

### DIFF
--- a/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
+++ b/src/Doctrine/Common/Filter/PropertyAwareFilterInterface.php
@@ -19,8 +19,6 @@ namespace ApiPlatform\Doctrine\Common\Filter;
  * @author Antoine Bluchet <soyuka@gmail.com>
  *
  * @method array<string>|null getProperties()
- *
- * @experimental
  */
 interface PropertyAwareFilterInterface
 {

--- a/src/Elasticsearch/Exception/IndexNotFoundException.php
+++ b/src/Elasticsearch/Exception/IndexNotFoundException.php
@@ -16,8 +16,6 @@ namespace ApiPlatform\Elasticsearch\Exception;
 /**
  * Index not found exception.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class IndexNotFoundException extends \Exception implements ExceptionInterface

--- a/src/Elasticsearch/Exception/NonUniqueIdentifierException.php
+++ b/src/Elasticsearch/Exception/NonUniqueIdentifierException.php
@@ -16,8 +16,6 @@ namespace ApiPlatform\Elasticsearch\Exception;
 /**
  * Non unique identifier exception.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class NonUniqueIdentifierException extends \Exception implements ExceptionInterface

--- a/src/Elasticsearch/Extension/AbstractFilterExtension.php
+++ b/src/Elasticsearch/Extension/AbstractFilterExtension.php
@@ -19,8 +19,6 @@ use Psr\Container\ContainerInterface;
 /**
  * Abstract class for easing the implementation of a filter extension.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 abstract class AbstractFilterExtension implements RequestBodySearchCollectionExtensionInterface

--- a/src/Elasticsearch/Extension/ConstantScoreFilterExtension.php
+++ b/src/Elasticsearch/Extension/ConstantScoreFilterExtension.php
@@ -20,8 +20,6 @@ use ApiPlatform\Elasticsearch\Filter\ConstantScoreFilterInterface;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class ConstantScoreFilterExtension extends AbstractFilterExtension

--- a/src/Elasticsearch/Extension/RequestBodySearchCollectionExtensionInterface.php
+++ b/src/Elasticsearch/Extension/RequestBodySearchCollectionExtensionInterface.php
@@ -20,8 +20,6 @@ use ApiPlatform\Metadata\Operation;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 interface RequestBodySearchCollectionExtensionInterface

--- a/src/Elasticsearch/Extension/SortExtension.php
+++ b/src/Elasticsearch/Extension/SortExtension.php
@@ -25,8 +25,6 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class SortExtension implements RequestBodySearchCollectionExtensionInterface

--- a/src/Elasticsearch/Extension/SortFilterExtension.php
+++ b/src/Elasticsearch/Extension/SortFilterExtension.php
@@ -20,8 +20,6 @@ use ApiPlatform\Elasticsearch\Filter\SortFilterInterface;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class SortFilterExtension extends AbstractFilterExtension

--- a/src/Elasticsearch/Filter/AbstractFilter.php
+++ b/src/Elasticsearch/Filter/AbstractFilter.php
@@ -31,8 +31,6 @@ use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 /**
  * Abstract class with helpers for easing the implementation of a filter.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 abstract class AbstractFilter implements FilterInterface

--- a/src/Elasticsearch/Filter/AbstractSearchFilter.php
+++ b/src/Elasticsearch/Filter/AbstractSearchFilter.php
@@ -30,8 +30,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
 /**
  * Abstract class with helpers for easing the implementation of a search filter like a term filter or a match filter.
  *
- * @experimental
- *
  * @internal
  *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>

--- a/src/Elasticsearch/Filter/ConstantScoreFilterInterface.php
+++ b/src/Elasticsearch/Filter/ConstantScoreFilterInterface.php
@@ -16,8 +16,6 @@ namespace ApiPlatform\Elasticsearch\Filter;
 /**
  * Elasticsearch filter interface for a constant score query.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 interface ConstantScoreFilterInterface extends FilterInterface

--- a/src/Elasticsearch/Filter/FilterInterface.php
+++ b/src/Elasticsearch/Filter/FilterInterface.php
@@ -19,8 +19,6 @@ use ApiPlatform\Metadata\Operation;
 /**
  * Elasticsearch filter interface.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 interface FilterInterface extends BaseFilterInterface

--- a/src/Elasticsearch/Filter/OrderFilter.php
+++ b/src/Elasticsearch/Filter/OrderFilter.php
@@ -105,8 +105,6 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
  *
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class OrderFilter extends AbstractFilter implements SortFilterInterface

--- a/src/Elasticsearch/Filter/SortFilterInterface.php
+++ b/src/Elasticsearch/Filter/SortFilterInterface.php
@@ -16,8 +16,6 @@ namespace ApiPlatform\Elasticsearch\Filter;
 /**
  * Elasticsearch filter interface for sorting.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 interface SortFilterInterface extends FilterInterface

--- a/src/Elasticsearch/Filter/TermFilter.php
+++ b/src/Elasticsearch/Filter/TermFilter.php
@@ -98,8 +98,6 @@ namespace ApiPlatform\Elasticsearch\Filter;
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class TermFilter extends AbstractSearchFilter

--- a/src/Elasticsearch/Paginator.php
+++ b/src/Elasticsearch/Paginator.php
@@ -21,8 +21,6 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 /**
  * Paginator for Elasticsearch.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class Paginator implements \IteratorAggregate, PaginatorInterface

--- a/src/Elasticsearch/Serializer/DocumentNormalizer.php
+++ b/src/Elasticsearch/Serializer/DocumentNormalizer.php
@@ -32,8 +32,6 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
 /**
  * Document denormalizer for Elasticsearch.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class DocumentNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface

--- a/src/Elasticsearch/Serializer/ItemNormalizer.php
+++ b/src/Elasticsearch/Serializer/ItemNormalizer.php
@@ -22,8 +22,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 /**
  * Item normalizer decorator that prevents {@see \ApiPlatform\Serializer\ItemNormalizer}
  * from taking over for the {@see DocumentNormalizer::FORMAT} format because of priorities.
- *
- * @experimental
  */
 final class ItemNormalizer implements NormalizerInterface, DenormalizerInterface, SerializerAwareInterface
 {

--- a/src/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
+++ b/src/Elasticsearch/Serializer/NameConverter/InnerFieldsNameConverter.php
@@ -19,8 +19,6 @@ use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 /**
  * Converts inner fields with a inner name converter.
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 final class InnerFieldsNameConverter implements NameConverterInterface

--- a/src/Elasticsearch/Util/FieldDatatypeTrait.php
+++ b/src/Elasticsearch/Util/FieldDatatypeTrait.php
@@ -27,8 +27,6 @@ use Symfony\Component\TypeInfo\Type\ObjectType;
  *
  * @internal
  *
- * @experimental
- *
  * @author Baptiste Meyer <baptiste.meyer@gmail.com>
  */
 trait FieldDatatypeTrait

--- a/src/Laravel/State/ParameterValidatorProvider.php
+++ b/src/Laravel/State/ParameterValidatorProvider.php
@@ -25,8 +25,6 @@ use Symfony\Component\HttpFoundation\Request;
  * Validates parameters using the Laravel validator.
  *
  * @implements ProviderInterface<object>
- *
- * @experimental
  */
 final class ParameterValidatorProvider implements ProviderInterface
 {

--- a/src/State/ParameterProvider/IriConverterParameterProvider.php
+++ b/src/State/ParameterProvider/IriConverterParameterProvider.php
@@ -23,8 +23,6 @@ use ApiPlatform\State\ParameterProviderInterface;
 use Psr\Log\LoggerInterface;
 
 /**
- * @experimental
- *
  * @author Vincent Amstoutz <vincent.amstoutz.dev@gmail.com>
  */
 final readonly class IriConverterParameterProvider implements ParameterProviderInterface

--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -26,8 +26,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Checks if the linked resources have security attributes and prepares them for access checking.
- *
- * @experimental
  */
 final class ReadLinkParameterProvider implements ParameterProviderInterface
 {

--- a/src/State/Provider/SecurityParameterProvider.php
+++ b/src/State/Provider/SecurityParameterProvider.php
@@ -30,8 +30,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
  * Loops over parameters to check parameter security.
  * Throws an exception if security is not granted.
  *
- * @experimental
- *
  * @implements ProviderInterface<object>
  */
 final class SecurityParameterProvider implements ProviderInterface


### PR DESCRIPTION
Per the C.4 stabilization decision, `@experimental` is kept **only** on MCP classes. Everything else that carried the marker is now considered stable, so the annotation is dropped.

## Subtrees touched

- **Elasticsearch** — extensions, filters, serializers, paginator, exceptions, name converter, field-datatype trait (20 files)
- **State parameter providers** — `SecurityParameterProvider`, `IriConverterParameterProvider`, `ReadLinkParameterProvider`
- **Doctrine** — `PropertyAwareFilterInterface`
- **Laravel** — `ParameterValidatorProvider`

MCP classes (`src/Mcp/**`, `Metadata/Mcp*`) keep `@experimental` and are untouched.

## Notes

- Pure docblock change: each edit removes only the `@experimental` tag line and its orphaned blank `*` (24 files, 48 deletions, no code changes).
- This aligns 4.4 with `main`, which already stripped these markers — smoothing the next up-merge.
- `src/GraphQl/foo.diff` still contains an `@experimental` string but is intentionally left alone (a separate merged PR removes that file).
