### PR TITLE
fix(symfony): remove redundant messenger dispatch docblocks

### DIFF
--- a/src/Doctrine/Common/Messenger/DispatchTrait.php
+++ b/src/Doctrine/Common/Messenger/DispatchTrait.php
@@ -24,9 +24,6 @@ trait DispatchTrait
 {
     private ?MessageBusInterface $messageBus;
 
-    /**
-     * @param object|Envelope $message
-     */
     private function dispatch(object $message): Envelope
     {
         if (!$this->messageBus instanceof MessageBusInterface) {

--- a/src/Symfony/Messenger/DispatchTrait.php
+++ b/src/Symfony/Messenger/DispatchTrait.php
@@ -24,9 +24,6 @@ trait DispatchTrait
 {
     private ?MessageBusInterface $messageBus;
 
-    /**
-     * @param object|Envelope $message
-     */
     private function dispatch(object $message): Envelope
     {
         if (!$this->messageBus instanceof MessageBusInterface) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8312
| License       | MIT
| Doc PR        | n/a

## Summary

The two Messenger `DispatchTrait` implementations declared `@param object|Envelope $message`. That union is redundant because the method already accepts `object`, and `symfony/type-info` rejects unions combining `object` with a concrete class.

This removes the redundant docblocks and adds a regression test that resolves any future `@param $message` docblock type from both traits through TypeInfo with the trait import context.

## Local review

Reviewed before opening this PR. One test-risk finding was fixed before commit: the new regression test now records an assertion when a trait has no docblock or no `@param $message`, avoiding a future risky-test path.

## Test verification (RED → GREEN)

RED, after adding the regression test on upstream `main`:

```text
EE                                                                  2 / 2 (100%)

1) ApiPlatform\Symfony\Tests\Messenger\DispatchTraitTest::testDispatchMessageParamDocblockUsesTypeInfoCompatibleType@doctrine common messenger dispatch trait
Symfony\Component\TypeInfo\Exception\InvalidArgumentException: Cannot create union with both "object" and class type.

2) ApiPlatform\Symfony\Tests\Messenger\DispatchTraitTest::testDispatchMessageParamDocblockUsesTypeInfoCompatibleType@symfony messenger dispatch trait
Symfony\Component\TypeInfo\Exception\InvalidArgumentException: Cannot create union with both "object" and class type.

ERRORS!
Tests: 2, Assertions: 2, Errors: 2.
```

GREEN, with the fix:

```text
..                                                                  2 / 2 (100%)

OK (2 tests, 2 assertions)
```

Fix-reverted regression check:

```text
EE                                                                  2 / 2 (100%)

ApiPlatform\Symfony\Tests\Messenger\DispatchTraitTest::testDispatchMessageParamDocblockUsesTypeInfoCompatibleType
Symfony\Component\TypeInfo\Exception\InvalidArgumentException: Cannot create union with both "object" and class type.

ERRORS!
Tests: 2, Assertions: 0, Errors: 2.
```

Additional checks:

```text
php vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-unsupported-php-version=yes --dry-run --diff src/Symfony/Messenger/DispatchTrait.php src/Doctrine/Common/Messenger/DispatchTrait.php src/Symfony/Tests/Messenger/DispatchTraitTest.php
Found 0 of 3 files that can be fixed

php vendor/bin/phpstan analyse src/Symfony/Messenger/DispatchTrait.php src/Doctrine/Common/Messenger/DispatchTrait.php src/Symfony/Tests/Messenger/DispatchTraitTest.php
[OK] No errors
```

All commands were run inside ephemeral Docker containers with `docker run --rm -u "$(id -u):$(id -g)" -v "$PWD":/app -w /app composer:2 ...`.
