### PR TITLE
fix(mcp): return resource read results for resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -142,7 +142,7 @@
         "jangregor/phpstan-prophecy": "^2.1.11",
         "justinrainbow/json-schema": "^6.5.2",
         "laravel/framework": "^11.0 || ^12.0 || ^13.0",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.7",
         "orchestra/testbench": "^10.9 || ^11.0",
         "phpspec/prophecy-phpunit": "^2.2",
         "phpstan/extension-installer": "^1.1",

--- a/src/Laravel/ApiPlatformProvider.php
+++ b/src/Laravel/ApiPlatformProvider.php
@@ -193,6 +193,7 @@ use Negotiation\Negotiator;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\McpBundle\Controller\McpController;
+use Symfony\AI\McpBundle\Http\MiddlewareFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -1342,7 +1343,8 @@ class ApiPlatformProvider extends ServiceProvider
                 $psrHttpFactory,
                 $httpFoundationFactory,
                 $psr17Factory,
-                $psr17Factory
+                $psr17Factory,
+                new MiddlewareFactory()
             );
         });
     }

--- a/src/Mcp/State/StructuredContentProcessor.php
+++ b/src/Mcp/State/StructuredContentProcessor.php
@@ -19,6 +19,7 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\SerializerContextBuilderInterface;
 use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Content\TextResourceContents;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Result\CallToolResult;
 use Mcp\Schema\Result\ReadResourceResult;
@@ -69,6 +70,15 @@ final class StructuredContentProcessor implements ProcessorInterface
             if ($includeStructuredContent) {
                 $structuredContent = $normalized;
             }
+        }
+
+        if ($operation instanceof McpResource) {
+            return new Response(
+                $context['mcp_request']->getId(),
+                new ReadResourceResult([
+                    new TextResourceContents($operation->getUri(), $operation->getMimeType() ?? 'application/json', $result),
+                ]),
+            );
         }
 
         return new Response(

--- a/src/Mcp/Tests/State/StructuredContentProcessorTest.php
+++ b/src/Mcp/Tests/State/StructuredContentProcessorTest.php
@@ -14,13 +14,16 @@ declare(strict_types=1);
 namespace ApiPlatform\Mcp\Tests\State;
 
 use ApiPlatform\Mcp\State\StructuredContentProcessor;
+use ApiPlatform\Metadata\McpResource;
 use ApiPlatform\Metadata\McpTool;
 use ApiPlatform\State\ProcessorInterface;
 use ApiPlatform\State\SerializerContextBuilderInterface;
 use Mcp\Schema\Content\TextContent;
+use Mcp\Schema\Content\TextResourceContents;
 use Mcp\Schema\JsonRpc\Request;
 use Mcp\Schema\JsonRpc\Response;
 use Mcp\Schema\Result\CallToolResult;
+use Mcp\Schema\Result\ReadResourceResult;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
@@ -80,6 +83,45 @@ class StructuredContentProcessorTest extends TestCase
         $this->assertInstanceOf(TextContent::class, $textContent);
         $this->assertNotSame('{}', $textContent->text);
         $this->assertSame($expectedJson, $textContent->text);
+    }
+
+    public function testMcpResourceReturnsReadResourceResult(): void
+    {
+        $expectedJson = '{"name":"foo"}';
+        $resourceUri = 'app://dummy';
+        $resourceMimeType = 'application/json';
+
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->method('process')->willReturn(new \stdClass());
+
+        $serializer = $this->createMock(SerializerEncoderNormalizer::class);
+        $serializer->method('normalize')->willReturn(['name' => 'foo']);
+        $serializer->method('encode')->willReturn($expectedJson);
+
+        $contextBuilder = $this->createMock(SerializerContextBuilderInterface::class);
+        $contextBuilder->method('createFromRequest')->willReturn([]);
+
+        $processor = new StructuredContentProcessor($serializer, $contextBuilder, $decorated);
+
+        $operation = (new McpResource(uri: $resourceUri, mimeType: $resourceMimeType))->withClass(\stdClass::class);
+
+        $mcpRequest = $this->createMock(Request::class);
+        $mcpRequest->method('getId')->willReturn('req-1');
+
+        /** @var Response $response */
+        $response = $processor->process([], $operation, [], [
+            'mcp_request' => $mcpRequest,
+            'request' => new HttpRequest(),
+        ]);
+
+        $result = $response->result;
+        $this->assertInstanceOf(ReadResourceResult::class, $result);
+
+        $resourceContents = $result->contents[0];
+        $this->assertInstanceOf(TextResourceContents::class, $resourceContents);
+        $this->assertSame($resourceUri, $resourceContents->uri);
+        $this->assertSame($resourceMimeType, $resourceContents->mimeType);
+        $this->assertSame($expectedJson, $resourceContents->text);
     }
 }
 

--- a/src/Mcp/composer.json
+++ b/src/Mcp/composer.json
@@ -30,7 +30,7 @@
         "php": ">=8.2",
         "api-platform/metadata": "^5.0@alpha",
         "api-platform/json-schema": "^5.0@alpha",
-        "mcp/sdk": "^0.6",
+        "mcp/sdk": "^0.7",
         "symfony/object-mapper": "^7.4 || ^8.0",
         "symfony/polyfill-php85": "^1.32"
     },


### PR DESCRIPTION
Fixes #8428.

## What changed
- Return `ReadResourceResult` for `McpResource` operations handled by `StructuredContentProcessor`.
- Preserve the existing `CallToolResult` path for MCP tools.
- Add a unit regression test that asserts resource reads expose `contents` via `TextResourceContents`.
- Align the root and split-package `mcp/sdk` constraints with `symfony/mcp-bundle dev-main`, which now requires `mcp/sdk ^0.7`.

## RED
```
docker run --rm --label com.ora.cleanup.scope=contribute -v "$PWD":/app -w /app composer:2.9.8 sh -lc 'composer update symfony/mcp-bundle --dry-run'

Your requirements could not be resolved to an installable set of packages.
Root composer.json requires mcp/sdk ^0.6 ... package is fixed to v0.7.0 (lock file version) by a partial update and that version does not match.
```

Original behavior RED:
```
docker run --rm --label com.ora.cleanup.scope=contribute -v "$PWD":/app -w /app php:8.4-cli vendor/bin/phpunit src/Mcp/Tests/State/StructuredContentProcessorTest.php --filter testMcpResourceReturnsReadResourceResult

Failed asserting that an instance of class Mcp\Schema\Result\CallToolResult is an instance of class Mcp\Schema\Result\ReadResourceResult.
Tests: 1, Assertions: 1, Failures: 1.
```

## GREEN
```
./run-ci.sh

composer update symfony/mcp-bundle mcp/sdk --dry-run: OK
composer install --no-progress: OK
vendor/bin/phpunit src/Mcp/Tests/State/StructuredContentProcessorTest.php --filter testMcpResourceReturnsReadResourceResult: Tests: 1, Assertions: 5, PHPUnit Notices: 1
php-cs-fixer dry-run on touched files: Found 0 of 4 files that can be fixed.
```
