### PR TITLE
fix(serializer): denormalize object-typed args on discriminated input DTO subclass

### DIFF
--- a/src/Serializer/AbstractItemNormalizer.php
+++ b/src/Serializer/AbstractItemNormalizer.php
@@ -273,6 +273,13 @@ abstract class AbstractItemNormalizer extends AbstractObjectNormalizer
         if ($this->resourceClassResolver->isResourceClass($type)) {
             $resourceClass = $this->resourceClassResolver->getResourceClass($objectToPopulate, $type);
             $context['resource_class'] = $resourceClass;
+        } elseif (($context['api_platform_input'] ?? false) && isset($context['resource_class']) && $context['resource_class'] !== $type) {
+            // A discriminated input DTO base (not itself a resource) resolves to a concrete
+            // subclass here: pin the resource class to that concrete class so constructor and
+            // setter argument metadata is read from the subclass and not the abstract base,
+            // which lacks subclass-only properties (and thus their types).
+            $resourceClass = $type;
+            $context['resource_class'] = $type;
         }
 
         if (\is_string($data)) {

--- a/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/ChannelResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/ChannelResource.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DiscriminatedInputDto;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Post;
+
+#[ApiResource(
+    operations: [
+        new Post(
+            uriTemplate: '/discriminated_notification_channels',
+            input: NotificationChannelInput::class,
+            processor: [self::class, 'process'],
+        ),
+    ]
+)]
+final class ChannelResource
+{
+    public ?int $id = 1;
+
+    public ?string $type = null;
+
+    public ?string $url = null;
+
+    public ?int $retries = null;
+
+    public static function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): self
+    {
+        if (!$data instanceof WebhookChannelInput) {
+            throw new \InvalidArgumentException(\sprintf('Expected "%s", got "%s".', WebhookChannelInput::class, get_debug_type($data)));
+        }
+
+        $resource = new self();
+        $resource->type = $data->type;
+        $resource->url = $data->config->url;
+        $resource->retries = $data->config->retries;
+
+        return $resource;
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/NotificationChannelInput.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/NotificationChannelInput.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DiscriminatedInputDto;
+
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'webhook' => WebhookChannelInput::class,
+])]
+abstract class NotificationChannelInput
+{
+}

--- a/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/WebhookChannelInput.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/WebhookChannelInput.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DiscriminatedInputDto;
+
+final class WebhookChannelInput extends NotificationChannelInput
+{
+    public function __construct(
+        public readonly string $type,
+        public readonly WebhookConfig $config,
+    ) {
+    }
+}

--- a/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/WebhookConfig.php
+++ b/tests/Fixtures/TestBundle/ApiResource/DiscriminatedInputDto/WebhookConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DiscriminatedInputDto;
+
+final class WebhookConfig
+{
+    public function __construct(
+        public readonly string $url,
+        public readonly int $retries = 3,
+    ) {
+    }
+}

--- a/tests/Functional/DiscriminatedInputDtoTest.php
+++ b/tests/Functional/DiscriminatedInputDtoTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\DiscriminatedInputDto\ChannelResource;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class DiscriminatedInputDtoTest extends ApiTestCase
+{
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [ChannelResource::class];
+    }
+
+    public function testObjectTypedSubclassOnlyConstructorArgumentIsDenormalized(): void
+    {
+        self::createClient()->request('POST', '/discriminated_notification_channels', [
+            'headers' => ['Content-Type' => 'application/ld+json'],
+            'json' => [
+                'type' => 'webhook',
+                'config' => ['url' => 'https://example.com/hook', 'retries' => 5],
+            ],
+        ]);
+
+        $this->assertResponseStatusCodeSame(201);
+        $this->assertJsonContains([
+            'type' => 'webhook',
+            'url' => 'https://example.com/hook',
+            'retries' => 5,
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Fixes #8414
| License       | MIT
| Doc PR        | n/a

## Problem

When an operation uses a plain (non-`#[ApiResource]`) input DTO carrying a Symfony Serializer `#[DiscriminatorMap]`, and a concrete subclass declares a constructor argument that is (a) not a property on the abstract base and (b) object-typed (a nested DTO, not a scalar/array), that argument is passed to the constructor as the raw array instead of being denormalized — `TypeError`, HTTP 500.

Regression from #7779 (shipped 4.2.17); not affected `<= 4.2.16`.

```
WebhookChannelInput::__construct(): Argument #2 ($config) must be of type WebhookConfig, array given
```

## Root cause

In `AbstractItemNormalizer::denormalize()`, the input-DTO path (#7779) pins `resource_class` to the abstract input base. The discriminator then resolves the concrete subclass for instantiation, but because the resolved class is not itself a resource, `resource_class` stays the abstract base. Constructor/setter argument metadata is looked up against that base (`createAndValidateAttributeValue()`), so a subclass-only property resolves to *no type* and its nested payload falls through as a raw array.

The existing `CrudAbstractTest::testCreateConcreteViaDiscriminatorOnAbstract` doesn't catch this: there the abstract base *is* a resource, so the pre-existing `isResourceClass()` branch already re-pins `resource_class` to the concrete resource.

## Fix

On the input path, when the discriminator resolves a concrete non-resource subclass, pin `resource_class` to that concrete class so subclass-only argument types are found and denormalized. Sits next to the existing `isResourceClass()` branch that already handles the resource case.

## Tests

- New functional test `DiscriminatedInputDtoTest` mirroring the issue (plain-DTO input + Serializer `DiscriminatorMap` + object-typed subclass-only constructor arg). Fails with the exact `TypeError`/500 before the fix, 201 after.
- `CrudAbstractTest` (Doctrine table-inheritance discriminator) and the `AbstractItemNormalizer` unit suite stay green.