### PR TITLE
[Draft] Add Meilisearch support (src/Meilisearch)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
         "api-platform/jsonld": "self.version",
         "api-platform/laravel": "self.version",
         "api-platform/mcp": "self.version",
+        "api-platform/meilisearch": "self.version",
         "api-platform/metadata": "self.version",
         "api-platform/openapi": "self.version",
         "api-platform/parameter-validator": "self.version",

--- a/src/Meilisearch/Extension/FilterExtension.php
+++ b/src/Meilisearch/Extension/FilterExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Extension;
+
+use ApiPlatform\Meilisearch\Filter\FilterInterface;
+use ApiPlatform\Metadata\Operation;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Resolves the operation's `#[ApiFilter]`-declared filter services and lets
+ * each contribute to the search parameters, then AND-joins every collected
+ * `filterExpressions` fragment into Meilisearch's single `filter` string.
+ *
+ * Simpler than Elasticsearch's AbstractFilterExtension: there's one filter
+ * interface (not a family split by ConstantScoreFilterInterface/
+ * SortFilterInterface), because there's no JSON query-DSL tree to merge
+ * fragments into at different points.
+ */
+final class FilterExtension implements RequestParametersCollectionExtensionInterface
+{
+    public function __construct(private readonly ContainerInterface $filterLocator)
+    {
+    }
+
+    public function applyToCollection(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    {
+        $filterIds = $operation?->getFilters();
+
+        if ($filterIds) {
+            foreach ($filterIds as $filterId) {
+                if ($this->filterLocator->has($filterId) && ($filter = $this->filterLocator->get($filterId)) instanceof FilterInterface) {
+                    $parameters = $filter->apply($parameters, $resourceClass, $operation, $context);
+                }
+            }
+        }
+
+        if ($expressions = $parameters['filterExpressions'] ?? null) {
+            $parameters['filter'] = implode(' AND ', $expressions);
+        }
+        unset($parameters['filterExpressions']);
+
+        return $parameters;
+    }
+}

--- a/src/Meilisearch/Extension/RequestParametersCollectionExtensionInterface.php
+++ b/src/Meilisearch/Extension/RequestParametersCollectionExtensionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Extension;
+
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * Incrementally contributes to a Meilisearch search-parameters array
+ * (q, filter, sort, facets, ...) while querying a resource collection.
+ *
+ * Unlike Elasticsearch's RequestBodySearchCollectionExtensionInterface, this
+ * operates on Meilisearch's flat parameters array rather than a nested query
+ * body -- there is no query-DSL tree to merge.
+ */
+interface RequestParametersCollectionExtensionInterface
+{
+    /**
+     * @param array<string, mixed> $parameters
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    public function applyToCollection(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array;
+}

--- a/src/Meilisearch/Extension/SortExtension.php
+++ b/src/Meilisearch/Extension/SortExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Extension;
+
+use ApiPlatform\Metadata\HttpOperation;
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * Applies the operation's default order (or a resource-wide default
+ * direction) as Meilisearch `sort` entries (`["field:asc", ...]`).
+ *
+ * Sorting on a property requires it to be declared in the index's
+ * `sortableAttributes` -- Meilisearch will 400 otherwise. That's the
+ * caller's responsibility (see Options/index settings), not this class's.
+ */
+final class SortExtension implements RequestParametersCollectionExtensionInterface
+{
+    public function __construct(private readonly ?string $defaultDirection = null)
+    {
+    }
+
+    public function applyToCollection(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    {
+        $sort = [];
+
+        if ($operation && null !== ($defaultOrder = $operation->getOrder())) {
+            foreach ($defaultOrder as $property => $direction) {
+                if (\is_int($property)) {
+                    $property = $direction;
+                    $direction = 'asc';
+                }
+
+                $sort[] = \sprintf('%s:%s', $property, strtolower((string) $direction));
+            }
+        } elseif (null !== $this->defaultDirection) {
+            $property = 'id';
+            if ($operation instanceof HttpOperation) {
+                $uriVariables = $operation->getUriVariables()[0] ?? null;
+                $property = $uriVariables ? $uriVariables->getIdentifiers()[0] ?? 'id' : 'id';
+            }
+
+            $sort[] = \sprintf('%s:%s', $property, strtolower($this->defaultDirection));
+        }
+
+        if (!$sort) {
+            return $parameters;
+        }
+
+        $parameters['sort'] = array_merge($parameters['sort'] ?? [], $sort);
+
+        return $parameters;
+    }
+}

--- a/src/Meilisearch/Filter/AbstractFilter.php
+++ b/src/Meilisearch/Filter/AbstractFilter.php
@@ -39,6 +39,32 @@ abstract class AbstractFilter implements FilterInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getDescription(string $resourceClass): array
+    {
+        $description = [];
+
+        foreach ($this->getProperties($resourceClass) as $property) {
+            $description[$property] = [
+                'property' => $property,
+                'type' => 'string',
+                'required' => false,
+                'is_collection' => false,
+            ];
+
+            $description[$property.'[]'] = [
+                'property' => $property,
+                'type' => 'string',
+                'required' => false,
+                'is_collection' => true,
+            ];
+        }
+
+        return $description;
+    }
+
+    /**
      * Quotes a value for use inside a Meilisearch filter expression.
      */
     protected function quote(mixed $value): string

--- a/src/Meilisearch/Filter/AbstractFilter.php
+++ b/src/Meilisearch/Filter/AbstractFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Filter;
+
+/**
+ * @author API Platform Community
+ */
+abstract class AbstractFilter implements FilterInterface
+{
+    /**
+     * @param string[]|null $properties null means "no restriction" (every filterable-in-the-index property is accepted)
+     */
+    public function __construct(protected readonly ?array $properties = null)
+    {
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getProperties(string $resourceClass): array
+    {
+        return $this->properties ?? [];
+    }
+
+    protected function isPropertyEnabled(string $property): bool
+    {
+        return null === $this->properties || \in_array($property, $this->properties, true);
+    }
+
+    /**
+     * Quotes a value for use inside a Meilisearch filter expression.
+     */
+    protected function quote(mixed $value): string
+    {
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_numeric($value)) {
+            return (string) $value;
+        }
+
+        return '"'.str_replace('"', '\\"', (string) $value).'"';
+    }
+}

--- a/src/Meilisearch/Filter/FilterInterface.php
+++ b/src/Meilisearch/Filter/FilterInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Meilisearch\Filter;
 
+use ApiPlatform\Metadata\FilterInterface as BaseFilterInterface;
 use ApiPlatform\Metadata\Operation;
 
 /**
@@ -21,8 +22,14 @@ use ApiPlatform\Metadata\Operation;
  * `filter` expression fragments (see FilterExtension) -- simpler than
  * Elasticsearch's bool/must JSON-tree merging, since Meilisearch's filter
  * syntax is a single flat expression string.
+ *
+ * Extends the core FilterInterface (still required by
+ * ParameterValidationResourceMetadataCollectionFactory for `filters:`-
+ * referenced services as of 5.0-alpha, despite getDescription() itself
+ * being marked @deprecated there since 4.2) so filters declared this way
+ * satisfy both contracts.
  */
-interface FilterInterface
+interface FilterInterface extends BaseFilterInterface
 {
     /**
      * @param array<string, mixed> $parameters

--- a/src/Meilisearch/Filter/FilterInterface.php
+++ b/src/Meilisearch/Filter/FilterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Filter;
+
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * A filter contributes a fragment to a Meilisearch search-parameters array.
+ * Multiple filters on the same resource compose by AND-joining their
+ * `filter` expression fragments (see FilterExtension) -- simpler than
+ * Elasticsearch's bool/must JSON-tree merging, since Meilisearch's filter
+ * syntax is a single flat expression string.
+ */
+interface FilterInterface
+{
+    /**
+     * @param array<string, mixed> $parameters
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    public function apply(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array;
+}

--- a/src/Meilisearch/Filter/SearchFilter.php
+++ b/src/Meilisearch/Filter/SearchFilter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Filter;
+
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * Free-text search filter: the first configured property found in the
+ * request's filters becomes Meilisearch's `q` search term. Unlike
+ * Elasticsearch's MatchFilter (which targets one field per query clause),
+ * Meilisearch searches across every attribute declared in the index's
+ * `searchableAttributes` at once -- `q` isn't property-scoped, so this
+ * filter's job is just "is a free-text search active, and what's the term."
+ *
+ * Syntax: `?property=search+terms` (property name is only used to opt in
+ * via `#[ApiFilter(SearchFilter::class, properties: ['title'])]`; the term
+ * itself searches the whole index).
+ */
+final class SearchFilter extends AbstractFilter
+{
+    public function apply(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    {
+        if (isset($parameters['q']) && '' !== $parameters['q']) {
+            return $parameters;
+        }
+
+        foreach ($context['filters'] ?? [] as $property => $value) {
+            if (!$this->isPropertyEnabled($property) || !\is_string($value) || '' === $value) {
+                continue;
+            }
+
+            $parameters['q'] = $value;
+
+            return $parameters;
+        }
+
+        return $parameters;
+    }
+}

--- a/src/Meilisearch/Filter/TermFilter.php
+++ b/src/Meilisearch/Filter/TermFilter.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Filter;
+
+use ApiPlatform\Metadata\Operation;
+
+/**
+ * Exact-match / facet filter: `?genres[]=Action&genres[]=Comedy` becomes the
+ * Meilisearch filter expression `(genres = "Action" OR genres = "Comedy")`.
+ *
+ * Requires the property to be declared in the index's `filterableAttributes`
+ * -- Meilisearch 400s on an undeclared attribute, there is no equivalent
+ * restriction in Elasticsearch's mapping-based approach. Index settings are
+ * the caller's responsibility, not this filter's.
+ *
+ * Syntax: `?property=value` or `?property[]=value` for multiple values.
+ */
+final class TermFilter extends AbstractFilter
+{
+    public function apply(array $parameters, string $resourceClass, ?Operation $operation = null, array $context = []): array
+    {
+        $expressions = [];
+
+        foreach ($context['filters'] ?? [] as $property => $values) {
+            if (!$this->isPropertyEnabled($property)) {
+                continue;
+            }
+
+            $values = (array) $values;
+            if (!$values) {
+                continue;
+            }
+
+            $terms = array_map(fn ($value): string => \sprintf('%s = %s', $property, $this->quote($value)), $values);
+            $expressions[] = \count($terms) > 1 ? '('.implode(' OR ', $terms).')' : $terms[0];
+        }
+
+        if (!$expressions) {
+            return $parameters;
+        }
+
+        $parameters['filterExpressions'] = array_merge($parameters['filterExpressions'] ?? [], $expressions);
+
+        return $parameters;
+    }
+}

--- a/src/Meilisearch/Metadata/Resource/Factory/MeilisearchProviderResourceMetadataCollectionFactory.php
+++ b/src/Meilisearch/Metadata/Resource/Factory/MeilisearchProviderResourceMetadataCollectionFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Metadata\Resource\Factory;
+
+use ApiPlatform\Meilisearch\State\CollectionProvider;
+use ApiPlatform\Meilisearch\State\ItemProvider;
+use ApiPlatform\Meilisearch\State\Options;
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+
+/**
+ * Auto-assigns CollectionProvider/ItemProvider to any operation whose
+ * stateOptions is a Meilisearch\State\Options instance and has no explicit
+ * provider set -- so `stateOptions: new Options(index: 'movie')` is enough
+ * on its own, no `provider:` needed. Mirrors
+ * ElasticsearchProviderResourceMetadataCollectionFactory exactly.
+ */
+final class MeilisearchProviderResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(private readonly ResourceMetadataCollectionFactoryInterface $decorated)
+    {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        foreach ($resourceMetadataCollection as $i => $resourceMetadata) {
+            $operations = $resourceMetadata->getOperations();
+
+            if ($operations) {
+                foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
+                    if ($operation->getProvider()) {
+                        continue;
+                    }
+
+                    if (!$operation->getStateOptions() instanceof Options) {
+                        continue;
+                    }
+
+                    $operations->add($operationName, $operation->withProvider($operation instanceof CollectionOperationInterface ? CollectionProvider::class : ItemProvider::class));
+                }
+
+                $resourceMetadata = $resourceMetadata->withOperations($operations);
+            }
+
+            $resourceMetadataCollection[$i] = $resourceMetadata;
+        }
+
+        return $resourceMetadataCollection;
+    }
+}

--- a/src/Meilisearch/Paginator.php
+++ b/src/Meilisearch/Paginator.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch;
+
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use Meilisearch\Search\SearchResult;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Paginator for Meilisearch. Assumes offset/limit pagination (the SearchResult
+ * was requested without `page`/`hitsPerPage`, see CollectionProvider) so
+ * getEstimatedTotalHits() is always populated.
+ *
+ * @author API Platform Community
+ */
+final class Paginator implements \IteratorAggregate, PaginatorInterface
+{
+    private array $cachedDenormalizedHits = [];
+
+    public function __construct(
+        private readonly DenormalizerInterface $denormalizer,
+        private readonly SearchResult $searchResult,
+        private readonly string $resourceClass,
+        private readonly int $limit,
+        private readonly int $offset,
+        private readonly array $denormalizationContext = [],
+        private readonly string $primaryKey = 'id',
+    ) {
+    }
+
+    public function count(): int
+    {
+        return $this->searchResult->getHitsCount();
+    }
+
+    public function getLastPage(): float
+    {
+        if (0 >= $this->limit) {
+            return 1.;
+        }
+
+        return ceil($this->getTotalItems() / $this->limit) ?: 1.;
+    }
+
+    public function getTotalItems(): float
+    {
+        return (float) ($this->searchResult->getEstimatedTotalHits() ?? $this->searchResult->getHitsCount());
+    }
+
+    public function getCurrentPage(): float
+    {
+        if (0 >= $this->limit) {
+            return 1.;
+        }
+
+        return floor($this->offset / $this->limit) + 1.;
+    }
+
+    public function getItemsPerPage(): float
+    {
+        return (float) $this->limit;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        $denormalizationContext = array_merge([AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true], $this->denormalizationContext);
+
+        foreach ($this->searchResult->getHits() as $hit) {
+            $cacheKey = isset($hit[$this->primaryKey]) ? hash('xxh3', (string) $hit[$this->primaryKey]) : null;
+
+            if ($cacheKey && \array_key_exists($cacheKey, $this->cachedDenormalizedHits)) {
+                yield $this->cachedDenormalizedHits[$cacheKey];
+                continue;
+            }
+
+            $object = $this->denormalizer->denormalize($hit, $this->resourceClass, 'array', $denormalizationContext);
+
+            if ($cacheKey) {
+                $this->cachedDenormalizedHits[$cacheKey] = $object;
+            }
+
+            yield $object;
+        }
+    }
+}

--- a/src/Meilisearch/README.md
+++ b/src/Meilisearch/README.md
@@ -1,0 +1,19 @@
+# API Platform - Meilisearch Support
+
+Integration for [Meilisearch](https://www.meilisearch.com) with the [API Platform](https://api-platform.com) framework.
+
+Modeled on `api-platform/elasticsearch`, with two deliberate deviations:
+
+- **One client, one exception type.** Meilisearch has a single official PHP client (MIT licensed) and a single `ApiException` with a typed `httpStatus` property, so `CollectionProvider`/`ItemProvider` don't need Elasticsearch's `V7Client|Client|OpenSearchClient` union type or its three different 404-exception classes.
+- **Flat search parameters, not a nested query body.** Meilisearch's API takes `q`, a single `filter` expression string, `sort: ["field:asc"]`, `facets: [...]`, `limit`/`offset` — there's no bool/must/should tree to build. `RequestParametersCollectionExtensionInterface` and `FilterInterface` operate on that flat array; composing multiple filters is AND-joining expression strings, not merging JSON.
+
+Per-operation config works exactly like Elasticsearch's: attach `stateOptions: new ApiPlatform\Meilisearch\State\Options(index: 'movie')` to an operation and `MeilisearchProviderResourceMetadataCollectionFactory` auto-assigns `CollectionProvider`/`ItemProvider` — no `provider:` needed, no route-name matching.
+
+**Caveat not present in the Elasticsearch integration:** Meilisearch requires attributes to be pre-declared as `filterableAttributes`/`sortableAttributes` on the index, or a query against them 400s. This package does not manage index settings — that's the caller's responsibility (e.g. via whatever indexes the documents in the first place).
+
+> [!CAUTION]
+>
+> This is a read-only sub split of `api-platform/core`, please
+> [report issues](https://github.com/api-platform/core/issues) and
+> [send Pull Requests](https://github.com/api-platform/core/pulls)
+> in the [core API Platform repository](https://github.com/api-platform/core).

--- a/src/Meilisearch/State/CollectionProvider.php
+++ b/src/Meilisearch/State/CollectionProvider.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\State;
+
+use ApiPlatform\Meilisearch\Extension\RequestParametersCollectionExtensionInterface;
+use ApiPlatform\Meilisearch\Paginator;
+use ApiPlatform\Metadata\InflectorInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Util\Inflector;
+use ApiPlatform\State\ApiResource\Error;
+use ApiPlatform\State\Pagination\Pagination;
+use ApiPlatform\State\ProviderInterface;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Collection provider for Meilisearch.
+ *
+ * Unlike Elasticsearch's CollectionProvider, the client type here is a
+ * single concrete class (Meilisearch\Client) -- one official SDK, one
+ * license, no elasticsearch-php-v7/elastic-elasticsearch-v8/opensearch-php
+ * union type to juggle.
+ *
+ * @author API Platform Community
+ */
+final class CollectionProvider implements ProviderInterface
+{
+    /**
+     * @param RequestParametersCollectionExtensionInterface[] $collectionExtensions
+     */
+    public function __construct(
+        private readonly Client $client,
+        private readonly ?DenormalizerInterface $denormalizer = null,
+        private readonly ?Pagination $pagination = null,
+        private readonly iterable $collectionExtensions = [],
+        private readonly ?InflectorInterface $inflector = new Inflector(),
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): Paginator
+    {
+        $resourceClass = $operation->getClass();
+        $parameters = ['q' => ''];
+
+        foreach ($this->collectionExtensions as $collectionExtension) {
+            $parameters = $collectionExtension->applyToCollection($parameters, $resourceClass, $operation, $context);
+        }
+
+        $q = $parameters['q'] ?? '';
+        unset($parameters['q']);
+
+        $limit = $parameters['limit'] ??= $this->pagination->getLimit($operation, $context);
+        $offset = $parameters['offset'] ??= $this->pagination->getOffset($operation, $context);
+
+        $options = $operation->getStateOptions() instanceof Options ? $operation->getStateOptions() : new Options(index: $this->getIndex($operation));
+
+        try {
+            $searchResult = $this->client->index($options->getIndex() ?? $this->getIndex($operation))->search($q, $parameters);
+        } catch (ApiException $e) {
+            throw new Error(status: $e->httpStatus, detail: $e->getMessage(), title: $e->getMessage(), originalTrace: $e->getTrace());
+        }
+
+        return new Paginator(
+            $this->denormalizer,
+            $searchResult,
+            $resourceClass,
+            $limit,
+            $offset,
+            $context,
+            $options->getPrimaryKey() ?? 'id',
+        );
+    }
+
+    private function getIndex(Operation $operation): string
+    {
+        return $this->inflector->tableize($operation->getShortName());
+    }
+}

--- a/src/Meilisearch/State/ItemProvider.php
+++ b/src/Meilisearch/State/ItemProvider.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\State;
+
+use ApiPlatform\Metadata\InflectorInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Util\Inflector;
+use ApiPlatform\State\ApiResource\Error;
+use ApiPlatform\State\ProviderInterface;
+use Meilisearch\Client;
+use Meilisearch\Exceptions\ApiException;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Item provider for Meilisearch.
+ *
+ * @author API Platform Community
+ */
+final class ItemProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly Client $client,
+        private readonly ?DenormalizerInterface $denormalizer = null,
+        private readonly ?InflectorInterface $inflector = new Inflector(),
+    ) {
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
+    {
+        $resourceClass = $operation->getClass();
+        $options = $operation->getStateOptions();
+        if (!$options instanceof Options) {
+            $options = new Options(index: $this->getIndex($operation));
+        }
+
+        $index = $options->getIndex() ?? $this->getIndex($operation);
+        $id = (string) reset($uriVariables);
+
+        try {
+            $document = $this->client->index($index)->getDocument($id);
+        } catch (ApiException $e) {
+            if (404 === $e->httpStatus) {
+                return null;
+            }
+
+            throw new Error(status: $e->httpStatus, detail: $e->getMessage(), title: $e->getMessage(), originalTrace: $e->getTrace());
+        }
+
+        $item = $this->denormalizer->denormalize($document, $resourceClass, 'array', [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true]);
+        if (!\is_object($item) && null !== $item) {
+            throw new \UnexpectedValueException('Expected item to be an object or null.');
+        }
+
+        return $item;
+    }
+
+    private function getIndex(Operation $operation): string
+    {
+        return $this->inflector->tableize($operation->getShortName());
+    }
+}

--- a/src/Meilisearch/State/Options.php
+++ b/src/Meilisearch/State/Options.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\State;
+
+use ApiPlatform\State\OptionsInterface;
+
+class Options implements OptionsInterface
+{
+    public function __construct(
+        protected ?string $index = null,
+        protected ?string $primaryKey = null,
+    ) {
+    }
+
+    public function getIndex(): ?string
+    {
+        return $this->index;
+    }
+
+    public function withIndex(?string $index): self
+    {
+        $self = clone $this;
+        $self->index = $index;
+
+        return $self;
+    }
+
+    public function getPrimaryKey(): ?string
+    {
+        return $this->primaryKey;
+    }
+
+    public function withPrimaryKey(?string $primaryKey): self
+    {
+        $self = clone $this;
+        $self->primaryKey = $primaryKey;
+
+        return $self;
+    }
+}

--- a/src/Meilisearch/Tests/Extension/FilterExtensionTest.php
+++ b/src/Meilisearch/Tests/Extension/FilterExtensionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Extension;
+
+use ApiPlatform\Meilisearch\Extension\FilterExtension;
+use ApiPlatform\Meilisearch\Filter\SearchFilter;
+use ApiPlatform\Meilisearch\Filter\TermFilter;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\Metadata\GetCollection;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class FilterExtensionTest extends TestCase
+{
+    public function testAndJoinsFilterExpressionsIntoASingleFilterString(): void
+    {
+        $locator = $this->containerFor([
+            'movie.term_filter' => new TermFilter(['genre', 'year']),
+        ]);
+
+        $operation = (new GetCollection())->withClass(Movie::class)->withFilters(['movie.term_filter']);
+        $extension = new FilterExtension($locator);
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation, [
+            'filters' => ['genre' => 'sci-fi', 'year' => 1977],
+        ]);
+
+        self::assertSame('genre = "sci-fi" AND year = 1977', $parameters['filter']);
+        self::assertArrayNotHasKey('filterExpressions', $parameters);
+    }
+
+    public function testCombinesMultipleFilterServices(): void
+    {
+        $locator = $this->containerFor([
+            'movie.search_filter' => new SearchFilter(['title']),
+            'movie.term_filter' => new TermFilter(['genre']),
+        ]);
+
+        $operation = (new GetCollection())->withClass(Movie::class)->withFilters(['movie.search_filter', 'movie.term_filter']);
+        $extension = new FilterExtension($locator);
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation, [
+            'filters' => ['title' => 'wars', 'genre' => 'sci-fi'],
+        ]);
+
+        self::assertSame('wars', $parameters['q']);
+        self::assertSame('genre = "sci-fi"', $parameters['filter']);
+    }
+
+    public function testNoFiltersLeavesParametersUntouched(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class);
+        $extension = new FilterExtension($this->containerFor([]));
+
+        $parameters = $extension->applyToCollection(['q' => 'wars'], Movie::class, $operation, []);
+
+        self::assertSame(['q' => 'wars'], $parameters);
+    }
+
+    public function testUnknownFilterServiceIsIgnored(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class)->withFilters(['does.not.exist']);
+        $extension = new FilterExtension($this->containerFor([]));
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation, []);
+
+        self::assertSame([], $parameters);
+    }
+
+    private function containerFor(array $services): ContainerInterface
+    {
+        return new class($services) implements ContainerInterface {
+            public function __construct(private readonly array $services)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->services[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->services[$id]);
+            }
+        };
+    }
+}

--- a/src/Meilisearch/Tests/Extension/SortExtensionTest.php
+++ b/src/Meilisearch/Tests/Extension/SortExtensionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Extension;
+
+use ApiPlatform\Meilisearch\Extension\SortExtension;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\Metadata\GetCollection;
+use PHPUnit\Framework\TestCase;
+
+class SortExtensionTest extends TestCase
+{
+    public function testAppliesOperationOrder(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class)->withOrder(['year' => 'desc']);
+        $extension = new SortExtension();
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation);
+
+        self::assertSame(['year:desc'], $parameters['sort']);
+    }
+
+    public function testAppliesOperationOrderWithImplicitAscending(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class)->withOrder(['year']);
+        $extension = new SortExtension();
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation);
+
+        self::assertSame(['year:asc'], $parameters['sort']);
+    }
+
+    public function testMergesWithExistingSort(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class)->withOrder(['year' => 'desc']);
+        $extension = new SortExtension();
+
+        $parameters = $extension->applyToCollection(['sort' => ['title:asc']], Movie::class, $operation);
+
+        self::assertSame(['title:asc', 'year:desc'], $parameters['sort']);
+    }
+
+    public function testNoOrderLeavesParametersUntouched(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class);
+        $extension = new SortExtension();
+
+        $parameters = $extension->applyToCollection(['q' => 'wars'], Movie::class, $operation);
+
+        self::assertArrayNotHasKey('sort', $parameters);
+    }
+
+    public function testDefaultDirectionAppliesToIdentifier(): void
+    {
+        $operation = (new GetCollection())->withClass(Movie::class);
+        $extension = new SortExtension('asc');
+
+        $parameters = $extension->applyToCollection([], Movie::class, $operation);
+
+        self::assertSame(['id:asc'], $parameters['sort']);
+    }
+}

