### PR TITLE
ci: verify splitsh-lite checksum before running it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install splitsh
+        env:
+          SPLITSH_VERSION: v1.0.1
+          SPLITSH_SHA256: 2539301ce5e21d0ca44b689d0dd2c1b20d9f9e996c1fe6c462afb8af4e7141cc
         run: |
-          curl -L https://github.com/splitsh/lite/releases/download/v1.0.1/lite_linux_amd64.tar.gz > lite_linux_amd64.tar.gz
+          curl -fsSL "https://github.com/splitsh/lite/releases/download/$SPLITSH_VERSION/lite_linux_amd64.tar.gz" > lite_linux_amd64.tar.gz
+          echo "$SPLITSH_SHA256  lite_linux_amd64.tar.gz" | sha256sum --check --strict
           tar -zxpf lite_linux_amd64.tar.gz
           chmod +x splitsh-lite
           echo "$(pwd)" >> $GITHUB_PATH


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | ∅
| License       | MIT
| Doc PR        | ∅

## What

The Subtree Split job downloads the `splitsh-lite` release tarball, unpacks it and executes it. This adds a `sha256sum --check` between the download and `tar`, so a tarball whose bytes changed aborts the job instead of running. `curl` also gains `-f`: without it an HTTP error page is written to the file and curl still exits 0, leaving `tar` to consume the error body.

The version and the digest live in `env:` so they stay visibly paired, and the checksum line uses the exact two-space format `sha256sum` emits, so it can be regenerated and pasted verbatim.

## Why

Release assets on GitHub are mutable: the URL pins a name, not a payload, and anyone with push access to `splitsh/lite` can replace the file behind an unchanged `v1.0.1` link. That download happens in the one job that holds `API_PLATFORM_APP_PRIVATE_KEY`, whose App can write to all twenty-one component repositories and dispatch releases in `api-platform/api-platform` and `api-platform/demo`. Arbitrary code there reaches every published Composer package, so it is the highest-value step in the repository to leave unverified. This is the same class of hole that pinning actions to commit SHAs closes, applied to a payload no action pin covers.

`splitsh/lite` publishes no checksums, so the digest was computed from the asset as currently served. That is trust-on-first-use: it prevents future substitution but cannot prove the current bytes are the 2017 originals. The release API corroborates them — the asset's `updated_at` is two seconds after its `created_at` in February 2017 and has not moved since, and GitHub bumps that field when an asset is replaced, across 203k downloads.

A stronger root of trust would mean building `splitsh-lite` from a pinned source commit or vendoring the binary; both are larger changes than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
