### PR TITLE
fix(metadata): preserve bracketed indexes in query values

### DIFF
--- a/src/Metadata/Tests/Util/IriHelperTest.php
+++ b/src/Metadata/Tests/Util/IriHelperTest.php
@@ -23,10 +23,6 @@ use PHPUnit\Framework\TestCase;
  */
 class IriHelperTest extends TestCase
 {
-    private const OBJECTS_PATH = '/objects';
-    private const PAGE_PARAMETER_NAME = 'page';
-    private const BRACKETED_INDEX_VALUE = 'x[0]';
-
     public function testHelpers(): void
     {
         $parsed = [
@@ -97,14 +93,14 @@ class IriHelperTest extends TestCase
     public function testHelpersCollapseSimpleListQueryParameters(): void
     {
         $parts = [
-            'path' => self::OBJECTS_PATH,
+            'path' => '/objects',
             'query' => '',
         ];
         $parameters = [
             'foo' => ['a', 'b'],
         ];
 
-        $iri = IriHelper::createIri($parts, $parameters, self::PAGE_PARAMETER_NAME, 2.);
+        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
 
         $this->assertSame('/objects?foo%5B%5D=a&foo%5B%5D=b&page=2', $iri);
     }
@@ -112,16 +108,31 @@ class IriHelperTest extends TestCase
     public function testCreateIriPreservesBracketedNumericIndexesInQueryValues(): void
     {
         $parts = [
-            'path' => self::OBJECTS_PATH,
+            'path' => '/objects',
             'query' => '',
         ];
         $parameters = [
-            'v' => self::BRACKETED_INDEX_VALUE,
+            'v' => 'x[0]',
         ];
 
-        $iri = IriHelper::createIri($parts, $parameters, self::PAGE_PARAMETER_NAME, 2.);
+        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
 
         $this->assertSame('/objects?v=x%5B0%5D&page=2', $iri);
+    }
+
+    public function testHelpersCollapseListKeysWhilePreservingBracketedValues(): void
+    {
+        $parts = [
+            'path' => '/objects',
+            'query' => '',
+        ];
+        $parameters = [
+            'foo' => ['x[0]', 'b'],
+        ];
+
+        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
+
+        $this->assertSame('/objects?foo%5B%5D=x%5B0%5D&foo%5B%5D=b&page=2', $iri);
     }
 
     public function testParseIriWithInvalidUrl(): void

--- a/src/Metadata/Tests/Util/IriHelperTest.php
+++ b/src/Metadata/Tests/Util/IriHelperTest.php
@@ -23,6 +23,10 @@ use PHPUnit\Framework\TestCase;
  */
 class IriHelperTest extends TestCase
 {
+    private const OBJECTS_PATH = '/objects';
+    private const PAGE_PARAMETER_NAME = 'page';
+    private const BRACKETED_INDEX_VALUE = 'x[0]';
+
     public function testHelpers(): void
     {
         $parsed = [
@@ -93,16 +97,31 @@ class IriHelperTest extends TestCase
     public function testHelpersCollapseSimpleListQueryParameters(): void
     {
         $parts = [
-            'path' => '/objects',
+            'path' => self::OBJECTS_PATH,
             'query' => '',
         ];
         $parameters = [
             'foo' => ['a', 'b'],
         ];
 
-        $iri = IriHelper::createIri($parts, $parameters, 'page', 2.);
+        $iri = IriHelper::createIri($parts, $parameters, self::PAGE_PARAMETER_NAME, 2.);
 
         $this->assertSame('/objects?foo%5B%5D=a&foo%5B%5D=b&page=2', $iri);
+    }
+
+    public function testCreateIriPreservesBracketedNumericIndexesInQueryValues(): void
+    {
+        $parts = [
+            'path' => self::OBJECTS_PATH,
+            'query' => '',
+        ];
+        $parameters = [
+            'v' => self::BRACKETED_INDEX_VALUE,
+        ];
+
+        $iri = IriHelper::createIri($parts, $parameters, self::PAGE_PARAMETER_NAME, 2.);
+
+        $this->assertSame('/objects?v=x%5B0%5D&page=2', $iri);
     }
 
     public function testParseIriWithInvalidUrl(): void

--- a/src/Metadata/Util/IriHelper.php
+++ b/src/Metadata/Util/IriHelper.php
@@ -26,11 +26,6 @@ use ApiPlatform\State\Util\RequestParser;
  */
 final class IriHelper
 {
-    private const EMPTY_BRACKET_REPLACEMENT = '%5B%5D';
-    private const INDEXED_LEAF_BRACKET_PATTERN = '/%5B\d+%5D(?!%5B)/';
-    private const QUERY_ASSIGNMENT_SEPARATOR = '=';
-    private const QUERY_SEPARATOR = '&';
-
     private function __construct()
     {
     }
@@ -69,8 +64,13 @@ final class IriHelper
             $parameters[$pageParameterName] = $page;
         }
 
-        $query = http_build_query($parameters, '', self::QUERY_SEPARATOR, \PHP_QUERY_RFC3986);
-        $parts['query'] = self::collapseNumericLeafIndexesInQueryKeys($query);
+        $query = http_build_query($parameters, '', '&', \PHP_QUERY_RFC3986);
+        // Only collapse a numeric index when it is the leaf segment of a bracket chain (a simple
+        // list element): collapsing a non-leaf index would merge distinct keys of a nested array
+        // into separate elements (e.g. filters[0][a] must stay filters[0][a]). The (?=[^=&]*=)
+        // lookahead confines matches to the key half of a pair, as an RFC3986-encoded value can
+        // never contain a literal '='.
+        $parts['query'] = preg_replace('/%5B\d+%5D(?!%5B)(?=[^=&]*=)/', '%5B%5D', $query);
 
         $url = '';
         if ((UrlGeneratorInterface::ABS_URL === $urlGenerationStrategy || UrlGeneratorInterface::NET_PATH === $urlGenerationStrategy) && isset($parts['host'])) {
@@ -111,22 +111,5 @@ final class IriHelper
         }
 
         return $url;
-    }
-
-    private static function collapseNumericLeafIndexesInQueryKeys(string $query): string
-    {
-        $parameters = explode(self::QUERY_SEPARATOR, $query);
-
-        foreach ($parameters as $index => $parameter) {
-            [$key, $value] = explode(self::QUERY_ASSIGNMENT_SEPARATOR, $parameter, 2) + [1 => null];
-
-            // Only collapse a numeric index when it is the leaf segment of a bracket chain
-            // (a simple list element). Collapsing a non-leaf index would merge distinct keys of a
-            // nested array into separate elements (e.g. filters[0][a] must stay filters[0][a]).
-            $key = preg_replace(self::INDEXED_LEAF_BRACKET_PATTERN, self::EMPTY_BRACKET_REPLACEMENT, $key);
-            $parameters[$index] = null === $value ? $key : $key.self::QUERY_ASSIGNMENT_SEPARATOR.$value;
-        }
-
-        return implode(self::QUERY_SEPARATOR, $parameters);
     }
 }

--- a/src/Metadata/Util/IriHelper.php
+++ b/src/Metadata/Util/IriHelper.php
@@ -26,6 +26,11 @@ use ApiPlatform\State\Util\RequestParser;
  */
 final class IriHelper
 {
+    private const EMPTY_BRACKET_REPLACEMENT = '%5B%5D';
+    private const INDEXED_LEAF_BRACKET_PATTERN = '/%5B\d+%5D(?!%5B)/';
+    private const QUERY_ASSIGNMENT_SEPARATOR = '=';
+    private const QUERY_SEPARATOR = '&';
+
     private function __construct()
     {
     }
@@ -64,11 +69,8 @@ final class IriHelper
             $parameters[$pageParameterName] = $page;
         }
 
-        $query = http_build_query($parameters, '', '&', \PHP_QUERY_RFC3986);
-        // Only collapse a numeric index when it is the leaf segment of a bracket chain
-        // (a simple list element). Collapsing a non-leaf index would merge distinct keys of a
-        // nested array into separate elements (e.g. filters[0][a] must stay filters[0][a]).
-        $parts['query'] = preg_replace('/%5B\d+%5D(?!%5B)/', '%5B%5D', $query);
+        $query = http_build_query($parameters, '', self::QUERY_SEPARATOR, \PHP_QUERY_RFC3986);
+        $parts['query'] = self::collapseNumericLeafIndexesInQueryKeys($query);
 
         $url = '';
         if ((UrlGeneratorInterface::ABS_URL === $urlGenerationStrategy || UrlGeneratorInterface::NET_PATH === $urlGenerationStrategy) && isset($parts['host'])) {
@@ -109,5 +111,22 @@ final class IriHelper
         }
 
         return $url;
+    }
+
+    private static function collapseNumericLeafIndexesInQueryKeys(string $query): string
+    {
+        $parameters = explode(self::QUERY_SEPARATOR, $query);
+
+        foreach ($parameters as $index => $parameter) {
+            [$key, $value] = explode(self::QUERY_ASSIGNMENT_SEPARATOR, $parameter, 2) + [1 => null];
+
+            // Only collapse a numeric index when it is the leaf segment of a bracket chain
+            // (a simple list element). Collapsing a non-leaf index would merge distinct keys of a
+            // nested array into separate elements (e.g. filters[0][a] must stay filters[0][a]).
+            $key = preg_replace(self::INDEXED_LEAF_BRACKET_PATTERN, self::EMPTY_BRACKET_REPLACEMENT, $key);
+            $parameters[$index] = null === $value ? $key : $key.self::QUERY_ASSIGNMENT_SEPARATOR.$value;
+        }
+
+        return implode(self::QUERY_SEPARATOR, $parameters);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8288
| License       | MIT
| Doc PR        | n/a

## Summary

`IriHelper::createIri()` used to collapse encoded numeric brackets on the entire query string. That also rewrote bracketed indexes inside query values, for example `x[0]` became `x[]`.

This keeps the existing list-key normalization, but applies it only to encoded query keys before joining each `key=value` pair back together.

## Local review

Reviewed before opening this PR. No findings: the change is scoped to `IriHelper`, keeps the existing nested-array regression test, and adds a value-corruption regression test for the reported case.

## Test verification (RED → GREEN)

RED, upstream `4.3` at `36d457f9` with only the new regression test applied:

```text
....F.                                                              6 / 6 (100%)

1) ApiPlatform\Metadata\Tests\Util\IriHelperTest::testCreateIriPreservesBracketedNumericIndexesInQueryValues
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/objects?v=x%5B0%5D&page=2'
+'/objects?v=x%5B%5D&page=2'

FAILURES!
Tests: 6, Assertions: 11, Failures: 1.
```

GREEN, with the fix:

```text
......                                                              6 / 6 (100%)

OK (6 tests, 11 assertions)
```

Fix-reverted regression check:

```text
....F.                                                              6 / 6 (100%)

ApiPlatform\Metadata\Tests\Util\IriHelperTest::testCreateIriPreservesBracketedNumericIndexesInQueryValues
Failed asserting that two strings are identical.
-'/objects?v=x%5B0%5D&page=2'
+'/objects?v=x%5B%5D&page=2'

FAILURES!
Tests: 6, Assertions: 11, Failures: 1.
```

Additional checks:

```text
php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes --dry-run --diff src/Metadata/Util/IriHelper.php src/Metadata/Tests/Util/IriHelperTest.php
Found 0 of 2 files that can be fixed

APP_DEBUG=1 php tests/Fixtures/app/console cache:warmup --env=test
php vendor/bin/phpstan analyse src/Metadata/Util/IriHelper.php src/Metadata/Tests/Util/IriHelperTest.php
[OK] No errors
```

All commands were run inside ephemeral Docker containers with `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/app -w /app composer:2 ...`.