--- a/src/Meilisearch/Tests/Filter/SearchFilterTest.php
+++ b/src/Meilisearch/Tests/Filter/SearchFilterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Filter;
+
+use ApiPlatform\Meilisearch\Filter\SearchFilter;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use PHPUnit\Framework\TestCase;
+
+class SearchFilterTest extends TestCase
+{
+    public function testSetsQFromConfiguredProperty(): void
+    {
+        $filter = new SearchFilter(['title']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['title' => 'star wars']]);
+
+        self::assertSame('star wars', $parameters['q']);
+    }
+
+    public function testIgnoresUnconfiguredProperty(): void
+    {
+        $filter = new SearchFilter(['title']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['genre' => 'sci-fi']]);
+
+        self::assertArrayNotHasKey('q', $parameters);
+    }
+
+    public function testDoesNotOverrideAnAlreadySetQ(): void
+    {
+        $filter = new SearchFilter(['title']);
+
+        $parameters = $filter->apply(['q' => 'already set'], Movie::class, null, ['filters' => ['title' => 'star wars']]);
+
+        self::assertSame('already set', $parameters['q']);
+    }
+
+    public function testIgnoresEmptyValue(): void
+    {
+        $filter = new SearchFilter(['title']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['title' => '']]);
+
+        self::assertArrayNotHasKey('q', $parameters);
+    }
+
+    public function testNoRestrictionAcceptsAnyProperty(): void
+    {
+        $filter = new SearchFilter();
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['title' => 'star wars']]);
+
+        self::assertSame('star wars', $parameters['q']);
+    }
+}

