### PR TITLE
feat(metadata): add parameter name to uriVariablesConverter context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "jangregor/phpstan-prophecy": "^2.1.11",
         "justinrainbow/json-schema": "^6.5.2",
         "laravel/framework": "^11.0 || ^12.0 || ^13.0",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.7",
         "orchestra/testbench": "^10.9 || ^11.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "phpstan/extension-installer": "^1.1",

--- a/src/Metadata/Tests/UriVariablesConverterTest.php
+++ b/src/Metadata/Tests/UriVariablesConverterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Metadata\Tests;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\UriVariablesConverter;
+use ApiPlatform\Metadata\UriVariableTransformerInterface;
+use ApiPlatform\Tests\Fixtures\TestBundle\Document\Dummy;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+
+class UriVariablesConverterTest extends TestCase
+{
+    public function testParameterNameAddedToContext(): void
+    {
+        $transformer = $this->createMock(UriVariableTransformerInterface::class);
+
+        $contextDuringSupports = [];
+        $transformer
+            ->expects($this->once())
+            ->method('supportsTransformation')
+            ->willReturnCallback(static function ($v, $t, $context) use (&$contextDuringSupports) {
+                $contextDuringSupports = $context;
+
+                return true;
+            });
+
+        $contextduringTransform = [];
+        $transformer
+            ->expects($this->once())
+            ->method('transform')
+            ->willReturnCallback(static function ($v, $t, $context) use (&$contextduringTransform) {
+                $contextduringTransform = $context;
+
+                return $v;
+            });
+
+        $metadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $metadataFactory->method('create')->willReturn(new ApiProperty(nativeType: new BuiltinType(TypeIdentifier::STRING)));
+
+        $converter = new UriVariablesConverter(
+            $metadataFactory,
+            $this->createStub(ResourceMetadataCollectionFactoryInterface::class),
+            [$transformer],
+        );
+
+        $context = ['operation' => new Get(), 'parameterName' => 'not-overwritten'];
+        $converter->convert(['foo' => 'bar'], Dummy::class, $context);
+
+        self::assertArrayHasKey('parameterName', $contextDuringSupports);
+        self::assertEquals($contextDuringSupports['parameterName'], 'foo');
+
+        self::assertArrayHasKey('parameterName', $contextduringTransform);
+        self::assertEquals($contextDuringSupports['parameterName'], 'foo');
+
+        self::assertEquals('not-overwritten', $context['parameterName']);
+    }
+}

--- a/src/Metadata/UriVariablesConverter.php
+++ b/src/Metadata/UriVariablesConverter.php
@@ -60,12 +60,14 @@ final class UriVariablesConverter implements UriVariablesConverterInterface
             }
 
             foreach ($this->uriVariableTransformers as $uriVariableTransformer) {
-                if (!$uriVariableTransformer->supportsTransformation($value, $types, $context)) {
+                $paramContext = $context;
+                $paramContext['parameterName'] = $parameterName;
+                if (!$uriVariableTransformer->supportsTransformation($value, $types, $paramContext)) {
                     continue;
                 }
 
                 try {
-                    $uriVariables[$parameterName] = $uriVariableTransformer->transform($value, $types, $context);
+                    $uriVariables[$parameterName] = $uriVariableTransformer->transform($value, $types, $paramContext);
                     break;
                 } catch (InvalidUriVariableException $e) {
                     throw new InvalidUriVariableException(\sprintf('Identifier "%s" could not be transformed.', $parameterName), $e->getCode(), $e);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Tickets       | 
| License       | MIT
| Doc PR        | 

Adds the parameter name of the variable that's currently being processed to the context so custom implementations of `UriVariableTransformerInterface` can do something with it.

Our immediate use-case is that we have a uri variable that's a base64 encoded classname for a foreign entity, say:

```php
#[GetCollection(
    uriTemplate: '/blips/{targetClass}/{foreignKey}',
    uriVariables: ['targetClass', 'foreignKey'],
)]
class Blip {}
```

The `targetClass` value is actually just a base64 encoded string, and it's also stored in the database. If we just use it like this (using symfony/doctrine), it will create the query with the correct parameters, but the value for targetClass remains b64 encoded.

We can get around that by adding a custom uri variables transformer:
```php
class BlipUriVariableTransformer implements UriVariableTransformerInterface
{
    public function supportsTransformation(mixed $value, array $types, array $context = []): bool
    {
        $operation = $context['operation'] ?? null;
        return $operation instanceof GetCollection && $operation->getClass() === Blip::class;
    }

    // ...
}
```

But this also triggers for the foreign key argument, so we need to base64 decode, and then check if the class exists, during the transformation itself:

```php
    public function transform(mixed $value, array $types, array $context = []): string
    {
        $newValue = base64_decode($value);
        if (class_exists($newValue)) {
            return $newValue;
        }
        return $value;
    }
```

This is not very clean... 😞 

So this pull requests adds the current parameter name that's being transformed to the context, which will change our implementation to:

```php
class BlipUriVariableTransformer implements UriVariableTransformerInterface
{
    public function supportsTransformation(mixed $value, array $types, array $context = []): bool
    {
        $operation = $context['operation'] ?? null;
        if (!$operation instanceof GetCollection || $operation->getClass() !== Blip::class) {
            return false;
        }
        return ($context['parameterName'] ?? null) === 'targetClass';
    }

    public function transform(mixed $value, array $types, array $context = []): string
    {
        return base64_decode($value);
    }
}
```

Very nice! 👍 

I've also noticed there wasn't a unit test yet for `UriVariablesConverter`, so I just added one but it only validates that the `parameterName` is temporarily available in the context and not overwritten outside of it.