### PR TITLE
fix(metadata): drop unreachable array guards on serializer attributes

### DIFF
--- a/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
+++ b/src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
@@ -58,14 +58,6 @@ final class SerializerPropertyMetadataFactory implements PropertyMetadataFactory
 
             [$normalizationAttributes, $denormalizationAttributes] = $this->getEffectiveSerializerAttributes($options);
 
-            if ($normalizationAttributes && !\is_array($normalizationAttributes)) {
-                $normalizationAttributes = [$normalizationAttributes];
-            }
-
-            if ($denormalizationAttributes && !\is_array($denormalizationAttributes)) {
-                $denormalizationAttributes = [$denormalizationAttributes];
-            }
-
             $ignoredAttributes = $options['ignored_attributes'] ?? [];
         } catch (ResourceClassNotFoundException) {
             // TODO: for input/output classes, the serializer groups must be read from the actual resource class


### PR DESCRIPTION
One of three PRs finishing the 4.3 CI unblock started in #8458. Pure dead-code removal, no behaviour change.

PHPStan (PHP 8.5) fails on 4.3 with:

```
src/Metadata/Property/Factory/SerializerPropertyMetadataFactory.php
  61  Call to function is_array() with non-empty-array will always evaluate to true.
  65  Call to function is_array() with non-empty-array will always evaluate to true.
```

`getEffectiveSerializerAttributes()` (`:239-278`) is declared `@return (array|null)[]` and every return path yields `array|null`, so the `!\is_array()` branches could never execute. Introduced by copy-paste in `64b46b2d0` (#7629), where attributes support was cloned from the groups block above.

## Why the sibling guards are left alone

The structurally identical guards for `$normalizationGroups` / `$denormalizationGroups` a few lines up do **not** error, and that asymmetry is correct rather than an oversight:

- `getEffectiveSerializerGroups()` returns `(string[]|string|null)[]` — the `string` member keeps `!is_array()` reachable.
- It is grounded in Symfony's contract, not just our docblocks. `AbstractNormalizer::getGroups()` does `\is_scalar($groups) ? (array) $groups : $groups`, explicitly supporting a scalar `groups`. `AbstractNormalizer::isAllowedAttribute()` has no equivalent coercion for `ATTRIBUTES`; a non-array simply falls through to `return true`.

So `attributes` is array-only by Symfony's own contract. Coercing a scalar here would make this factory diverge from the serializer that consumes the value.