--- a/src/Meilisearch/Tests/Filter/TermFilterTest.php
+++ b/src/Meilisearch/Tests/Filter/TermFilterTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Filter;
+
+use ApiPlatform\Meilisearch\Filter\TermFilter;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use PHPUnit\Framework\TestCase;
+
+class TermFilterTest extends TestCase
+{
+    public function testSingleValue(): void
+    {
+        $filter = new TermFilter(['genre']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['genre' => 'sci-fi']]);
+
+        self::assertSame(['genre = "sci-fi"'], $parameters['filterExpressions']);
+    }
+
+    public function testMultipleValuesOrTogether(): void
+    {
+        $filter = new TermFilter(['genre']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['genre' => ['sci-fi', 'comedy']]]);
+
+        self::assertSame(['(genre = "sci-fi" OR genre = "comedy")'], $parameters['filterExpressions']);
+    }
+
+    public function testNumericValueIsNotQuoted(): void
+    {
+        $filter = new TermFilter(['year']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['year' => 1977]]);
+
+        self::assertSame(['year = 1977'], $parameters['filterExpressions']);
+    }
+
+    public function testMultiplePropertiesAppendSeparateExpressions(): void
+    {
+        $filter = new TermFilter(['genre', 'year']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['genre' => 'sci-fi', 'year' => 1977]]);
+
+        self::assertSame(['genre = "sci-fi"', 'year = 1977'], $parameters['filterExpressions']);
+    }
+
+    public function testAppendsToExistingFilterExpressions(): void
+    {
+        $filter = new TermFilter(['genre']);
+
+        $parameters = $filter->apply(['filterExpressions' => ['title = "Star Wars"']], Movie::class, null, ['filters' => ['genre' => 'sci-fi']]);
+
+        self::assertSame(['title = "Star Wars"', 'genre = "sci-fi"'], $parameters['filterExpressions']);
+    }
+
+    public function testIgnoresUnconfiguredProperty(): void
+    {
+        $filter = new TermFilter(['genre']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['title' => 'wars']]);
+
+        self::assertArrayNotHasKey('filterExpressions', $parameters);
+    }
+
+    public function testQuoteEscapesEmbeddedQuotes(): void
+    {
+        $filter = new TermFilter(['title']);
+
+        $parameters = $filter->apply([], Movie::class, null, ['filters' => ['title' => 'A "Great" Movie']]);
+
+        self::assertSame(['title = "A \\"Great\\" Movie"'], $parameters['filterExpressions']);
+    }
+}

