### PR TITLE
chore(state): document processor and provider interface

### DIFF
--- a/src/State/ProcessorInterface.php
+++ b/src/State/ProcessorInterface.php
@@ -37,6 +37,8 @@ interface ProcessorInterface
      *
      * @psalm-param array{request?: Request, previous_data?: mixed, resource_class?: string|null, original_data?: mixed, ...<string, mixed>} $context
      *
+     * @throws \Throwable
+     *
      * @return T2
      */
     public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []);

--- a/src/State/ProviderInterface.php
+++ b/src/State/ProviderInterface.php
@@ -36,6 +36,8 @@ interface ProviderInterface
      *
      * @psalm-param array{request?: Request, resource_class?: string, ...<string, mixed>} $context
      *
+     * @throws \Throwable
+     *
      * @return T|PartialPaginatorInterface<T>|iterable<T>|null
      */
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Closes #..., closes #... <!-- please link related issues if existing -->
| License       | MIT
| Doc PR        | api-platform/docs#... <!-- required for new features -->

Hi @soyuka 

The DeserializeProvider is throwing multiple exceptions.

But when writing
```
try {
      $this->providerInterface->provide(...)
} catch (...) {

}
```
we end up with a dead catch from PHPStan thinking the service/interface is throwing nothing.

Looking at other provider, lot of them are throwing exceptions. Same for processor.
So I think it's better to document it can throw, promoting usage of try/catch if wanted.

Ci is already failing ; but this PR is only about phpdoc