### PR TITLE
test(state): mark the deprecated serializer-aware provider test

### DIFF
--- a/tests/Functional/JsonLd/SerializableItemDataProviderTest.php
+++ b/tests/Functional/JsonLd/SerializableItemDataProviderTest.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Functional\JsonLd;
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
 use ApiPlatform\Tests\Fixtures\TestBundle\Model\SerializableResource;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 final class SerializableItemDataProviderTest extends ApiTestCase
 {
@@ -31,8 +32,11 @@ final class SerializableItemDataProviderTest extends ApiTestCase
         return [SerializableResource::class];
     }
 
+    #[IgnoreDeprecations]
     public function testGetSerializableResource(): void
     {
+        $this->expectUserDeprecationMessage('Since api-platform/core 4.2: The "ApiPlatform\State\SerializerAwareProviderInterface" interface is deprecated and will be removed in 5.0. It violates the dependency injection principle.');
+
         self::createClient()->request('GET', '/serializable_resources/1');
 
         $this->assertResponseStatusCodeSame(200);


### PR DESCRIPTION
Fixes the `PHPUnit (PHP 8.5) (no deprecations)` job, which runs `vendor/bin/phpunit --fail-on-deprecation --display-deprecations` and currently reports:

```
1 test triggered 1 deprecation:

1) src/State/SerializerAwareProviderTrait.php:33
Since api-platform/core 4.2: The "ApiPlatform\State\SerializerAwareProviderInterface" interface is
deprecated and will be removed in 5.0. It violates the dependency injection principle.

Triggered by:

* ApiPlatform\Tests\Functional\JsonLd\SerializableItemDataProviderTest::testGetSerializableResource
```

## Why

The `SerializableProvider` test fixture implements `SerializerAwareProviderInterface`. `DataProviderPass` therefore adds a `setSerializerLocator()` method call to its definition, and the trait triggers the 4.2 deprecation when the service is instantiated during the request.

The deprecation is correct and intentional — the interface still ships in 4.3 and is only removed in 5.0, so the code path must stay covered. Only the test needs to declare that it exercises a deprecated feature.

## Change

`#[IgnoreDeprecations]` plus `expectUserDeprecationMessage()` on the test, following the convention already used in `tests/Functional/EnumDenormalizationValidationTest.php`. Using the expectation rather than a bare ignore keeps the deprecation asserted, so it will be noticed when the interface is dropped in 5.0.

## Verified locally

| Run | Before | After |
| --- | --- | --- |
| `--fail-on-deprecation --display-deprecations` with `ignoreIndirectDeprecations="false"` | reproduces the CI message verbatim | OK (1 test, 3 assertions) |
| same, with the committed config | silent | OK (1 test, 3 assertions) |

The expectation is satisfied under both settings, so it does not depend on how the deprecation is categorised.

Note: this is the only remaining red check on #8425.