--- a/src/Meilisearch/Tests/Fixtures/Movie.php
+++ b/src/Meilisearch/Tests/Fixtures/Movie.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Fixtures;
+
+use ApiPlatform\Meilisearch\Filter\SearchFilter;
+use ApiPlatform\Meilisearch\Filter\TermFilter;
+use ApiPlatform\Meilisearch\State\CollectionProvider;
+use ApiPlatform\Meilisearch\State\ItemProvider;
+use ApiPlatform\Meilisearch\State\Options;
+use ApiPlatform\Metadata\ApiFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+
+#[ApiResource(operations: [
+    new Get(provider: ItemProvider::class, stateOptions: new Options(index: 'movie')),
+    new GetCollection(provider: CollectionProvider::class, stateOptions: new Options(index: 'movie')),
+])]
+#[ApiFilter(SearchFilter::class, properties: ['title'])]
+#[ApiFilter(TermFilter::class, properties: ['genre', 'year'])]
+class Movie
+{
+    #[ApiProperty(identifier: true)]
+    public ?int $id = null;
+
+    public ?string $title = null;
+
+    public ?string $genre = null;
+
+    public ?int $year = null;
+}

--- a/src/Meilisearch/Tests/Metadata/Resource/Factory/MeilisearchProviderResourceMetadataCollectionFactoryTest.php
+++ b/src/Meilisearch/Tests/Metadata/Resource/Factory/MeilisearchProviderResourceMetadataCollectionFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\Metadata\Resource\Factory;
+
+use ApiPlatform\Meilisearch\Metadata\Resource\Factory\MeilisearchProviderResourceMetadataCollectionFactory;
+use ApiPlatform\Meilisearch\State\CollectionProvider;
+use ApiPlatform\Meilisearch\State\ItemProvider;
+use ApiPlatform\Meilisearch\State\Options;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+
+class MeilisearchProviderResourceMetadataCollectionFactoryTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testConstruct(): void
+    {
+        self::assertInstanceOf(
+            ResourceMetadataCollectionFactoryInterface::class,
+            new MeilisearchProviderResourceMetadataCollectionFactory(
+                $this->prophesize(ResourceMetadataCollectionFactoryInterface::class)->reveal()
+            )
+        );
+    }
+
+    public function testAssignsCollectionAndItemProvidersWhenOptionsIsMeilisearch(): void
+    {
+        $decorated = $this->decoratedFactoryReturning(new ApiResource(
+            operations: [
+                'get' => new Get(class: Movie::class, stateOptions: new Options(index: 'movie')),
+                'get_collection' => new GetCollection(class: Movie::class, stateOptions: new Options(index: 'movie')),
+            ],
+        ));
+
+        $factory = new MeilisearchProviderResourceMetadataCollectionFactory($decorated);
+        $operations = $factory->create(Movie::class)[0]->getOperations();
+
+        self::assertSame(ItemProvider::class, iterator_to_array($operations)['get']->getProvider());
+        self::assertSame(CollectionProvider::class, iterator_to_array($operations)['get_collection']->getProvider());
+    }
+
+    public function testDoesNotOverrideAnExplicitProvider(): void
+    {
+        $decorated = $this->decoratedFactoryReturning(new ApiResource(
+            operations: [
+                'get_collection' => new GetCollection(
+                    class: Movie::class,
+                    stateOptions: new Options(index: 'movie'),
+                    provider: 'app.custom_provider',
+                ),
+            ],
+        ));
+
+        $factory = new MeilisearchProviderResourceMetadataCollectionFactory($decorated);
+        $operations = $factory->create(Movie::class)[0]->getOperations();
+
+        self::assertSame('app.custom_provider', iterator_to_array($operations)['get_collection']->getProvider());
+    }
+
+    public function testLeavesNonMeilisearchOperationsUntouched(): void
+    {
+        $decorated = $this->decoratedFactoryReturning(new ApiResource(
+            operations: [
+                'get_collection' => new GetCollection(class: Movie::class),
+            ],
+        ));
+
+        $factory = new MeilisearchProviderResourceMetadataCollectionFactory($decorated);
+        $operations = $factory->create(Movie::class)[0]->getOperations();
+
+        self::assertNull(iterator_to_array($operations)['get_collection']->getProvider());
+    }
+
+    private function decoratedFactoryReturning(ApiResource $resource): ResourceMetadataCollectionFactoryInterface
+    {
+        $decoratedProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
+        $decoratedProphecy->create(Movie::class)->willReturn(new ResourceMetadataCollection(Movie::class, [$resource]));
+
+        return $decoratedProphecy->reveal();
+    }
+}

