### PR TITLE
[MCP] Allow MCP sdk 0.7 

### DIFF
--- a/src/Mcp/composer.json
+++ b/src/Mcp/composer.json
@@ -30,7 +30,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^5.0@alpha",
         "api-platform/json-schema": "^5.0@alpha",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.6 || ^0.7",
         "symfony/object-mapper": "^7.4 || ^8.0",
         "symfony/polyfill-php85": "^1.32"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | 
| License       | MIT
| Doc PR        | 

Allow MCP SDK 0.7 for compatibility with latest symfony/mcp-bundle release