### PR TITLE
test: adapt json-streamer and object-mapper fixtures to Symfony 8.1.4

### DIFF
--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithRelation.php
@@ -35,6 +35,7 @@ use Symfony\Component\ObjectMapper\Attribute\Map;
 #[Map(target: MappedResourceWithRelationEntity::class)]
 class MappedResourceWithRelation
 {
+    #[Map(transform: 'intval')]
     public ?string $id = null;
     #[Map(if: false)]
     public ?string $relationName = null;

--- a/tests/Functional/JsonStreamerTest.php
+++ b/tests/Functional/JsonStreamerTest.php
@@ -113,7 +113,7 @@ class JsonStreamerTest extends ApiTestCase
         $r = self::createClient()->request('GET', '/json_stream_resources/1', ['headers' => ['accept' => 'application/ld+json']]);
         $res = json_decode($r->getBrowserKitResponse()->getContent(), true);
         $this->assertIsInt($res['views']);
-        $this->assertIsInt($res['rating']);
+        $this->assertIsFloat($res['rating']);
         $this->assertIsBool($res['isFeatured']);
         $this->assertIsString($res['price']);
         $this->assertEquals('/json_stream_resources/1', $res['@id']);
@@ -170,7 +170,7 @@ class JsonStreamerTest extends ApiTestCase
         $r = self::createClient()->request('GET', '/json_stream_resources/1', ['headers' => ['accept' => 'application/json']]);
         $res = json_decode($r->getBrowserKitResponse()->getContent(), true);
         $this->assertIsInt($res['views']);
-        $this->assertIsInt($res['rating']);
+        $this->assertIsFloat($res['rating']);
         $this->assertIsBool($res['isFeatured']);
         $this->assertIsString($res['price']);
         $this->assertArrayNotHasKey('@id', $res);
@@ -227,7 +227,7 @@ class JsonStreamerTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSame('asd', $res['title']);
         $this->assertSame(0, $res['views']);
-        $this->assertSame(0, $res['rating']);
+        $this->assertSame(0.0, $res['rating']);
         $this->assertFalse($res['isFeatured']);
         $this->assertContains($res['price'], ['0', '0.00']); // Depends on DB
         $this->assertStringStartsWith('/json_stream_resources/', $res['@id']);
@@ -276,7 +276,7 @@ class JsonStreamerTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSame('asd', $res['title']);
         $this->assertSame(0, $res['views']);
-        $this->assertSame(0, $res['rating']);
+        $this->assertSame(0.0, $res['rating']);
         $this->assertFalse($res['isFeatured']);
         $this->assertContains($res['price'], ['0', '0.00']); // Depends on DB
         $this->assertArrayNotHasKey('@id', $res);


### PR DESCRIPTION
One of three PRs finishing the 4.3 CI unblock started in #8458. Test-only — no shipped code changes. Both hunks are adaptations to Symfony 8.1.4 components that moved while 4.3 CI was dark.

## json-streamer 8.1.4 — `rating`

Upstream commit `57ff6c1` "[JsonStreamer] Use readable JSON encode defaults" (2026-08-01) added `JSON_PRESERVE_ZERO_FRACTION`. Floats with integral values now encode as `5.0` rather than `5`.

`JsonStreamResource::$rating` is declared `float` (`tests/Fixtures/TestBundle/Entity/JsonStreamResource.php:50`), so emitting `5.0` is correct JSON semantics and round-trips the declared type. The previous `assertIsInt` only passed because the encoder was lossy about it. Assertions changed to `assertIsFloat` / `assertSame(0.0, ...)`.

The same stale assertion in `testJsonStreamerWriteJson` is fixed too. That test is currently skipped, so it was not failing — it would have failed the day the skip lifts.

Note `views` (declared `int`) is unaffected and still asserted as an int, and `totalItems` is deliberately not touched here — that one was a genuine bug in shipped code, fixed separately.

## object-mapper 8.1.4 — `MappedResourceWithRelation::$id`

Upstream commit `38f9183` "[ObjectMapper] Honor the target property `#[Map]` for the same-name copy when the source carries metadata" (2026-08-05) changed the same-name-copy path to consult the target's `#[Map]`.

`MappedResourceWithRelation::$id` (`?string`) carried no `#[Map]`, so on write it took that path, picked up the entity's `#[Map(transform: 'strval')]` (`MappedResourceWithRelationEntity.php:25`), and fed a string into `setId(?int)` (`:43`):

```
Expected argument of type "?int", "string" given at property path "id"
```

The fixture only ever declared the forward transform (entity `int` → DTO `string`) and left the write direction as an untyped same-name copy that worked only because the mapper was not consulting anything. Declaring the inverse `#[Map(transform: 'intval')]` is the missing half, not a workaround.

Confirmed by pinning: `object-mapper` 8.1.1 passes, 8.1.4 fails, and the fix passes on **both** — so it is version-robust rather than tuned to the current release.