--- a/src/Meilisearch/Tests/PaginatorTest.php
+++ b/src/Meilisearch/Tests/PaginatorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests;
+
+use ApiPlatform\Meilisearch\Paginator;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use Meilisearch\Search\SearchResult;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class PaginatorTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private const HITS = [
+        ['id' => 5, 'title' => 'Fribourg'],
+        ['id' => 6, 'title' => 'Lausanne'],
+        ['id' => 7, 'title' => 'Vallorbe'],
+        ['id' => 8, 'title' => 'Lugano'],
+    ];
+
+    private const OFFSET = 4;
+    private const LIMIT = 4;
+
+    private PaginatorInterface $paginator;
+
+    protected function setUp(): void
+    {
+        $this->paginator = $this->getPaginator();
+    }
+
+    public function testConstruct(): void
+    {
+        self::assertInstanceOf(PaginatorInterface::class, $this->paginator);
+    }
+
+    public function testCount(): void
+    {
+        self::assertCount(4, $this->paginator);
+    }
+
+    public function testGetLastPage(): void
+    {
+        self::assertSame(2., $this->paginator->getLastPage());
+    }
+
+    public function testGetLastPageWithZeroAsLimit(): void
+    {
+        self::assertSame(1., $this->getPaginator(0, 0)->getLastPage());
+    }
+
+    public function testGetLastPageWithNegativeLimit(): void
+    {
+        self::assertSame(1., $this->getPaginator(-1, 0)->getLastPage());
+    }
+
+    public function testGetTotalItems(): void
+    {
+        self::assertSame(8., $this->paginator->getTotalItems());
+    }
+
+    public function testGetCurrentPage(): void
+    {
+        self::assertSame(2., $this->paginator->getCurrentPage());
+    }
+
+    public function testGetCurrentPageWithZeroAsLimit(): void
+    {
+        self::assertSame(1., $this->getPaginator(0, 0)->getCurrentPage());
+    }
+
+    public function testGetItemsPerPage(): void
+    {
+        self::assertSame(4., $this->paginator->getItemsPerPage());
+    }
+
+    public function testGetIterator(): void
+    {
+        // set local cache
+        iterator_to_array($this->paginator);
+
+        self::assertEquals(
+            array_map($this->denormalizeMovie(...), self::HITS),
+            iterator_to_array($this->paginator)
+        );
+    }
+
+    private function getPaginator(int $limit = self::LIMIT, int $offset = self::OFFSET, array $hits = self::HITS): Paginator
+    {
+        $searchResult = new SearchResult([
+            'hits' => $hits,
+            'processingTimeMs' => 1,
+            'query' => '',
+            'offset' => $offset,
+            'limit' => $limit,
+            'estimatedTotalHits' => 8,
+        ]);
+
+        $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
+        foreach ($hits as $hit) {
+            $denormalizerProphecy
+                ->denormalize($hit, Movie::class, 'array', [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])
+                ->willReturn($this->denormalizeMovie($hit));
+        }
+
+        return new Paginator($denormalizerProphecy->reveal(), $searchResult, Movie::class, $limit, $offset);
+    }
+
+    private function denormalizeMovie(array $hit): Movie
+    {
+        $movie = new Movie();
+        $movie->id = $hit['id'];
+        $movie->title = $hit['title'];
+
+        return $movie;
+    }
+}

