### PR TITLE
test: assert rating as a json number across json-streamer versions

### DIFF
--- a/tests/Functional/JsonStreamerTest.php
+++ b/tests/Functional/JsonStreamerTest.php
@@ -113,7 +113,9 @@ class JsonStreamerTest extends ApiTestCase
         $r = self::createClient()->request('GET', '/json_stream_resources/1', ['headers' => ['accept' => 'application/ld+json']]);
         $res = json_decode($r->getBrowserKitResponse()->getContent(), true);
         $this->assertIsInt($res['views']);
-        $this->assertIsFloat($res['rating']);
+        // json-streamer only encodes with JSON_PRESERVE_ZERO_FRACTION since 8.1.4, so an integral
+        // float decodes as int on lower versions
+        $this->assertTrue(\is_int($res['rating']) || \is_float($res['rating']));
         $this->assertIsBool($res['isFeatured']);
         $this->assertIsString($res['price']);
         $this->assertEquals('/json_stream_resources/1', $res['@id']);
@@ -170,7 +172,9 @@ class JsonStreamerTest extends ApiTestCase
         $r = self::createClient()->request('GET', '/json_stream_resources/1', ['headers' => ['accept' => 'application/json']]);
         $res = json_decode($r->getBrowserKitResponse()->getContent(), true);
         $this->assertIsInt($res['views']);
-        $this->assertIsFloat($res['rating']);
+        // json-streamer only encodes with JSON_PRESERVE_ZERO_FRACTION since 8.1.4, so an integral
+        // float decodes as int on lower versions
+        $this->assertTrue(\is_int($res['rating']) || \is_float($res['rating']));
         $this->assertIsBool($res['isFeatured']);
         $this->assertIsString($res['price']);
         $this->assertArrayNotHasKey('@id', $res);
@@ -227,7 +231,7 @@ class JsonStreamerTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSame('asd', $res['title']);
         $this->assertSame(0, $res['views']);
-        $this->assertSame(0.0, $res['rating']);
+        $this->assertEquals(0, $res['rating']);
         $this->assertFalse($res['isFeatured']);
         $this->assertContains($res['price'], ['0', '0.00']); // Depends on DB
         $this->assertStringStartsWith('/json_stream_resources/', $res['@id']);
@@ -276,7 +280,7 @@ class JsonStreamerTest extends ApiTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSame('asd', $res['title']);
         $this->assertSame(0, $res['views']);
-        $this->assertSame(0.0, $res['rating']);
+        $this->assertEquals(0, $res['rating']);
         $this->assertFalse($res['isFeatured']);
         $this->assertContains($res['price'], ['0', '0.00']); // Depends on DB
         $this->assertArrayNotHasKey('@id', $res);


### PR DESCRIPTION
Fixes the `PHPUnit (PHP 8.3) (Symfony lowest)` job, which #8461 broke.

## What broke

#8461 adapted the `rating` assertions to json-streamer 8.1.4, which encodes with `JSON_PRESERVE_ZERO_FRACTION`:

```php
$this->assertIsFloat($res['rating']);
$this->assertSame(0.0, $res['rating']);
```

That pins the test to >= 8.1.4. The `Symfony lowest` job runs `composer update --prefer-lowest`, which resolves an earlier json-streamer that encodes an integral float as `5`:

```
1) JsonStreamerTest::testJsonStreamerJsonLd
Failed asserting that 5 is of type float.
2) JsonStreamerTest::testJsonStreamerJson
Failed asserting that 4 is of type float.
```

`Symfony lowest` was green on `e22463fdb` and red from `e3cb2da6c` (#8461), so this is a clean regression rather than a pre-existing condition.

## Fix

The PHP type of a decoded JSON number is an encoder detail that varies by version; the assertion should not depend on it. Assert that it is a JSON number of either type:

```php
// json-streamer only encodes with JSON_PRESERVE_ZERO_FRACTION since 8.1.4, so an integral
// float decodes as int on lower versions
$this->assertTrue(\is_int($res['rating']) || \is_float($res['rating']));
```

and compare the write-path value loosely (`assertEquals(0, ...)`) so `0` and `0.0` both satisfy it. `views` (a real `int`) and `price` (a `string`) keep their strict assertions.

## Verification

Reproduced the failure locally by downgrading to json-streamer 8.1.2 — the assertions on 4.3 fail exactly as CI reports:

```
Failed asserting that 4 is of type float.
Failed asserting that 3 is of type float.
Failed asserting that 0 is identical to 0.0.
```

With this change, `phpunit tests/Functional --filter JsonStreamer` passes under **both** json-streamer 8.1.2 and 8.1.4 (7 tests, 41 assertions, 1 skipped). `composer.json` restored afterwards; only the test file changes.