### PR TITLE
refactor(mcp): dedupe security and validator gates

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/ApiPlatformExtension.php
@@ -179,6 +179,11 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             $patchFormats['jsonapi'] = ['application/vnd.api+json'];
         }
 
+        // McpToolProvider requires Symfony's object_mapper service; mirror FrameworkBundle's gate so we don't try to wire it when object-mapper is dev-only.
+        $mcpEnabled = ($config['mcp']['enabled'] ?? false) && class_exists(McpBundle::class) && ContainerBuilder::willBeAvailable('symfony/object-mapper', ObjectMapperInterface::class, ['symfony/framework-bundle']);
+        // kernel listeners never run for a JSON-RPC tool call, so MCP needs its own provider chain
+        $mcpProviderChain = $mcpEnabled && $config['use_symfony_listeners'];
+
         $this->registerCommonConfiguration($container, $config, $loader, $formats, $patchFormats, $errorFormats, $docsFormats);
         $this->registerMetadataConfiguration($container, $config, $loader);
         $this->registerOAuthConfiguration($container, $config);
@@ -193,12 +198,12 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $this->registerDoctrineOrmConfiguration($container, $config, $loader);
         $this->registerDoctrineMongoDbOdmConfiguration($container, $config, $loader);
         $this->registerHttpCacheConfiguration($container, $config, $loader);
-        $this->registerValidatorConfiguration($container, $config, $loader);
+        $this->registerValidatorConfiguration($container, $config, $loader, $mcpProviderChain);
         $this->registerDataCollectorConfiguration($container, $config, $loader);
         $this->registerMercureConfiguration($container, $config, $loader);
         $this->registerMessengerConfiguration($container, $config, $loader);
         $this->registerElasticsearchConfiguration($container, $config, $loader);
-        $this->registerSecurityConfiguration($container, $config, $loader);
+        $this->registerSecurityConfiguration($container, $config, $loader, $mcpProviderChain);
         $this->registerMakerConfiguration($container, $config, $loader);
         $this->registerArgumentResolverConfiguration($loader);
         $this->registerLinkSecurityConfiguration($loader, $config);
@@ -214,34 +219,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $container->setParameter('api_platform.mcp.format', $config['mcp']['format'] ?? null);
 
-        // McpToolProvider requires Symfony's object_mapper service; mirror FrameworkBundle's gate so we don't try to wire it when object-mapper is dev-only.
-        if (($config['mcp']['enabled'] ?? false) && class_exists(McpBundle::class) && ContainerBuilder::willBeAvailable('symfony/object-mapper', ObjectMapperInterface::class, ['symfony/framework-bundle'])) {
+        if ($mcpEnabled) {
             $loader->load('mcp/mcp.php');
-
-            if ($config['use_symfony_listeners']) {
-                // In this mode the state pipeline is driven by kernel listeners, which never run for
-                // a JSON-RPC tool call, so MCP needs its own provider chain to keep enforcing
-                // security, parameters and validation.
-                $loader->load('mcp/events.php');
-
-                /** @var string[] $bundles */
-                $bundles = $container->getParameter('kernel.bundles');
-                $hasValidator = interface_exists(ValidatorInterface::class);
-
-                if ($hasValidator) {
-                    $loader->load('mcp/validator.php');
-                }
-
-                if (isset($bundles['SecurityBundle'])) {
-                    $loader->load('mcp/security.php');
-
-                    if ($hasValidator) {
-                        $loader->load('mcp/security_validator.php');
-                    }
-                }
-            } else {
-                $loader->load('mcp/state.php');
-            }
+            $loader->load($mcpProviderChain ? 'mcp/events.php' : 'mcp/state.php');
         }
 
         $container->registerForAutoconfiguration(FilterInterface::class)
@@ -956,9 +936,9 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         return $formats;
     }
 
