### PR TITLE
fix(symfony): support repeated global parameter classes

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -705,7 +705,13 @@ final class Configuration implements ConfigurationInterface
                     ->info('Global parameters applied to all resources and operations.')
                     ->useAttributeAsKey('parameter_class')
                     ->prototype('array')
-                        ->ignoreExtraKeys(false);
+                        ->ignoreExtraKeys(false)
+                        ->children()
+                            ->scalarNode('class')
+                                ->cannotBeEmpty()
+                                ->info('The parameter class for a named global parameter entry.')
+                            ->end()
+                        ->end();
 
         $this->defineDefault($parametersNode, new \ReflectionClass(Parameter::class), $nameConverter);
 

--- a/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
@@ -157,7 +157,9 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
                 continue;
             }
 
-            $parameterClass = $config['class'] ?? $entryName;
+            $parameterClass = is_subclass_of($entryName, Parameter::class)
+                ? $entryName
+                : ($config['class'] ?? QueryParameter::class);
 
             if (!\is_string($parameterClass) || !is_subclass_of($parameterClass, Parameter::class)) {
                 continue;

--- a/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactory.php
@@ -152,8 +152,14 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
     {
         $parameters = [];
 
-        foreach ($this->defaultParameters as $parameterClass => $config) {
-            if (!is_subclass_of($parameterClass, Parameter::class)) {
+        foreach ($this->defaultParameters as $entryName => $config) {
+            if (!\is_array($config)) {
+                continue;
+            }
+
+            $parameterClass = $config['class'] ?? $entryName;
+
+            if (!\is_string($parameterClass) || !is_subclass_of($parameterClass, Parameter::class)) {
                 continue;
             }
 

--- a/tests/Fixtures/app/RepeatedDefaultParametersAppKernel.php
+++ b/tests/Fixtures/app/RepeatedDefaultParametersAppKernel.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\HeaderParameter;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RepeatedDefaultParametersAppKernel extends AppKernel
+{
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        parent::configureContainer($container, $loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            if ($container->hasDefinition('phpunit_resource_name_collection')) {
+                $container->removeDefinition('phpunit_resource_name_collection');
+            }
+
+            $container->loadFromExtension('api_platform', [
+                'defaults' => [
+                    'parameters' => [
+                        'api_token' => [
+                            'class' => HeaderParameter::class,
+                            'key' => 'API-Token',
+                            'required' => true,
+                            'description' => 'API token',
+                        ],
+                        'request_id' => [
+                            'class' => HeaderParameter::class,
+                            'key' => 'Request-ID',
+                            'required' => false,
+                            'description' => 'Request correlation identifier',
+                        ],
+                    ],
+                ],
+            ]);
+        });
+    }
+}

--- a/tests/Fixtures/app/bootstrap.php
+++ b/tests/Fixtures/app/bootstrap.php
@@ -22,6 +22,7 @@ if (false !== $xdebugMaxNestingLevel && $xdebugMaxNestingLevel <= 512) {
 $loader = require __DIR__.'/../../../vendor/autoload.php';
 require __DIR__.'/AppKernel.php';
 require __DIR__.'/DefaultParametersAppKernel.php';
+require __DIR__.'/RepeatedDefaultParametersAppKernel.php';
 
 if (!is_file($resourcesFile = __DIR__.'/var/resources.php')) {
     if (!is_dir(dirname($resourcesFile))) {

--- a/tests/Functional/RepeatedDefaultParametersTest.php
+++ b/tests/Functional/RepeatedDefaultParametersTest.php
@@ -11,10 +11,9 @@
 
 declare(strict_types=1);
 
-use ApiPlatform\Metadata\HeaderParameter;
+namespace ApiPlatform\Tests\Functional;
+
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class RepeatedDefaultParametersTest extends ApiTestCase
 {
@@ -22,7 +21,7 @@ final class RepeatedDefaultParametersTest extends ApiTestCase
 
     protected static function getKernelClass(): string
     {
-        return RepeatedDefaultParametersAppKernel::class;
+        return \RepeatedDefaultParametersAppKernel::class;
     }
 
     public function testRepeatedDefaultParametersAppearTogetherInOpenApi(): void
@@ -65,38 +64,5 @@ final class RepeatedDefaultParametersTest extends ApiTestCase
         }
 
         $this->fail('No OpenAPI operation contained both repeated default header parameters.');
-    }
-}
-
-final class RepeatedDefaultParametersAppKernel extends AppKernel
-{
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
-    {
-        parent::configureContainer($container, $loader);
-
-        $loader->load(static function (ContainerBuilder $container): void {
-            if ($container->hasDefinition('phpunit_resource_name_collection')) {
-                $container->removeDefinition('phpunit_resource_name_collection');
-            }
-
-            $container->loadFromExtension('api_platform', [
-                'defaults' => [
-                    'parameters' => [
-                        'api_token' => [
-                            'class' => HeaderParameter::class,
-                            'key' => 'API-Token',
-                            'required' => true,
-                            'description' => 'API token',
-                        ],
-                        'request_id' => [
-                            'class' => HeaderParameter::class,
-                            'key' => 'Request-ID',
-                            'required' => false,
-                            'description' => 'Request correlation identifier',
-                        ],
-                    ],
-                ],
-            ]);
-        });
     }
 }

--- a/tests/Functional/RepeatedDefaultParametersTest.php
+++ b/tests/Functional/RepeatedDefaultParametersTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use ApiPlatform\Metadata\HeaderParameter;
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RepeatedDefaultParametersTest extends ApiTestCase
+{
+    protected static ?bool $alwaysBootKernel = false;
+
+    protected static function getKernelClass(): string
+    {
+        return RepeatedDefaultParametersAppKernel::class;
+    }
+
+    public function testRepeatedDefaultParametersAppearTogetherInOpenApi(): void
+    {
+        $response = self::createClient()->request('GET', '/docs', [
+            'headers' => ['Accept' => 'application/vnd.openapi+json'],
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $content = $response->toArray();
+
+        foreach ($content['paths'] as $pathItem) {
+            foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
+                if (!isset($pathItem[$method]['parameters'])) {
+                    continue;
+                }
+
+                $parameters = [];
+                foreach ($pathItem[$method]['parameters'] as $parameter) {
+                    if ('header' === $parameter['in']) {
+                        $parameters[$parameter['name']] = $parameter;
+                    }
+                }
+
+                if (!isset($parameters['API-Token'], $parameters['Request-ID'])) {
+                    continue;
+                }
+
+                $this->assertSame('API-Token', $parameters['API-Token']['name']);
+                $this->assertSame('header', $parameters['API-Token']['in']);
+                $this->assertSame('API token', $parameters['API-Token']['description']);
+                $this->assertTrue($parameters['API-Token']['required']);
+                $this->assertSame('Request-ID', $parameters['Request-ID']['name']);
+                $this->assertSame('header', $parameters['Request-ID']['in']);
+                $this->assertSame('Request correlation identifier', $parameters['Request-ID']['description']);
+                $this->assertFalse($parameters['Request-ID']['required']);
+
+                return;
+            }
+        }
+
+        $this->fail('No OpenAPI operation contained both repeated default header parameters.');
+    }
+}
+
+final class RepeatedDefaultParametersAppKernel extends AppKernel
+{
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        parent::configureContainer($container, $loader);
+
+        $loader->load(static function (ContainerBuilder $container): void {
+            if ($container->hasDefinition('phpunit_resource_name_collection')) {
+                $container->removeDefinition('phpunit_resource_name_collection');
+            }
+
+            $container->loadFromExtension('api_platform', [
+                'defaults' => [
+                    'parameters' => [
+                        'api_token' => [
+                            'class' => HeaderParameter::class,
+                            'key' => 'API-Token',
+                            'required' => true,
+                            'description' => 'API token',
+                        ],
+                        'request_id' => [
+                            'class' => HeaderParameter::class,
+                            'key' => 'Request-ID',
+                            'required' => false,
+                            'description' => 'Request correlation identifier',
+                        ],
+                    ],
+                ],
+            ]);
+        });
+    }
+}

--- a/tests/Validator/Metadata/Resource/Factory/ParameterValidationConfigurationTest.php
+++ b/tests/Validator/Metadata/Resource/Factory/ParameterValidationConfigurationTest.php
@@ -81,6 +81,83 @@ final class ParameterValidationConfigurationTest extends TestCase
         $this->assertArrayHasKey('ApiPlatform\Metadata\QueryParameter', $config['defaults']['parameters']);
     }
 
+    public function testNamedDefaultParametersWithSameClassConfiguration(): void
+    {
+        $config = $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'defaults' => [
+                    'parameters' => [
+                        'api_token' => [
+                            'class' => 'ApiPlatform\Metadata\HeaderParameter',
+                            'key' => 'API-Token',
+                            'required' => true,
+                        ],
+                        'request_id' => [
+                            'class' => 'ApiPlatform\Metadata\HeaderParameter',
+                            'key' => 'Request-ID',
+                            'required' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $parameters = $config['defaults']['parameters'];
+
+        $this->assertCount(2, $parameters);
+        $this->assertSame('ApiPlatform\Metadata\HeaderParameter', $parameters['api_token']['class']);
+        $this->assertSame('API-Token', $parameters['api_token']['key']);
+        $this->assertTrue($parameters['api_token']['required']);
+        $this->assertSame('ApiPlatform\Metadata\HeaderParameter', $parameters['request_id']['class']);
+        $this->assertSame('Request-ID', $parameters['request_id']['key']);
+        $this->assertFalse($parameters['request_id']['required']);
+    }
+
+    public function testHistoricalAndNamedDefaultParametersConfiguration(): void
+    {
+        $config = $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'defaults' => [
+                    'parameters' => [
+                        'ApiPlatform\Metadata\QueryParameter' => [
+                            'key' => 'page_size',
+                        ],
+                        'api_token' => [
+                            'class' => 'ApiPlatform\Metadata\HeaderParameter',
+                            'key' => 'API-Token',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $parameters = $config['defaults']['parameters'];
+
+        $this->assertCount(2, $parameters);
+        $this->assertArrayHasKey('ApiPlatform\Metadata\QueryParameter', $parameters);
+        $this->assertArrayNotHasKey('class', $parameters['ApiPlatform\Metadata\QueryParameter']);
+        $this->assertSame('page_size', $parameters['ApiPlatform\Metadata\QueryParameter']['key']);
+        $this->assertSame('ApiPlatform\Metadata\HeaderParameter', $parameters['api_token']['class']);
+        $this->assertSame('API-Token', $parameters['api_token']['key']);
+    }
+
+    public function testNamedDefaultParameterClassCannotBeEmpty(): void
+    {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
+        $this->processor->processConfiguration($this->configuration, [
+            'api_platform' => [
+                'defaults' => [
+                    'parameters' => [
+                        'api_token' => [
+                            'class' => '',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testDefaultParametersWithAllOptions(): void
     {
         $config = $this->processor->processConfiguration($this->configuration, [

--- a/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
+++ b/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
@@ -36,6 +36,21 @@ final class ParameterValidationResourceMetadataCollectionFactoryDefaultParameter
         ],
     ];
 
+    private const REPEATED_DEFAULT_PARAMETERS = [
+        'api_token' => [
+            'class' => HeaderParameter::class,
+            'key' => 'API-Token',
+            'required' => true,
+            'description' => 'API token',
+        ],
+        'request_id' => [
+            'class' => HeaderParameter::class,
+            'key' => 'Request-ID',
+            'required' => false,
+            'description' => 'Request correlation identifier',
+        ],
+    ];
+
     public function testDefaultParametersAppliedToRealResource(): void
     {
         $attributesFactory = new AttributesResourceMetadataCollectionFactory();
@@ -108,6 +123,73 @@ final class ParameterValidationResourceMetadataCollectionFactoryDefaultParameter
         $this->assertTrue($parameters->has('API-Version', HeaderParameter::class));
         $this->assertTrue($parameters->has('filter', QueryParameter::class));
     }
+
+    public function testNamedDefaultParametersWithSameClassAreApplied(): void
+    {
+        $attributesFactory = new AttributesResourceMetadataCollectionFactory();
+        $parameterValidationFactory = new ParameterValidationResourceMetadataCollectionFactory(
+            $attributesFactory,
+            null,
+            self::REPEATED_DEFAULT_PARAMETERS
+        );
+
+        $collection = $parameterValidationFactory->create(TestProductResource::class);
+        $operation = $collection[0]->getOperations()?->getIterator()->current();
+        $parameters = $operation?->getParameters();
+
+        $this->assertNotNull($parameters);
+        $this->assertCount(2, $parameters);
+        $this->assertTrue($parameters->has('API-Token', HeaderParameter::class));
+        $this->assertTrue($parameters->has('Request-ID', HeaderParameter::class));
+        $this->assertSame('API token', $parameters->get('API-Token', HeaderParameter::class)?->getDescription());
+        $this->assertSame('Request correlation identifier', $parameters->get('Request-ID', HeaderParameter::class)?->getDescription());
+        $this->assertTrue($parameters->get('API-Token', HeaderParameter::class)?->getRequired());
+        $this->assertFalse($parameters->get('Request-ID', HeaderParameter::class)?->getRequired());
+    }
+
+    public function testHistoricalAndNamedDefaultParametersAreAppliedTogether(): void
+    {
+        $attributesFactory = new AttributesResourceMetadataCollectionFactory();
+        $parameterValidationFactory = new ParameterValidationResourceMetadataCollectionFactory(
+            $attributesFactory,
+            null,
+            [
+                QueryParameter::class => [
+                    'key' => 'page_size',
+                ],
+                ...self::REPEATED_DEFAULT_PARAMETERS,
+            ]
+        );
+
+        $collection = $parameterValidationFactory->create(TestProductResource::class);
+        $operation = $collection[0]->getOperations()?->getIterator()->current();
+        $parameters = $operation?->getParameters();
+
+        $this->assertNotNull($parameters);
+        $this->assertCount(3, $parameters);
+        $this->assertTrue($parameters->has('page_size', QueryParameter::class));
+        $this->assertTrue($parameters->has('API-Token', HeaderParameter::class));
+        $this->assertTrue($parameters->has('Request-ID', HeaderParameter::class));
+    }
+
+    public function testOperationParameterOverridesOnlyMatchingNamedDefaultParameter(): void
+    {
+        $attributesFactory = new AttributesResourceMetadataCollectionFactory();
+        $parameterValidationFactory = new ParameterValidationResourceMetadataCollectionFactory(
+            $attributesFactory,
+            null,
+            self::REPEATED_DEFAULT_PARAMETERS
+        );
+
+        $collection = $parameterValidationFactory->create(TestProductResourceWithRepeatedHeaders::class);
+        $operation = $collection[0]->getOperations()?->getIterator()->current();
+        $parameters = $operation?->getParameters();
+
+        $this->assertNotNull($parameters);
+        $this->assertCount(2, $parameters);
+        $this->assertSame('Local API token', $parameters->get('API-Token', HeaderParameter::class)?->getDescription());
+        $this->assertSame('Request correlation identifier', $parameters->get('Request-ID', HeaderParameter::class)?->getDescription());
+    }
 }
 
 #[ApiResource(operations: [new GetCollection()])]
@@ -127,6 +209,21 @@ class TestProductResource
     ]
 )]
 class TestProductResourceWithParameters
+{
+    public int $id = 1;
+    public string $name = 'Test Product';
+}
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'API-Token' => new HeaderParameter(key: 'API-Token', description: 'Local API token'),
+            ]
+        ),
+    ]
+)]
+class TestProductResourceWithRepeatedHeaders
 {
     public int $id = 1;
     public string $name = 'Test Product';

--- a/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
+++ b/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
@@ -143,8 +143,8 @@ final class ParameterValidationResourceMetadataCollectionFactoryDefaultParameter
         $this->assertTrue($parameters->has('Request-ID', HeaderParameter::class));
         $this->assertSame('API token', $parameters->get('API-Token', HeaderParameter::class)?->getDescription());
         $this->assertSame('Request correlation identifier', $parameters->get('Request-ID', HeaderParameter::class)?->getDescription());
-        $this->assertTrue($parameters->get('API-Token', HeaderParameter::class)?->getRequired());
-        $this->assertFalse($parameters->get('Request-ID', HeaderParameter::class)?->getRequired());
+        $this->assertTrue($parameters->get('API-Token', HeaderParameter::class)->getRequired());
+        $this->assertFalse($parameters->get('Request-ID', HeaderParameter::class)->getRequired());
     }
 
     public function testHistoricalAndNamedDefaultParametersAreAppliedTogether(): void

--- a/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
+++ b/tests/Validator/Metadata/Resource/Factory/ParameterValidationResourceMetadataCollectionFactoryDefaultParametersTest.php
@@ -172,6 +172,22 @@ final class ParameterValidationResourceMetadataCollectionFactoryDefaultParameter
         $this->assertTrue($parameters->has('Request-ID', HeaderParameter::class));
     }
 
+    public function testNamedDefaultParameterWithoutClassDefaultsToQueryParameter(): void
+    {
+        $attributesFactory = new AttributesResourceMetadataCollectionFactory();
+        $parameterValidationFactory = new ParameterValidationResourceMetadataCollectionFactory(
+            $attributesFactory,
+            null,
+            ['sort' => ['key' => 'sort', 'required' => false]]
+        );
+
+        $collection = $parameterValidationFactory->create(TestProductResource::class);
+        $parameters = $collection[0]->getOperations()?->getIterator()->current()?->getParameters();
+
+        $this->assertCount(1, $parameters);
+        $this->assertTrue($parameters->has('sort', QueryParameter::class));
+    }
+
     public function testOperationParameterOverridesOnlyMatchingNamedDefaultParameter(): void
     {
         $attributesFactory = new AttributesResourceMetadataCollectionFactory();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Refs #8315
| License       | MIT
| Doc PR        | https://github.com/api-platform/docs/pull/2319

This PR fixes repeated global default parameters in the Symfony integration.

Named entries can now specify their parameter class explicitly, allowing multiple parameters to use the same class while preserving the existing class-keyed configuration syntax.

For example:

```yaml
api_platform:
    defaults:
        parameters:
            api_token:
                class: ApiPlatform\Metadata\HeaderParameter
                key: API-Token

            request_id:
                class: ApiPlatform\Metadata\HeaderParameter
                key: Request-ID