### PR TITLE
chore: resolve stale SerializerContextBuilder / ContextAction 5.0 TODOs

### DIFF
--- a/src/JsonLd/Action/ContextAction.php
+++ b/src/JsonLd/Action/ContextAction.php
@@ -32,11 +32,6 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 final class ContextAction
 {
-    public const RESERVED_SHORT_NAMES = [
-        'ConstraintViolationList' => true,
-        'Error' => true,
-    ];
-
     public function __construct(
         private readonly ContextBuilderInterface $contextBuilder,
         private readonly ResourceNameCollectionFactoryInterface $resourceNameCollectionFactory,
@@ -88,11 +83,6 @@ final class ContextAction
     {
         if ('Entrypoint' === $shortName) {
             return ['@context' => $this->contextBuilder->getEntrypointContext()];
-        }
-
-        // TODO: remove this, exceptions are resources since 3.2
-        if (isset(self::RESERVED_SHORT_NAMES[$shortName])) {
-            return ['@context' => $this->contextBuilder->getBaseContext()];
         }
 
         foreach ($this->resourceNameCollectionFactory->create() as $resourceClass) {

--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -76,15 +76,6 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
             $context['types'] = $types;
         }
 
-        // TODO: remove this as uri variables are available in the SerializerProcessor but correctly parsed
-        if ($operation->getUriVariables()) {
-            $context['uri_variables'] = [];
-
-            foreach (array_keys($operation->getUriVariables()) as $parameterName) {
-                $context['uri_variables'][$parameterName] = $request->attributes->get($parameterName);
-            }
-        }
-
         if (null === $context['output'] && $this->getStateOptionsClass($operation)) {
             $context['force_resource_class'] = $operation->getClass();
         }

--- a/tests/Functional/JsonLd/ContextTest.php
+++ b/tests/Functional/JsonLd/ContextTest.php
@@ -121,4 +121,22 @@ final class ContextTest extends ApiTestCase
         $this->assertSame('http://purl.org/dc/terms/', $body['@context']['dct']);
         $this->assertSame('dct:title', $body['@context']['title']);
     }
+
+    public function testErrorContextIsResolvedThroughItsResource(): void
+    {
+        $response = self::createClient()->request('GET', '/contexts/Error');
+        $this->assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $this->assertArrayHasKey('@context', $body);
+        $this->assertSame('http://www.w3.org/ns/hydra/core#', $body['@context']['hydra']);
+    }
+
+    public function testConstraintViolationContextIsResolvedThroughItsResource(): void
+    {
+        $response = self::createClient()->request('GET', '/contexts/ConstraintViolation');
+        $this->assertResponseIsSuccessful();
+        $body = $response->toArray();
+        $this->assertArrayHasKey('@context', $body);
+        $this->assertSame('http://www.w3.org/ns/hydra/core#', $body['@context']['hydra']);
+    }
 }

--- a/tests/JsonLd/Action/ContextActionTest.php
+++ b/tests/JsonLd/Action/ContextActionTest.php
@@ -52,17 +52,6 @@ class ContextActionTest extends TestCase
         $this->assertEquals(['@context' => ['/entrypoints']], $contextAction('Entrypoint'));
     }
 
-    public function testContextActionWithContexts(): void
-    {
-        $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);
-        $resourceNameCollectionFactoryProphecy = $this->prophesize(ResourceNameCollectionFactoryInterface::class);
-        $resourceMetadataCollectionFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
-        $contextBuilderProphecy->getBaseContext()->willReturn(['/contexts']);
-        $contextAction = new ContextAction($contextBuilderProphecy->reveal(), $resourceNameCollectionFactoryProphecy->reveal(), $resourceMetadataCollectionFactoryProphecy->reveal());
-
-        $this->assertEquals(['@context' => ['/contexts']], $contextAction('ConstraintViolationList'));
-    }
-
     public function testContextActionWithResourceClass(): void
     {
         $contextBuilderProphecy = $this->prophesize(ContextBuilderInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

Two verification-gated cleanups from the 4.4/5.0 audit.

### `refactor(serializer)`: drop redundant `uri_variables` assignment

`SerializerContextBuilder::createFromRequest()` populated `uri_variables` from raw request attributes, but every serialization consumer overrides it with correctly-parsed values immediately after calling it — `SerializeProcessor`, `DeserializeProvider` and `Mcp\StructuredContentProcessor`. No other caller reads the builder's `uri_variables` (`PayloadArgumentResolver` only reads `input`/`resource_class`; `_api_normalization_context` is written, never read for `uri_variables`).

### `refactor(jsonld)!`: resolve reserved short names through their resources

`ContextAction` served a hardcoded base `@context` for the `Error` and `ConstraintViolationList` short names. Exceptions are resources since 3.2: `Error` and the validation resource `ConstraintViolation` now resolve through the normal resource loop. The legacy `ConstraintViolationList` context route had no producer left — responses reference `/contexts/ConstraintViolation`.

**BREAKING CHANGE:** removes the public `ContextAction::RESERVED_SHORT_NAMES` constant and the `/contexts/ConstraintViolationList` route.

### Verification

- Full regression sweep (Serializer unit + JSON-API/JSON-LD/HAL + Parameters/Doctrine + Security/CrudUriVariables functional): 862 tests, 0 failures.
- Combined change on 5.0: 144 tests, 0 failures. Added `ContextTest` coverage for `/contexts/Error` and `/contexts/ConstraintViolation` resolving through their resources.
- php-cs-fixer + PHPStan clean.