### PR TITLE
fix(hydra): stream totalItems as an integer

### DIFF
--- a/src/Hydra/Collection.php
+++ b/src/Hydra/Collection.php
@@ -31,7 +31,7 @@ class Collection
     #[StreamedName('@type')]
     public string $type = 'Collection';
 
-    public float $totalItems;
+    public int $totalItems;
 
     public ?IriTemplate $search = null;
     public ?PartialCollectionView $view = null;

--- a/src/Hydra/State/JsonStreamerProcessor.php
+++ b/src/Hydra/State/JsonStreamerProcessor.php
@@ -91,7 +91,7 @@ final class JsonStreamerProcessor implements ProcessorInterface
             }
 
             if ($data instanceof PaginatorInterface) {
-                $collection->totalItems = $data->getTotalItems();
+                $collection->totalItems = (int) $data->getTotalItems();
             }
 
             if (\is_array($data) || ($data instanceof \Countable && !$data instanceof PartialPaginatorInterface)) {


### PR DESCRIPTION
One of three PRs finishing the 4.3 CI unblock started in #8458. This is the only one that changes runtime behaviour, which is why it is split out.

## Problem

`Hydra\Collection::$totalItems` was declared `float` (`src/Hydra/Collection.php:34`). `symfony/json-streamer` 8.1.4 (released 2026-08-01) began encoding with `JSON_PRESERVE_ZERO_FRACTION` — see upstream commit `57ff6c1` "[JsonStreamer] Use readable JSON encode defaults", now at `vendor/symfony/json-streamer/Write/PhpGenerator.php:43-44`. A float `10.0` therefore serialises as `10.0` instead of `10`.

That output contradicts two contracts this project publishes for the same field:

- `src/Hydra/JsonSchema/SchemaFactory.php:172-173` — `'type' => 'integer'`, `'minimum' => 0`
- `src/JsonLd/HydraContext.php:606-609` — `'range' => 'xsd:integer'`

It also diverged from the non-streamed path: `src/Hydra/Serializer/CollectionNormalizer.php:66` passes the same value through plain `json_encode` (no `PRESERVE_ZERO_FRACTION`), emitting `10`. The streamed and normalised representations of one resource disagreed.

## Fix

Narrow the property to `int` and cast at the assignment site in `src/Hydra/State/JsonStreamerProcessor.php:94`. The float originates from `PaginatorInterface::getTotalItems(): float` (`src/State/Pagination/PaginatorInterface.php:36`), which is unchanged.

`Hydra\Collection` is marked `@internal` (`src/Hydra/Collection.php:21`), so narrowing the property type is not a BC break.

## Effect

Streamed JSON-LD collections emit `"hydra:totalItems": 10` rather than `10.0`, matching the published JSON Schema, the JSON-LD context, and the non-streamed output.
