### PR TITLE
ci: raise inter-component floors so the PHP 8.5 lowest jobs pass

### DIFF
--- a/src/Doctrine/Odm/composer.json
+++ b/src/Doctrine/Odm/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^5.0@alpha",
+        "api-platform/doctrine-common": "^5.0.0-alpha.2",
         "api-platform/metadata": "^5.0@alpha",
         "api-platform/serializer": "^5.0@alpha",
         "api-platform/state": "^5.0@alpha",

--- a/src/Doctrine/Orm/composer.json
+++ b/src/Doctrine/Orm/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "api-platform/doctrine-common": "^5.0@alpha",
+        "api-platform/doctrine-common": "^5.0.0-alpha.2",
         "api-platform/metadata": "^5.0@alpha",
         "api-platform/serializer": "^5.0@alpha",
         "api-platform/state": "^5.0@alpha",

--- a/src/JsonApi/composer.json
+++ b/src/JsonApi/composer.json
@@ -25,7 +25,7 @@
         "api-platform/documentation": "^5.0@alpha",
         "api-platform/json-schema": "^5.0@alpha",
         "api-platform/metadata": "^5.0@alpha",
-        "api-platform/serializer": "^5.0@alpha",
+        "api-platform/serializer": "^5.0.0-alpha.2",
         "api-platform/state": "^5.0@alpha",
         "symfony/error-handler": "^7.4 || ^8.0",
         "symfony/http-foundation": "^7.4 || ^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #8444
| License       | MIT
| Doc PR        | n/a

## Summary

`doctrine-orm`, `doctrine-odm` and `json-api` declare `^5.0@alpha` for sibling
components whose APIs they already use. Under `--prefer-lowest` Composer honours
that constraint literally and installs `5.0.0-alpha.1`, which does not provide
those APIs — so the three `PHP 8.5 lowest` component jobs fail. The declared
constraint is simply narrower than what the code needs; this widens it to the
released version that actually provides the behaviour.

This is not a pin to make CI green: `5.0.0-alpha.2` is a real published release,
and `alpha.1` genuinely cannot run this code.

### doctrine-orm / doctrine-odm

`src/Doctrine/Orm/Filter` and `src/Doctrine/Odm/Filter` (2 files each) use
`ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait`, added to
doctrine-common in #8351. The file is absent from the `v5.0.0-alpha.1` tag and
present from `v5.0.0-alpha.2`:

```
$ gh api repos/api-platform/doctrine-common/contents/Filter/NameConverterAwareTrait.php?ref=v5.0.0-alpha.1
404 Not Found
$ gh api repos/api-platform/doctrine-common/contents/Filter/NameConverterAwareTrait.php?ref=v5.0.0-alpha.2
NameConverterAwareTrait.php
```

so the lowest job dies before it can assert anything:

```
Error: Trait "ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait" not found
```

### json-api

`ItemNormalizer` resolves the operation for a circular reference through
behaviour that serializer only has from `v5.0.0-alpha.2`.

## Test verification (before → after)

Reproduced the `PHP 8.5 lowest` component job exactly as CI runs it — `cd` into
the component, `composer update --prefer-lowest --prefer-source`, then the
component's own PHPUnit — on `main`, with only the constraint changed:

### doctrine-orm

**Before** (`api-platform/doctrine-common: ^5.0@alpha` → resolves 5.0.0-alpha.1):

```text
api-platform/doctrine-common       5.0.0-alpha.1 Common files used by api-p...
Error: Trait "ApiPlatform\Doctrine\Common\Filter\NameConverterAwareTrait" not found

Filter/ExistsFilter.php:130
Tests/Filter/ExistsFilterTest.php:232
Tests/Filter/ExistsFilterTestTrait.php:23

ERRORS!
Tests: 293, Assertions: 871, Errors: 43, Deprecations: 35.
```

**After** (`^5.0.0-alpha.2` → resolves 5.0.0-alpha.2):

```text
api-platform/doctrine-common       5.0.0-alpha.2 Common files used by api-p...

Tests: 293, Assertions: 916, Deprecations: 35.
OK, but there were issues!
```

### json-api

**Before** (`api-platform/serializer: ^5.0@alpha` → resolves 5.0.0-alpha.1):

```text
api-platform/serializer            5.0.0-alpha.1 API Platform core Serializer

1) ApiPlatform\JsonApi\Tests\Serializer\ItemNormalizerTest::testNormalizeCircularReference
ApiPlatform\Metadata\Exception\OperationNotFoundException: Operation "" not found for resource "CircularReference".

vendor/api-platform/metadata/Resource/ResourceMetadataCollection.php:111
vendor/api-platform/metadata/Resource/ResourceMetadataCollection.php:97
Serializer/ItemNormalizer.php:448
Serializer/ItemNormalizer.php:150
Tests/Serializer/ItemNormalizerTest.php:229

ERRORS!
Tests: 74, Assertions: 200, Errors: 1, Deprecations: 17.
```

**After** (`^5.0.0-alpha.2` → resolves 5.0.0-alpha.2):

```text
api-platform/serializer            5.0.0-alpha.2 API Platform core Serializer

Tests: 74, Assertions: 201, Deprecations: 3.
OK, but there were issues!
```

That local failure is the same string the CI job reports, so the reproduction is
faithful and not an artefact of the local setup.

## Note on CI visibility

These three jobs currently cannot be seen failing on `main`, because every job
aborts earlier at `composer global require "soyuka/pmu:"` — `main` lost the
`PMU_VERSION` env entry in a merge up. #8474 restores it; with that applied, the
CI surfaces exactly the two failures this PR fixes.