--- a/src/Meilisearch/Tests/State/CollectionProviderTest.php
+++ b/src/Meilisearch/Tests/State/CollectionProviderTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\State;
+
+use ApiPlatform\Meilisearch\Extension\RequestParametersCollectionExtensionInterface;
+use ApiPlatform\Meilisearch\Paginator;
+use ApiPlatform\Meilisearch\State\CollectionProvider;
+use ApiPlatform\Meilisearch\State\Options;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\State\Pagination\Pagination;
+use Meilisearch\Client;
+use Meilisearch\Contracts\Http;
+use Meilisearch\Endpoints\Index;
+use Meilisearch\Exceptions\ApiException;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Meilisearch\Endpoints\Index is final and can't be mocked directly, so
+ * these tests construct a real Index wired to a mocked Http transport
+ * (the thing that actually makes requests) and mock Client (not final)
+ * to hand that Index back from index().
+ */
+class CollectionProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testProvide(): void
+    {
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->post('/indexes/movie/search', (object) [
+            'q' => 'wars',
+            'filter' => 'genre = "sci-fi"',
+            'sort' => ['year:desc'],
+            'offset' => 0,
+            'limit' => 30,
+        ])->willReturn([
+            'hits' => [['id' => 1, 'title' => 'Star Wars', 'genre' => 'sci-fi', 'year' => 1977]],
+            'processingTimeMs' => 1,
+            'query' => 'wars',
+            'offset' => 0,
+            'limit' => 30,
+            'estimatedTotalHits' => 1,
+        ]);
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $extension = new class implements RequestParametersCollectionExtensionInterface {
+            public function applyToCollection(array $parameters, string $resourceClass, ?\ApiPlatform\Metadata\Operation $operation = null, array $context = []): array
+            {
+                $parameters['q'] = 'wars';
+                $parameters['filter'] = 'genre = "sci-fi"';
+                $parameters['sort'] = ['year:desc'];
+
+                return $parameters;
+            }
+        };
+
+        $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
+        $denormalizerProphecy->denormalize([
+            'id' => 1, 'title' => 'Star Wars', 'genre' => 'sci-fi', 'year' => 1977,
+        ], Movie::class, 'array', [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn((static function (): Movie {
+            $movie = new Movie();
+            $movie->id = 1;
+            $movie->title = 'Star Wars';
+
+            return $movie;
+        })());
+
+        $pagination = new Pagination(['items_per_page' => 30]);
+
+        $provider = new CollectionProvider(
+            $clientProphecy->reveal(),
+            $denormalizerProphecy->reveal(),
+            $pagination,
+            [$extension],
+        );
+
+        $operation = (new GetCollection())->withClass(Movie::class)->withStateOptions(new Options(index: 'movie'));
+        $result = $provider->provide($operation);
+
+        self::assertInstanceOf(Paginator::class, $result);
+        self::assertSame(1., $result->getTotalItems());
+    }
+
+    public function testProvideWithoutExplicitOptionsFallsBackToInflectedShortName(): void
+    {
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->post('/indexes/movie/search', (object) [
+            'q' => '',
+            'offset' => 0,
+            'limit' => 30,
+        ])->willReturn([
+            'hits' => [],
+            'processingTimeMs' => 1,
+            'query' => '',
+            'offset' => 0,
+            'limit' => 30,
+            'estimatedTotalHits' => 0,
+        ]);
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $provider = new CollectionProvider(
+            $clientProphecy->reveal(),
+            $this->prophesize(DenormalizerInterface::class)->reveal(),
+            new Pagination(['items_per_page' => 30]),
+        );
+
+        // Operation short name "Movie" tableizes to "movie" -- same as the fixture's
+        // explicit index name, so this exercises the fallback path without needing
+        // a second fixture class.
+        $operation = (new GetCollection())->withClass(Movie::class)->withShortName('Movie');
+        $result = $provider->provide($operation);
+
+        self::assertSame(0., $result->getTotalItems());
+    }
+
+    public function testProvideWrapsApiException(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(404);
+        $response->getReasonPhrase()->willReturn('Not Found');
+        $response->getBody()->willReturn('{}');
+
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->post('/indexes/movie/search', (object) [
+            'q' => '',
+            'offset' => 0,
+            'limit' => 30,
+        ])->willThrow(new ApiException($response->reveal(), '{}'));
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $provider = new CollectionProvider(
+            $clientProphecy->reveal(),
+            $this->prophesize(DenormalizerInterface::class)->reveal(),
+            new Pagination(['items_per_page' => 30]),
+        );
+
+        $this->expectException(\ApiPlatform\State\ApiResource\Error::class);
+
+        $operation = (new GetCollection())->withClass(Movie::class)->withStateOptions(new Options(index: 'movie'));
+        $provider->provide($operation);
+    }
+}

--- a/src/Meilisearch/Tests/State/ItemProviderTest.php
+++ b/src/Meilisearch/Tests/State/ItemProviderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Meilisearch\Tests\State;
+
+use ApiPlatform\Meilisearch\State\ItemProvider;
+use ApiPlatform\Meilisearch\State\Options;
+use ApiPlatform\Meilisearch\Tests\Fixtures\Movie;
+use ApiPlatform\Metadata\Get;
+use Meilisearch\Client;
+use Meilisearch\Contracts\Http;
+use Meilisearch\Endpoints\Index;
+use Meilisearch\Exceptions\ApiException;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class ItemProviderTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testProvide(): void
+    {
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->get('/indexes/movie/documents/1', [])->willReturn([
+            'id' => 1, 'title' => 'Star Wars', 'genre' => 'sci-fi', 'year' => 1977,
+        ]);
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $movie = new Movie();
+        $movie->id = 1;
+        $movie->title = 'Star Wars';
+
+        $denormalizerProphecy = $this->prophesize(DenormalizerInterface::class);
+        $denormalizerProphecy->denormalize([
+            'id' => 1, 'title' => 'Star Wars', 'genre' => 'sci-fi', 'year' => 1977,
+        ], Movie::class, 'array', [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => true])->willReturn($movie);
+
+        $provider = new ItemProvider($clientProphecy->reveal(), $denormalizerProphecy->reveal());
+
+        $operation = (new Get())->withClass(Movie::class)->withStateOptions(new Options(index: 'movie'));
+        $result = $provider->provide($operation, ['id' => 1]);
+
+        self::assertSame($movie, $result);
+    }
+
+    public function testProvideReturnsNullOn404(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(404);
+        $response->getReasonPhrase()->willReturn('Not Found');
+        $response->getBody()->willReturn('{}');
+
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->get('/indexes/movie/documents/999', [])->willThrow(new ApiException($response->reveal(), '{}'));
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $provider = new ItemProvider($clientProphecy->reveal(), $this->prophesize(DenormalizerInterface::class)->reveal());
+
+        $operation = (new Get())->withClass(Movie::class)->withStateOptions(new Options(index: 'movie'));
+        $result = $provider->provide($operation, ['id' => 999]);
+
+        self::assertNull($result);
+    }
+
+    public function testProvideWrapsNon404ApiException(): void
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(500);
+        $response->getReasonPhrase()->willReturn('Internal Server Error');
+        $response->getBody()->willReturn('{}');
+
+        $httpProphecy = $this->prophesize(Http::class);
+        $httpProphecy->get('/indexes/movie/documents/1', [])->willThrow(new ApiException($response->reveal(), '{}'));
+
+        $index = new Index($httpProphecy->reveal(), 'movie');
+        $clientProphecy = $this->prophesize(Client::class);
+        $clientProphecy->index('movie')->willReturn($index);
+
+        $provider = new ItemProvider($clientProphecy->reveal(), $this->prophesize(DenormalizerInterface::class)->reveal());
+
+        $this->expectException(\ApiPlatform\State\ApiResource\Error::class);
+
+        $operation = (new Get())->withClass(Movie::class)->withStateOptions(new Options(index: 'movie'));
+        $provider->provide($operation, ['id' => 1]);
+    }
+}

