### PR TITLE
fix(doctrine): ignore operator-map values in ExactFilter and PartialSearchFilter

### DIFF
--- a/src/Doctrine/Orm/Filter/ExactFilter.php
+++ b/src/Doctrine/Orm/Filter/ExactFilter.php
@@ -36,6 +36,11 @@ final class ExactFilter implements FilterInterface, OpenApiParameterFilterInterf
         $parameter = $context['parameter'];
         $value = $parameter->getValue();
 
+        // associative arrays are operator-maps owned by ComparisonFilter/DateFilter, not equality
+        if (\is_array($value) && !array_is_list($value)) {
+            return;
+        }
+
         if (null === $parameter->getProperty()) {
             throw new InvalidArgumentException(\sprintf('The filter parameter with key "%s" must specify a property. Please provide the property explicitly.', $parameter->getKey()));
         }

--- a/src/Doctrine/Orm/Filter/PartialSearchFilter.php
+++ b/src/Doctrine/Orm/Filter/PartialSearchFilter.php
@@ -49,6 +49,11 @@ final class PartialSearchFilter implements FilterInterface, OpenApiParameterFilt
         $field = $alias.'.'.$property;
         $values = $parameter->getValue();
 
+        // associative arrays are operator-maps owned by ComparisonFilter/DateFilter, not equality
+        if (\is_array($values) && !array_is_list($values)) {
+            return;
+        }
+
         if (!is_iterable($values)) {
             $parameterName = $queryNameGenerator->generateParameterName($property);
             $queryBuilder->setParameter($parameterName, $this->formatLikeValue($values));

--- a/tests/Fixtures/TestBundle/Entity/ExactAndComparisonParameter.php
+++ b/tests/Fixtures/TestBundle/Entity/ExactAndComparisonParameter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Doctrine\Orm\Filter\ComparisonFilter;
+use ApiPlatform\Doctrine\Orm\Filter\ExactFilter;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Tests\Fixtures\TestBundle\Parameter\OperatorMapQueryParameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ApiResource(openapi: false)]
+#[GetCollection(
+    uriTemplate: 'exact_and_comparison_parameter{._format}',
+    parameters: [
+        'quantity' => new QueryParameter(filter: new ExactFilter(), property: 'quantity'),
+        'quantityComparison' => new OperatorMapQueryParameter(key: 'quantity', filter: new ComparisonFilter(new ExactFilter()), property: 'quantity'),
+    ]
+)]
+#[ORM\Entity]
+class ExactAndComparisonParameter
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(type: 'integer')]
+    private int $quantity = 0;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+}

--- a/tests/Fixtures/TestBundle/Parameter/OperatorMapQueryParameter.php
+++ b/tests/Fixtures/TestBundle/Parameter/OperatorMapQueryParameter.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Parameter;
+
+use ApiPlatform\Metadata\QueryParameter;
+
+/**
+ * Distinct class so an operator-map filter can share an HTTP key with a scalar filter:
+ * Parameters dedup by (key, parameter class), so two parameters on the same key must differ in class.
+ */
+final class OperatorMapQueryParameter extends QueryParameter
+{
+}

--- a/tests/Functional/Parameters/DoctrineTest.php
+++ b/tests/Functional/Parameters/DoctrineTest.php
@@ -17,6 +17,7 @@ use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\FilterWithStateOptions;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\FilterWithStateOptionsAndNoApiFilter;
 use ApiPlatform\Tests\Fixtures\TestBundle\Document\SearchFilterParameter as SearchFilterParameterDocument;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ExactAndComparisonParameter;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilterWithStateOptionsAndNoApiFilterEntity;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\FilterWithStateOptionsEntity;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\ProductWithQueryParameter;
@@ -42,7 +43,44 @@ final class DoctrineTest extends ApiTestCase
             FilterWithStateOptions::class,
             FilterWithStateOptionsAndNoApiFilter::class,
             ProductWithQueryParameter::class,
+            ExactAndComparisonParameter::class,
         ];
+    }
+
+    public function testExactFilterIgnoresOperatorMap(): void
+    {
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('Not tested with mongodb.');
+        }
+
+        $resource = ExactAndComparisonParameter::class;
+        $this->recreateSchema([$resource]);
+
+        $container = static::$kernel->getContainer();
+        $manager = $container->get('doctrine')->getManager();
+        foreach ([5, 8, 10, 15] as $q) {
+            $e = new ExactAndComparisonParameter();
+            $e->setQuantity($q);
+            $manager->persist($e);
+        }
+        $manager->flush();
+
+        $route = 'exact_and_comparison_parameter';
+
+        // Exact match: ?quantity=10 must return only the row with quantity = 10.
+        $response = self::createClient()->request('GET', $route.'?quantity=10');
+        $this->assertResponseIsSuccessful();
+        $members = $response->toArray()['hydra:member'];
+        $this->assertCount(1, $members);
+        $this->assertSame(10, $members[0]['quantity']);
+
+        // Operator map: ?quantity[lt]=10 must apply only the comparison (< 10),
+        // the exact filter must NOT also inject `quantity IN ('lt' => ...)`.
+        $response = self::createClient()->request('GET', $route.'?quantity[lt]=10');
+        $this->assertResponseIsSuccessful();
+        $quantities = array_map(static fn ($m) => $m['quantity'], $response->toArray()['hydra:member']);
+        sort($quantities);
+        $this->assertSame([5, 8], $quantities);
     }
 
     public function testDoctrineEntitySearchFilter(): void


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Fixes #8407 |
| License       | MIT |
| Doc PR        | n/a |

## What

`ExactFilter` and `PartialSearchFilter` treated an associative (non-list) array value as an `IN (...)` list / a set of `LIKE` clauses. When one of them shares an HTTP key with an operator-map filter (`ComparisonFilter`, `DateFilter`), the operator-map form `?prop[lt]=x` resolves the value to `['lt' => 'x']` for **every** parameter declared on that key — so the equality/partial filter injected a bogus `prop IN ('lt' => ...)` on top of the intended comparison, silently returning wrong results (usually zero rows).

Both filters now skip associative arrays: a non-list array is an operator map owned by `ComparisonFilter`/`DateFilter`, not equality.

```php
if (\is_array($value) && !array_is_list($value)) {
    return;
}
```

## Why

Reported in #8407: `ExactFilter` combined with `DateFilter` on the same property stopped working after migrating off `SearchFilter`, because `ExactFilter` fires on the bracketed date syntax too. The guard makes the equality/partial filters ignore value shapes that aren't theirs, so combining them with an operator-map filter fails safe.

## Test

New functional test `DoctrineTest::testExactFilterIgnoresOperatorMap()` with a fixture declaring an `ExactFilter` and a `ComparisonFilter` on the same key: `?quantity=10` matches exactly, `?quantity[lt]=10` applies only the comparison. Fails before the guard (empty result), passes after. No regressions across `tests/Functional/Parameters/`.
