### PR TITLE
feat(object-mapper): Honor the output class in ObjectMapperOutputProcessor on write operations

### DIFF
--- a/src/State/Processor/ObjectMapperOutputProcessor.php
+++ b/src/State/Processor/ObjectMapperOutputProcessor.php
@@ -48,7 +48,7 @@ final class ObjectMapperOutputProcessor implements ProcessorInterface
 
         $request = $context['request'] ?? null;
         $request?->attributes->set('persisted_data', $data);
-        $dto = $this->objectMapper->map($data, $operation->getClass());
+        $dto = $this->objectMapper->map($data, $operation->getOutput()['class'] ?? $operation->getClass());
 
         return $this->decorated ? $this->decorated->process($dto, $operation, $uriVariables, $context) : $dto;
     }

--- a/src/State/Tests/Processor/ObjectMapperOutputProcessorTest.php
+++ b/src/State/Tests/Processor/ObjectMapperOutputProcessorTest.php
@@ -107,6 +107,31 @@ class ObjectMapperOutputProcessorTest extends TestCase
         $this->assertSame($result, $processor->process($entity, $operation));
     }
 
+    public function testProcessMapsEntityToDefinedOutputClass(): void
+    {
+        $entity = new \stdClass();
+        $entity->id = 1;
+        $dto = new \stdClass();
+        $dto->id = 1;
+        $result = new \stdClass();
+        $operation = new Post(class: ObjectMapperOutputDummy::class, output: ['class' => ObjectMapperOutputDtoDummy::class], map: true);
+
+        $objectMapper = $this->createMock(ObjectMapperInterface::class);
+        $objectMapper->expects($this->once())
+            ->method('map')
+            ->with($entity, ObjectMapperOutputDtoDummy::class)
+            ->willReturn($dto);
+
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->expects($this->once())
+            ->method('process')
+            ->with($dto, $operation, [], $this->anything())
+            ->willReturn($result);
+
+        $processor = new ObjectMapperOutputProcessor($objectMapper, $decorated);
+        $this->assertSame($result, $processor->process($entity, $operation));
+    }
+
     public function testProcessSetsPersistedDataOnRequest(): void
     {
         $entity = new \stdClass();
@@ -134,5 +159,9 @@ class ObjectMapperOutputProcessorTest extends TestCase
 }
 
 class ObjectMapperOutputDummy
+{
+}
+
+class ObjectMapperOutputDtoDummy
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

### Problem

When using the Symfony ObjectMapper integration ( `stateOptions: new Options(entityClass: MyEntity::class)` ), the read side and write side are inconsistent in how they resolve the target class.

On the read side,  `ObjectMapperProvider` correctly respects a configured  output  class, falling back to the operation class:
```php
// src/State/Provider/ObjectMapperProvider.php
$data = $this->objectMapper->map($data, $operation->getOutput()['class'] ?? $operation->getClass());
```

On the write side,  `ObjectMapperOutputProcessor` ignores the `output` class entirely and always maps back to `$operation->getClass()` :
```php
// src/State/Processor/ObjectMapperOutputProcessor.php
$dto = $this->objectMapper->map($data, $operation->getClass());
```

As a result, a write operation (`POST / PATCH / PUT`) that declares a dedicated `output` class silently maps the persisted entity back to the resource class instead of the requested output DTO. There is no way to return a different representation from a write than from a read when using ObjectMapper.

This is particularly limiting when the resource class itself cannot serve as a valid output representation for writes (for example, when the resource's IRI cannot be generated from the write result), forcing users to fall back to `output: false` and losing the response body altogether.

#### Fix
Mirror the read side so the processor honors the operation's `output` class when one is defined, falling back to the operation class otherwise:
```php
$dto = $this->objectMapper->map($data, $operation->getOutput()['class'] ?? $operation->getClass());
```
This makes read and write paths symmetric and lets a write operation return a dedicated output DTO via ObjectMapper.

#### Backward compatibility

Fully backward compatible: when no `output` class is configured, `getOutput()` is `null` and behavior is unchanged (maps to `$operation->getClass()`).