-    private function registerValidatorConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader): void
+    private function registerValidatorConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader, bool $mcpProviderChain): void
     {
-        if (interface_exists(ValidatorInterface::class)) {
+        if ($this->isValidatorAvailable()) {
             $loader->load('metadata/validator.php');
             $loader->load('validator/validator.php');
 
@@ -967,6 +947,10 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
             }
 
             $loader->load($config['use_symfony_listeners'] ? 'validator/events.php' : 'validator/state.php');
+
+            if ($mcpProviderChain) {
+                $loader->load('mcp/validator.php');
+            }
 
             $container->registerForAutoconfiguration(ValidationGroupsGeneratorInterface::class)
                 ->addTag('api_platform.validation_groups_generator');
@@ -1067,7 +1051,7 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
         $loader->load('elasticsearch.php');
     }
 
-    private function registerSecurityConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader): void
+    private function registerSecurityConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader, bool $mcpProviderChain): void
     {
         /** @var string[] $bundles */
         $bundles = $container->getParameter('kernel.bundles');
@@ -1080,13 +1064,26 @@ final class ApiPlatformExtension extends Extension implements PrependExtensionIn
 
         $loader->load('state/security.php');
 
-        if (interface_exists(ValidatorInterface::class)) {
+        if ($mcpProviderChain) {
+            $loader->load('mcp/security.php');
+        }
+
+        if ($this->isValidatorAvailable()) {
             $loader->load('state/security_validator.php');
+
+            if ($mcpProviderChain) {
+                $loader->load('mcp/security_validator.php');
+            }
         }
 
         if ($this->isConfigEnabled($container, $config['graphql'])) {
             $loader->load('graphql/security.php');
         }
+    }
+
+    private function isValidatorAvailable(): bool
+    {
+        return interface_exists(ValidatorInterface::class);
     }
 
     private function registerOpenApiConfiguration(ContainerBuilder $container, array $config, PhpFileLoader $loader): void

--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -119,12 +119,20 @@ class ApiPlatformExtensionTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->container = $this->createContainer([
+            'DoctrineBundle' => DoctrineBundle::class,
+            'SecurityBundle' => SecurityBundle::class,
+            'TwigBundle' => TwigBundle::class,
+        ]);
+    }
+
+    /**
+     * @param array<string, class-string> $bundles
+     */
+    private function createContainer(array $bundles): ContainerBuilder
+    {
         $containerParameterBag = new ParameterBag([
-            'kernel.bundles' => [
-                'DoctrineBundle' => DoctrineBundle::class,
-                'SecurityBundle' => SecurityBundle::class,
-                'TwigBundle' => TwigBundle::class,
-            ],
+            'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => [
                 'TestBundle' => [
                     'parent' => null,
@@ -137,7 +145,7 @@ class ApiPlatformExtensionTest extends TestCase
             'kernel.environment' => 'test',
         ]);
 
-        $this->container = new ContainerBuilder($containerParameterBag);
+        return new ContainerBuilder($containerParameterBag);
     }
 
     private function assertContainerHas(array $services, array $aliases = []): void
@@ -368,6 +376,55 @@ class ApiPlatformExtensionTest extends TestCase
 
         $this->assertContainerHas($services, $aliases);
         $this->container->hasParameter('api_platform.swagger.http_auth');
+    }
+
+    public function testMcpProviderChainIsSecuredAndValidatedWithSecurityBundle(): void
+    {
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['use_symfony_listeners'] = true;
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertContainerHasService('api_platform.mcp.handler');
+
+        foreach ([
+            'api_platform.mcp.state_provider.access_checker',
+            'api_platform.mcp.state_provider.access_checker.pre_read',
+            'api_platform.mcp.state_provider.access_checker.post_deserialize',
+            'api_platform.mcp.state_provider.access_checker.post_validate',
+            'api_platform.mcp.state_provider.security_parameter',
+            'api_platform.mcp.state_provider.validate',
+            'api_platform.mcp.state_provider.parameter_validator',
+        ] as $service) {
+            $this->assertContainerHasService($service);
+        }
+    }
+
+    public function testMcpProviderChainIsNotSecuredWithoutSecurityBundle(): void
+    {
+        $this->container = $this->createContainer([
+            'DoctrineBundle' => DoctrineBundle::class,
+            'TwigBundle' => TwigBundle::class,
+        ]);
+
+        $config = self::DEFAULT_CONFIG;
+        $config['api_platform']['use_symfony_listeners'] = true;
+        (new ApiPlatformExtension())->load($config, $this->container);
+
+        $this->assertContainerHasService('api_platform.mcp.handler');
+        $this->assertNotContainerHasService('api_platform.state_provider.access_checker');
+
+        foreach ([
+            'api_platform.mcp.state_provider.access_checker',
+            'api_platform.mcp.state_provider.access_checker.pre_read',
+            'api_platform.mcp.state_provider.access_checker.post_deserialize',
+            'api_platform.mcp.state_provider.access_checker.post_validate',
+            'api_platform.mcp.state_provider.security_parameter',
+        ] as $service) {
+            $this->assertNotContainerHasService($service);
+        }
+
+        $this->assertContainerHasService('api_platform.mcp.state_provider.validate');
+        $this->assertContainerHasService('api_platform.mcp.state_provider.parameter_validator');
     }
 
     public function testItRegistersMetadataConfiguration(): void