--- a/src/Meilisearch/composer.json
+++ b/src/Meilisearch/composer.json
@@ -22,7 +22,7 @@
         "api-platform/metadata": "^4.2 || ^5.0@alpha",
         "api-platform/serializer": "^4.2 || ^5.0@alpha",
         "api-platform/state": "^4.2 || ^5.0@alpha",
-        "meilisearch/meilisearch-php": "^2.0",
+        "meilisearch/meilisearch-php": "dev-main",
         "psr/container": "^1.1 || ^2.0",
         "symfony/serializer": "^6.4 || ^7.4 || ^8.0"
     },

--- a/src/Meilisearch/composer.json
+++ b/src/Meilisearch/composer.json
@@ -1,0 +1,61 @@
+{
+    "name": "api-platform/meilisearch",
+    "description": "API Platform Meilisearch bridge",
+    "type": "library",
+    "keywords": [
+        "REST",
+        "API",
+        "filter",
+        "meilisearch",
+        "search"
+    ],
+    "homepage": "https://api-platform.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "API Platform Community",
+            "homepage": "https://api-platform.com/community/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "api-platform/metadata": "^4.2 || ^5.0@alpha",
+        "api-platform/serializer": "^4.2 || ^5.0@alpha",
+        "api-platform/state": "^4.2 || ^5.0@alpha",
+        "meilisearch/meilisearch-php": "^2.0",
+        "psr/container": "^1.1 || ^2.0",
+        "symfony/serializer": "^6.4 || ^7.4 || ^8.0"
+    },
+    "require-dev": {
+        "phpspec/prophecy-phpunit": "^2.2",
+        "phpunit/phpunit": "^11.5 || ^12.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "ApiPlatform\\Meilisearch\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "config": {
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "5.0.x-dev"
+        },
+        "thanks": {
+            "name": "api-platform/api-platform",
+            "url": "https://github.com/api-platform/api-platform"
+        }
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit"
+    },
+    "minimum-stability": "beta",
+    "prefer-stable": true
+}

--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -24,6 +24,8 @@ use ApiPlatform\Doctrine\Orm\Extension\QueryItemExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter as DoctrineOrmAbstractFilter;
 use ApiPlatform\Doctrine\Orm\State\LinksHandlerInterface as OrmLinksHandlerInterface;
 use ApiPlatform\Elasticsearch\Extension\RequestBodySearchCollectionExtensionInterface;
+use ApiPlatform\Meilisearch\Extension\RequestParametersCollectionExtensionInterface as MeilisearchRequestParametersCollectionExtensionInterface;
+use ApiPlatform\Meilisearch\Filter\FilterInterface as MeilisearchFilterInterface;
 use ApiPlatform\GraphQl\Error\ErrorHandlerInterface;
 use ApiPlatform\GraphQl\Executor;
 use ApiPlatform\GraphQl\Resolver\MutationResolverInterface;
@@ -198,6 +200,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerMercureConfiguration($container, $config, $loader);
         $this->registerMessengerConfiguration($container, $config, $loader);
         $this->registerElasticsearchConfiguration($container, $config, $loader);
+        $this->registerMeilisearchConfiguration($container, $config, $loader);
         $this->registerSecurityConfiguration($container, $config, $loader);
         $this->registerMakerConfiguration($container, $config, $loader);
         $this->registerArgumentResolverConfiguration($loader);
@@ -1048,6 +1051,31 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $container->setParameter('api_platform.elasticsearch.ssl_ca_bundle', $config['elasticsearch']['ssl_ca_bundle']);
         $container->setParameter('api_platform.elasticsearch.ssl_verification', $config['elasticsearch']['ssl_verification']);
         $loader->load('elasticsearch.php');
+    }
+
+    private function registerMeilisearchConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader): void
+    {
+        $enabled = $this->isConfigEnabled($container, $config['meilisearch']);
+
+        $container->setParameter('api_platform.meilisearch.enabled', $enabled);
+
+        if (!$enabled) {
+            return;
+        }
+
+        if (!InstalledVersions::isInstalled('api-platform/meilisearch')) {
+            throw new \LogicException('Meilisearch support cannot be enabled as the Meilisearch component is not installed. Try running "composer require api-platform/meilisearch".');
+        }
+
+        $clientDefinition = new Definition(\Meilisearch\Client::class);
+        $clientDefinition->setArguments([$config['meilisearch']['url'], $config['meilisearch']['api_key']]);
+        $container->setDefinition('api_platform.meilisearch.client', $clientDefinition);
+        $container->registerForAutoconfiguration(MeilisearchRequestParametersCollectionExtensionInterface::class)
+            ->addTag('api_platform.meilisearch.request_parameters_extension.collection');
+        $container->registerForAutoconfiguration(MeilisearchFilterInterface::class)
+            ->addTag('api_platform.meilisearch.filter');
+        $container->setParameter('api_platform.meilisearch.url', $config['meilisearch']['url']);
+        $loader->load('meilisearch.php');
     }
 
     private function registerSecurityConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader): void

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -176,6 +176,7 @@ final class Configuration implements ConfigurationInterface
         $this->addMercureSection($rootNode);
         $this->addMessengerSection($rootNode);
         $this->addElasticsearchSection($rootNode);
