### PR TITLE
ci: restrict default token permissions to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   COMPOSER_ROOT_VERSION: "4.3.x-dev"

--- a/.github/workflows/guides.yml
+++ b/.github/workflows/guides.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     COVERAGE: '0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   split:
     name: Subtree Split
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Generate App Token
         id: generate_token


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | ∅
| License       | MIT
| Doc PR        | ∅

## What

Declares a top-level `permissions: contents: read` in the CI, Guides and Release Pipeline workflows. `Commit Lint` already had one and is untouched.

Nothing in the CI or Guides workflows writes back to GitHub — no `git push`, no `gh` call, no PR-creating action. Artifact upload and dependency caching authenticate with `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN`, so they are unaffected by the restriction.

Release Pipeline does push: its subtree-split job runs `subtree.sh`, which splits each `src/*` component and pushes the result to the matching per-component repository. It nonetheless loses the `contents: write` that job declared, because that grant was never what authorised those pushes — every target is a *separate* repository (`api-platform/serializer`, `api-platform/state`, …), and `GITHUB_TOKEN` is scoped to this repository alone, so no permission level on it could reach them. The credential that does authorise them is the GitHub App token, which `actions/checkout` receives explicitly and stores as a host-scoped `http.https://github.com/.extraheader`, applying to the remotes the script adds afterwards. No step in the workflow references `GITHUB_TOKEN` at all, so all three jobs run read-only and the release process is unchanged.

## Why

With no explicit block, `GITHUB_TOKEN` inherits the repository or organisation default, which on older settings is read *and write* across every scope. That is ambient authority these jobs never exercise: any compromised step, dependency or action in a run triggered from a branch push could use it to push commits, edit issues, or alter releases.

Declaring the scopes makes the grant match the work, and also pins it against a future change to the org-wide default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
