### PR TITLE
test(symfony): skip mcp provider chain tests without mcp-bundle

### DIFF
--- a/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
+++ b/src/Symfony/Tests/Bundle/DependencyInjection/ApiPlatformExtensionTest.php
@@ -30,6 +30,7 @@ use ApiPlatform\Tests\Fixtures\TestBundle\TestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\ORM\OptimisticLockException;
 use PHPUnit\Framework\TestCase;
+use Symfony\AI\McpBundle\McpBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -380,6 +381,10 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testMcpProviderChainIsSecuredAndValidatedWithSecurityBundle(): void
     {
+        if (!class_exists(McpBundle::class)) {
+            $this->markTestSkipped('symfony/mcp-bundle is not installed.');
+        }
+
         $config = self::DEFAULT_CONFIG;
         $config['api_platform']['use_symfony_listeners'] = true;
         (new ApiPlatformExtension())->load($config, $this->container);
@@ -401,6 +406,10 @@ class ApiPlatformExtensionTest extends TestCase
 
     public function testMcpProviderChainIsNotSecuredWithoutSecurityBundle(): void
     {
+        if (!class_exists(McpBundle::class)) {
+            $this->markTestSkipped('symfony/mcp-bundle is not installed.');
+        }
+
         $this->container = $this->createContainer([
             'DoctrineBundle' => DoctrineBundle::class,
             'TwigBundle' => TwigBundle::class,


### PR DESCRIPTION
Fixes the 7 `api-platform/symfony` component jobs that went red on 4.3 with `d82766611` (#8457).

## What broke

#8457 added two DI tests asserting the MCP provider chain is wired:

```
ApiPlatformExtensionTest::testMcpProviderChainIsSecuredAndValidatedWithSecurityBundle
ApiPlatformExtensionTest::testMcpProviderChainIsNotSecuredWithoutSecurityBundle
Service "api_platform.mcp.handler" not found.
```

They pass in the monorepo suite, where `symfony/mcp-bundle` is installed. The split `api-platform/symfony` package does not require it, so the extension's own gate

```php
$mcpEnabled = ($config['mcp']['enabled'] ?? false) && class_exists(McpBundle::class) && ...
```

evaluates false there, no MCP service is registered, and both tests fail. The gap is that #8457 was only ever run against the monorepo suite.

## Fix

Guard both tests on `class_exists(McpBundle::class)`, mirroring the extension gate exactly, rather than asserting services that are correctly absent.

Verified the guard does not over-skip: with mcp-bundle installed both tests still execute and pass (2 tests, 17 assertions). The skip path itself is not reproducible locally — CI's split-package job is the verification.

Went from 3 failing jobs to 10 on 4.3; this should return it to 3. The remaining 3 (`Symfony 8.1` / `Symfony dev` / `Symfony lowest`) are an unrelated pre-existing `OpenApiCommandTest::testExecuteWithYaml` failure.