+        $this->addMeilisearchSection($rootNode);
         $this->addOpenApiSection($rootNode);
         $this->addMakerSection($rootNode);
         $this->addMcpSection($rootNode);
@@ -517,6 +518,40 @@ final class Configuration implements ConfigurationInterface
                                     return $v;
                                 })
                             ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    private function addMeilisearchSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('meilisearch')
+                    ->canBeEnabled()
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')
+                            ->defaultFalse()
+                            ->validate()
+                                ->ifTrue()
+                                ->then(static function (bool $v): bool {
+                                    if (!class_exists(\Meilisearch\Client::class)) {
+                                        throw new InvalidConfigurationException('The meilisearch/meilisearch-php package is required for Meilisearch support.');
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
+                        ->end()
+                        ->scalarNode('url')
+                            ->defaultValue('http://localhost:7700')
+                            ->info('The Meilisearch instance URL.')
+                        ->end()
+                        ->scalarNode('api_key')
+                            ->defaultNull()
+                            ->info('The Meilisearch API key.')
                         ->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/Resources/config/meilisearch.php
+++ b/src/Symfony/Bundle/Resources/config/meilisearch.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use ApiPlatform\Meilisearch\Extension\FilterExtension;
+use ApiPlatform\Meilisearch\Extension\SortExtension;
+use ApiPlatform\Meilisearch\Filter\SearchFilter;
+use ApiPlatform\Meilisearch\Filter\TermFilter;
+use ApiPlatform\Meilisearch\Metadata\Resource\Factory\MeilisearchProviderResourceMetadataCollectionFactory;
+use ApiPlatform\Meilisearch\State\CollectionProvider;
+use ApiPlatform\Meilisearch\State\ItemProvider;
+
+return function (ContainerConfigurator $container) {
+    $services = $container->services();
+
+    $services->set('api_platform.meilisearch.request_parameters_extension.filter', FilterExtension::class)
+        ->args([service('api_platform.filter_locator')])
+        ->tag('api_platform.meilisearch.request_parameters_extension.collection', ['priority' => 20]);
+
+    $services->set('api_platform.meilisearch.request_parameters_extension.sort', SortExtension::class)
+        ->args(['%api_platform.collection.order%'])
+        ->tag('api_platform.meilisearch.request_parameters_extension.collection', ['priority' => 10]);
+
+    $services->set('api_platform.meilisearch.term_filter', TermFilter::class)
+        ->abstract()
+        ->tag('api_platform.meilisearch.filter');
+
+    $services->alias(TermFilter::class, 'api_platform.meilisearch.term_filter');
+
+    $services->set('api_platform.meilisearch.search_filter', SearchFilter::class)
+        ->abstract()
+        ->tag('api_platform.meilisearch.filter');
+
+    $services->alias(SearchFilter::class, 'api_platform.meilisearch.search_filter');
+
+    $services->set('api_platform.meilisearch.state.item_provider', ItemProvider::class)
+        ->args([
+            service('api_platform.meilisearch.client'),
+            service('serializer'),
+            service('api_platform.inflector')->nullOnInvalid(),
+        ])
+        ->tag('api_platform.state_provider', ['priority' => -100, 'key' => 'ApiPlatform\Meilisearch\State\ItemProvider'])
+        ->tag('api_platform.state_provider', ['priority' => -100]);
+
+    $services->alias(ItemProvider::class, 'api_platform.meilisearch.state.item_provider');
+
+    $services->set('api_platform.meilisearch.state.collection_provider', CollectionProvider::class)
+        ->args([
+            service('api_platform.meilisearch.client'),
+            service('serializer'),
+            service('api_platform.pagination'),
+            tagged_iterator('api_platform.meilisearch.request_parameters_extension.collection'),
+            service('api_platform.inflector')->nullOnInvalid(),
+        ])
+        ->tag('api_platform.state_provider', ['priority' => -100, 'key' => 'ApiPlatform\Meilisearch\State\CollectionProvider'])
+        ->tag('api_platform.state_provider', ['priority' => -100]);
+
+    $services->alias(CollectionProvider::class, 'api_platform.meilisearch.state.collection_provider');
+
+    $services->set('api_platform.meilisearch.metadata.resource.metadata_collection_factory', MeilisearchProviderResourceMetadataCollectionFactory::class)
+        ->decorate('api_platform.metadata.resource.metadata_collection_factory', null, 39)
+        ->args([service('api_platform.meilisearch.metadata.resource.metadata_collection_factory.inner')]);
+};


### PR DESCRIPTION
**Title:** [Draft] Add Meilisearch support (src/Meilisearch)

**Body:**

Addresses #6222.

Adds `api-platform/meilisearch`, modeled directly on `api-platform/elasticsearch`'s architecture: `State/{CollectionProvider,ItemProvider,Options}`, a `Metadata/Resource/Factory` decorator that auto-assigns the right provider from `stateOptions` (no `provider:` needed, same as the ES bridge), and the matching `Configuration`/`ApiPlatformExtension`/`Resources/config/meilisearch.php` bundle wiring.

## What's different from the Elasticsearch bridge, and why

Meilisearch's API is simpler than Elasticsearch's on two axes that show up directly in the code:

- **Client/exceptions**: one official client (`meilisearch/meilisearch-php`, MIT), one `ApiException` with a typed `httpStatus` — no `V7Client|Client|OpenSearchClient` union, no juggling three different 404 exception classes.
- **Query shape**: Meilisearch takes flat search parameters (`q`, a single `filter` expression string, `sort`, `facets`, `limit`/`offset`), not a nested query-DSL body. `RequestParametersCollectionExtensionInterface`/`FilterInterface` operate on that flat array — filter composition is AND-joining expression strings rather than merging JSON `bool`/`must` trees.

## Scope of this draft

- REST only — the metadata factory decorator doesn't touch GraphQL operations yet (ES's does).
- Two filters: `SearchFilter` (free text → `q`) and `TermFilter` (exact-match/facet → `filter` expression). No range/geo filters yet.
- No index-settings management. Meilisearch requires `filterableAttributes`/`sortableAttributes` pre-declared on the index or a query 400s — this is the caller's responsibility here, same as it would be for whatever indexes the documents in the first place.
- `meilisearch/meilisearch-php: ^2.0` — currently only satisfiable via the v2 beta line (`dev-main`, aliased to `2.0.0`; see discussion on #6222 about whether that's acceptable for a first release).

## Verification

Wired into a real app against a live 9.7k-document Meilisearch index (movie dataset): free-text search with typo tolerance, facet filtering (`?genres[]=Comedy&year=1995`), and pagination all confirmed correct through a real `GetCollection` operation, `EXPLAIN`-equivalent traced back to Meilisearch's own query engine (not mocked). Functional tests against a Meilisearch service container are the next step before this comes out of draft — flagging that gap explicitly rather than claiming full coverage.

Opening as a draft to get architecture-level feedback (see the three questions on #6222) before investing in bundle-level tests/CI/docs polish.