### PR DESCRIPTION
Follow-up to #8435.

That PR fixed a real hole — with `use_symfony_listeners: true`, MCP tool calls bypassed security and validation entirely, because `api_platform.mcp.handler` was wired to the bare `CallableProvider` instead of a decorated chain. To decide whether to wire the new `mcp/security.php` and `mcp/validator.php`, it re-derived two gates inside `load()`:

- `isset($bundles['SecurityBundle'])` — canonical version already in `registerSecurityConfiguration()`
- `interface_exists(ValidatorInterface::class)` — canonical version already in `registerValidatorConfiguration()`

They agree today. But if either canonical gate ever changes, MCP silently loses security again — which is exactly the bug class #8435 just closed. A duplicated security gate is a latent version of the same defect.

## What changed

The MCP service files are now loaded from *inside* the two methods that already own those decisions:

- `mcp/security.php` loads after `registerSecurityConfiguration()`'s SecurityBundle early return, so it is structurally unreachable when security is absent — there is no second condition left to desync.
- `mcp/validator.php` and `mcp/security_validator.php` load inside `isValidatorAvailable()` branches, the same branches that own `validator/*.php` and `state/security_validator.php`.

A single `$mcpProviderChain` flag, derived once in `load()` from the existing MCP-enabled condition, is threaded into both methods.

| Gate | occurrences before | after |
|---|---|---|
| `isset($bundles['SecurityBundle'])` | 2 | 1 |
| `interface_exists(ValidatorInterface::class)` | 3 | 1 |

All three load conditions are preserved exactly; the block in `load()` collapses from 24 lines to 4.

## Testing

Two DI tests added. Written first, then verified red by deliberately desyncing the duplicated gate against the original code — reproducing the #8435 failure mode:

```
Service "api_platform.mcp.state_provider.access_checker" not found.
```

The negative test asserts `api_platform.mcp.handler` *is* still registered without SecurityBundle, so it cannot pass trivially by MCP being disabled outright.

`tests/Functional/McpSecurityTest.php` and `McpTest.php` pass in both listener modes (22 tests, 172 assertions each). Note `AppKernel::getCacheDir()` is not keyed by `USE_SYMFONY_LISTENERS`, so the cache was cleared between modes to avoid replaying a stale compiled container.

## Notes

- Load order changes: `mcp/validator.php` / `mcp/security.php` now load before `mcp/mcp.php` and `mcp/events.php`. Safe — all six files use distinct service ids and only `->decorate()`, which `DecoratorServicePass` resolves at compile time independent of definition order. Verified against the compiled container.
- `isValidatorAvailable()` also collapses a pre-existing double `interface_exists` in `registerValidatorConfiguration()` / `registerSecurityConfiguration()`.
- `$config['use_symfony_listeners']` still appears twice, selecting different file sets for different subsystems. Not the same drift hazard, left alone.

Branch 4.3 CI is currently broken for an unrelated reason (`symfony/mercure` v0.8.0 added two methods to `HubInterface` that the `TestHub` fixture does not implement, killing every job at container warmup). This PR's CI will not be meaningful until that lands.
