### PR TITLE
fix(test): support symfony/mercure 0.8 in test fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,7 +177,7 @@
         "symfony/json-streamer": "^7.4 || ^8.0",
         "symfony/maker-bundle": "^1.24",
         "symfony/mcp-bundle": "^0.12",
-        "symfony/mercure-bundle": "*",
+        "symfony/mercure-bundle": "^0.4.3|^0.5",
         "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
         "symfony/object-mapper": "^7.4 || ^8.0",
         "symfony/routing": "^6.4 || ^7.0 || ^8.0",

--- a/src/GraphQl/composer.json
+++ b/src/GraphQl/composer.json
@@ -34,7 +34,7 @@
         "phpspec/prophecy-phpunit": "^2.2",
         "api-platform/validator": "^4.3.1",
         "twig/twig": "^1.42.3 || ^2.12 || ^3.0",
-        "symfony/mercure-bundle": "*",
+        "symfony/mercure-bundle": "^0.4.3|^0.5",
         "symfony/routing": "^6.4 || ^7.0 || ^8.0",
         "phpunit/phpunit": "^11.5 || ^12.2"
     },

--- a/src/Serializer/composer.json
+++ b/src/Serializer/composer.json
@@ -40,7 +40,7 @@
         "phpspec/prophecy-phpunit": "^2.2",
         "phpunit/phpunit": "^11.5 || ^12.2",
         "sebastian/exporter": "^6.3.2 || ^7.0.2",
-        "symfony/mercure-bundle": "*",
+        "symfony/mercure-bundle": "^0.4.3|^0.5",
         "symfony/var-dumper": "^6.4 || ^7.0 || ^8.0",
         "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
         "symfony/type-info": "^7.3 || ^8.0"

--- a/src/Symfony/composer.json
+++ b/src/Symfony/composer.json
@@ -59,7 +59,7 @@
         "phpunit/phpunit": "^11.5 || ^12.2",
         "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
         "symfony/intl": "^6.4 || ^7.0 || ^8.0",
-        "symfony/mercure-bundle": "*",
+        "symfony/mercure-bundle": "^0.4.3|^0.5",
         "symfony/object-mapper": "^7.0 || ^8.0",
         "symfony/routing": "^6.4 || ^7.0 || ^8.0",
         "symfony/type-info": "^7.3 || ^8.0",

--- a/tests/Fixtures/TestBundle/Mercure/TestHub.php
+++ b/tests/Fixtures/TestBundle/Mercure/TestHub.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Tests\Fixtures\TestBundle\Mercure;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\ProtocolVersion;
 use Symfony\Component\Mercure\Update;
 
 final class TestHub implements HubInterface
@@ -71,5 +72,17 @@ final class TestHub implements HubInterface
         $this->updates[] = $update;
 
         return $this->hub->publish($update);
+    }
+
+    // Added to HubInterface in symfony/mercure 0.8. ProtocolVersion does not exist on 0.6/0.7, but PHP
+    // only resolves a return type when the method is called, and nothing calls these before 0.8.
+    public function getProtocolVersion(): ProtocolVersion
+    {
+        return $this->hub->getProtocolVersion();
+    }
+
+    public function getCookieName(): string
+    {
+        return $this->hub->getCookieName();
     }
 }


### PR DESCRIPTION
Unblocks 4.3 CI, which has produced no test signal since 2026-07-08.

## What broke

`symfony/mercure` v0.8.0 was released 2026-08-11 and added two methods to `HubInterface`:

```php
public function getProtocolVersion(): ProtocolVersion;   // v0.8.0 src/HubInterface.php:46
public function getCookieName(): string;                 // v0.8.0 src/HubInterface.php:51
```

`tests/Fixtures/TestBundle/Mercure/TestHub.php` is a decorator implementing `HubInterface` and did not define them:

```
PHP Fatal error: Class ApiPlatform\Tests\Fixtures\TestBundle\Mercure\TestHub contains 2 abstract
methods and must therefore be declared abstract or implement the remaining methods
(Symfony\Component\Mercure\HubInterface::getProtocolVersion, ...::getCookieName)
```

This kills the container at cache warmup, so **all 20 failing jobs died before PHPUnit started** — zero tests ran. It is entirely test infrastructure: nothing in `src/` implements `HubInterface`, and no shipped code is affected.

It landed silently because `symfony/mercure-bundle` was declared as `"*"` in all four composer files — a bare wildcard on a `0.x` component.

## What changed

1. `TestHub` implements both new methods, delegating to the inner hub.
2. `"symfony/mercure-bundle": "*"` → `"^0.4.3|^0.5"` in `composer.json`, `src/GraphQl/composer.json`, `src/Serializer/composer.json`, `src/Symfony/composer.json`. All four are `require-dev`; the `suggest` entry in `src/Symfony/composer.json` is untouched.

The constraint deliberately spans the breaking boundary so both majors stay covered:

| mercure-bundle | resolves symfony/mercure |
|---|---|
| v0.4.3 | `^0.6.1\|^0.7` — what the `lowest` jobs install |
| v0.5.0 | `^0.8` |

`ProtocolVersion` does not exist before 0.8. Declaring it as a return type is safe because PHP resolves return types lazily and nothing calls these methods on older versions — but that is an assumption worth testing rather than trusting, so it was tested.

## Verification

Both majors, cache warmup plus the Mercure functional tests:

| symfony/mercure | `ProtocolVersion` present | cache:warmup | `phpunit tests/Functional --filter Mercure` |
|---|---|---|---|
| v0.7.2 | no | OK | OK (6 tests, 30 assertions) |
| v0.8.0 | yes | OK | OK (6 tests, 30 assertions) |

php-cs-fixer: no changes. PHPStan on the changed fixture: no errors.

## Note

Branches `4.4` and `main` carry the identical `TestHub` and the same `"*"` constraint. `4.4` last ran CI on 2026-07-12, before mercure 0.8.0, so it has not detonated yet — it will on the next push. This should merge up rather than be fixed separately.
