### PR TITLE
fix(state): correct composer "conflicts" key to "conflict"

### DIFF
--- a/src/State/composer.json
+++ b/src/State/composer.json
@@ -45,7 +45,7 @@
         "symfony/web-link": "^7.4 || ^8.0",
         "willdurand/negotiation": "^3.1"
     },
-    "conflicts": {
+    "conflict": {
         "symfony/object-mapper": "<7.3.4"
     },
     "autoload": {


### PR DESCRIPTION
The `api-platform/state` composer.json used the key `"conflicts"` (plural). Composer only recognises the singular `"conflict"`, so the block was silently ignored and the `symfony/object-mapper: <7.3.4` exclusion was never actually enforced.

Renamed to `"conflict"` so the exclusion applies. No dependency change otherwise.

Targets `4.4`; propagates to `main` via the normal up-merge. (main carries the same typo.)