### PR TITLE
perf(laravel): add a local cache to the metadata cache factories

### DIFF
--- a/src/Laravel/Metadata/CachePropertyMetadataFactory.php
+++ b/src/Laravel/Metadata/CachePropertyMetadataFactory.php
@@ -17,11 +17,16 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use Illuminate\Support\Facades\Cache;
 
-final readonly class CachePropertyMetadataFactory implements PropertyMetadataFactoryInterface
+final class CachePropertyMetadataFactory implements PropertyMetadataFactoryInterface
 {
+    /**
+     * @var array<string, ApiProperty>
+     */
+    private array $localCache = [];
+
     public function __construct(
-        private PropertyMetadataFactoryInterface $decorated,
-        private string $cacheStore,
+        private readonly PropertyMetadataFactoryInterface $decorated,
+        private readonly string $cacheStore,
     ) {
     }
 
@@ -29,7 +34,7 @@ final readonly class CachePropertyMetadataFactory implements PropertyMetadataFac
     {
         $key = hash('xxh3', serialize(['resource_class' => $resourceClass, 'property' => $property] + $options));
 
-        return Cache::store($this->cacheStore)->rememberForever($key, function () use ($resourceClass, $property, $options) {
+        return $this->localCache[$key] ??= Cache::store($this->cacheStore)->rememberForever($key, function () use ($resourceClass, $property, $options) {
             return $this->decorated->create($resourceClass, $property, $options);
         });
     }

--- a/src/Laravel/Metadata/CachePropertyNameCollectionMetadataFactory.php
+++ b/src/Laravel/Metadata/CachePropertyNameCollectionMetadataFactory.php
@@ -17,11 +17,16 @@ use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use Illuminate\Support\Facades\Cache;
 
-final readonly class CachePropertyNameCollectionMetadataFactory implements PropertyNameCollectionFactoryInterface
+final class CachePropertyNameCollectionMetadataFactory implements PropertyNameCollectionFactoryInterface
 {
+    /**
+     * @var array<string, PropertyNameCollection>
+     */
+    private array $localCache = [];
+
     public function __construct(
-        private PropertyNameCollectionFactoryInterface $decorated,
-        private string $cacheStore,
+        private readonly PropertyNameCollectionFactoryInterface $decorated,
+        private readonly string $cacheStore,
     ) {
     }
 
@@ -29,7 +34,7 @@ final readonly class CachePropertyNameCollectionMetadataFactory implements Prope
     {
         $key = hash('xxh3', serialize(['resource_class' => $resourceClass] + $options));
 
-        return Cache::store($this->cacheStore)->rememberForever($key, function () use ($resourceClass, $options) {
+        return $this->localCache[$key] ??= Cache::store($this->cacheStore)->rememberForever($key, function () use ($resourceClass, $options) {
             return $this->decorated->create($resourceClass, $options);
         });
     }

--- a/src/Laravel/Metadata/CacheResourceCollectionMetadataFactory.php
+++ b/src/Laravel/Metadata/CacheResourceCollectionMetadataFactory.php
@@ -17,17 +17,22 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use Illuminate\Support\Facades\Cache;
 
-final readonly class CacheResourceCollectionMetadataFactory implements ResourceMetadataCollectionFactoryInterface
+final class CacheResourceCollectionMetadataFactory implements ResourceMetadataCollectionFactoryInterface
 {
+    /**
+     * @var array<string, ResourceMetadataCollection>
+     */
+    private array $localCache = [];
+
     public function __construct(
-        private ResourceMetadataCollectionFactoryInterface $decorated,
-        private string $cacheStore,
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+        private readonly string $cacheStore,
     ) {
     }
 
     public function create(string $resourceClass): ResourceMetadataCollection
     {
-        return Cache::store($this->cacheStore)->rememberForever($resourceClass, function () use ($resourceClass) {
+        return $this->localCache[$resourceClass] ??= Cache::store($this->cacheStore)->rememberForever($resourceClass, function () use ($resourceClass) {
             return $this->decorated->create($resourceClass);
         });
     }

--- a/src/Laravel/Tests/Metadata/CacheMetadataFactoriesTest.php
+++ b/src/Laravel/Tests/Metadata/CacheMetadataFactoriesTest.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests\Metadata;
+
+use ApiPlatform\Laravel\Metadata\CachePropertyMetadataFactory;
+use ApiPlatform\Laravel\Metadata\CachePropertyNameCollectionMetadataFactory;
+use ApiPlatform\Laravel\Metadata\CacheResourceCollectionMetadataFactory;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * Tests for issue #8413.
+ *
+ * Ensures the metadata cache factories serve repeated lookups from an in-memory cache
+ * instead of consulting the Laravel cache store on every call. Wiping the persistent
+ * store between two identical lookups proves the second one is answered from memory:
+ * without the in-memory cache, it would fall through to the (now empty) store and hit
+ * the decorated factory again.
+ */
+class CacheMetadataFactoriesTest extends TestCase
+{
+    public function testPropertyMetadataIsMemoizedInMemory(): void
+    {
+        $property = new ApiProperty();
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())
+            ->method('create')
+            ->with('App\Models\Book', 'title', [])
+            ->willReturn($property);
+
+        $factory = new CachePropertyMetadataFactory($decorated, 'array');
+
+        $this->assertSame($property, $factory->create('App\Models\Book', 'title'));
+
+        Cache::store('array')->clear();
+
+        $this->assertSame($property, $factory->create('App\Models\Book', 'title'));
+    }
+
+    public function testPropertyNameCollectionIsMemoizedInMemory(): void
+    {
+        $collection = new PropertyNameCollection(['title']);
+        $decorated = $this->createMock(PropertyNameCollectionFactoryInterface::class);
+        $decorated->expects($this->once())
+            ->method('create')
+            ->with('App\Models\Book', [])
+            ->willReturn($collection);
+
+        $factory = new CachePropertyNameCollectionMetadataFactory($decorated, 'array');
+
+        $this->assertSame($collection, $factory->create('App\Models\Book'));
+
+        Cache::store('array')->clear();
+
+        $this->assertSame($collection, $factory->create('App\Models\Book'));
+    }
+
+    public function testResourceMetadataCollectionIsMemoizedInMemory(): void
+    {
+        $collection = new ResourceMetadataCollection('App\Models\Book');
+        $decorated = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $decorated->expects($this->once())
+            ->method('create')
+            ->with('App\Models\Book')
+            ->willReturn($collection);
+
+        $factory = new CacheResourceCollectionMetadataFactory($decorated, 'array');
+
+        $this->assertSame($collection, $factory->create('App\Models\Book'));
+
+        Cache::store('array')->clear();
+
+        $this->assertSame($collection, $factory->create('App\Models\Book'));
+    }
+
+    public function testDifferentKeysAreCachedIndependently(): void
+    {
+        $title = new ApiProperty(description: 'title');
+        $isbn = new ApiProperty(description: 'isbn');
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnCallback(static fn (string $resourceClass, string $property) => match ($property) {
+                'title' => $title,
+                'isbn' => $isbn,
+                default => throw new \LogicException(\sprintf('Unexpected property "%s".', $property)),
+            });
+
+        $factory = new CachePropertyMetadataFactory($decorated, 'array');
+
+        $this->assertSame($title, $factory->create('App\Models\Book', 'title'));
+        $this->assertSame($isbn, $factory->create('App\Models\Book', 'isbn'));
+        $this->assertSame($title, $factory->create('App\Models\Book', 'title'));
+        $this->assertSame($isbn, $factory->create('App\Models\Book', 'isbn'));
+    }
+
+    public function testMetadataIsStoredInThePersistentCacheStore(): void
+    {
+        $property = new ApiProperty();
+        $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
+        $decorated->expects($this->once())
+            ->method('create')
+            ->with('App\Models\Book', 'title', [])
+            ->willReturn($property);
+
+        $factory = new CachePropertyMetadataFactory($decorated, 'array');
+        $factory->create('App\Models\Book', 'title');
+
+        $key = hash('xxh3', serialize(['resource_class' => 'App\Models\Book', 'property' => 'title']));
+        $this->assertSame($property, Cache::store('array')->get($key));
+    }
+}


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.3 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Closes #8413 |
| License       | MIT |

## Problem

The Laravel metadata cache factories (`CachePropertyMetadataFactory`, `CachePropertyNameCollectionMetadataFactory`, `CacheResourceCollectionMetadataFactory`) go through the Laravel cache repository on every `create()` call: store resolution via the facade, key hashing (`serialize()` + `xxh3`), and a `Repository::get()` that dispatches a `CacheHit` event per lookup.

`AbstractItemNormalizer` resolves metadata once per property per *item*, so a large collection response makes tens of thousands of trips through that stack in a single request (48,640 property-metadata lookups for a 2,023-item collection in the profiling from #8413). The Symfony implementation guards against exactly this with `CachedTrait`'s `$localCache` array. The Laravel port dropped that layer, so the per-request cost is `items × properties` instead of `properties`.

## Fix

Mirror the Symfony implementation: check an in-memory array before consulting the persistent store.

```php
return $this->localCache[$key] ??= Cache::store($this->cacheStore)->rememberForever($key, ...);
```

The factories are registered as singletons (`ApiPlatformProvider` / `ApiPlatformDeferredProvider`), so the array lives for the request, exactly like `CachedTrait`'s `$localCache` on the Symfony side. The persistent store keeps its role of amortizing metadata building across requests.

The three classes go from `final readonly` to `final` with individually `readonly` constructor properties, since a mutable array property requires it. The classes are `final`, so nothing can have extended them.

`??=` instead of `CachedTrait`'s `array_key_exists()`: the difference only matters when `null` is a legitimate cached value, and `null` is unrepresentable here. The decorated factories have non-nullable return types, and `rememberForever()` treats `null` from the store as a miss and falls through to the callback, so neither layer can ever produce it.

Measured on the reproduction from #8413 (2,023-item unpaginated collection, 7 scalar properties, plain JSON, v4.3.17): serialization drops from **1.18s to 0.61s**.

## Tests

Added `Tests/Metadata/CacheMetadataFactoriesTest.php`. The memoization proof avoids mocking the cache: perform a lookup, wipe the persistent store, look up again. The decorated factory must have been consulted exactly once, which is only possible if the second lookup was answered from memory. Also covers independent caching per key and the write to the persistent store.

The Laravel component suite passes unchanged.
