### PR TITLE
test(openapi): assert the yaml export structurally, not by key order

### DIFF
--- a/tests/OpenApi/Command/OpenApiCommandTest.php
+++ b/tests/OpenApi/Command/OpenApiCommandTest.php
@@ -76,27 +76,21 @@ class OpenApiCommandTest extends KernelTestCase
 
         $this->assertYaml($result);
 
-        $operationId = 'api_dummy_cars_get_collection';
+        // the serializer does not guarantee property order, so assert the structure rather than a
+        // rendered block, and keep separate assertions for the formatting this test cares about
+        $parsed = Yaml::parse($result);
+
+        $this->assertSame('api_dummy_cars_get_collection', $parsed['paths']['/dummy_cars']['get']['operationId'], 'nested object should be present.');
+        $this->assertSame(['DummyCar'], $parsed['paths']['/dummy_cars']['get']['tags']);
+        $this->assertSame('api_dummy_cars_id_get', $parsed['paths']['/dummy_cars/{id}']['get']['operationId']);
+        $this->assertSame([], $parsed['paths']['/dummy_cars/{id}']['get']['tags']);
 
         $expected = <<<YAML
-  /dummy_cars:
-    get:
-      operationId: $operationId
       tags:
         - DummyCar
 YAML;
-
-        $this->assertStringContainsString($expected, $result, 'nested object should be present.');
-
-        $operationId = 'api_dummy_cars_id_get';
-        $expected = <<<YAML
-  '/dummy_cars/{id}':
-    get:
-      operationId: $operationId
-      tags: []
-YAML;
-
-        $this->assertStringContainsString($expected, $result, 'arrays should be correctly formatted.');
+        $this->assertStringContainsString($expected, $result, 'sequences should be correctly formatted.');
+        $this->assertStringContainsString('      tags: []', $result, 'arrays should be correctly formatted.');
         $this->assertStringContainsString('openapi: '.OpenApi::VERSION, $result);
 
         $expected = <<<YAML


### PR DESCRIPTION
Fixes the last blocking failure on 4.3: `OpenApiCommandTest::testExecuteWithYaml` on the `PHPUnit (PHP 8.5) (Symfony dev)` job.

## Cause

The test matched rendered YAML blocks that assume `operationId` comes directly after `get:`:

```yaml
  /dummy_cars:
    get:
      operationId: api_dummy_cars_get_collection
      tags:
        - DummyCar
```

Under `symfony/serializer` 8.2.x-dev the Operation properties are emitted in a different order — `responses` first:

```yaml
  /dummy_cars:
    get:
      responses:
        '200':
```

**Nothing is missing.** `operationId` and `tags` are still there with the same values, just later in the mapping. I verified every individual fragment the test expects is present in the dev output; only the multi-key blocks fail. Object key order is not meaningful in YAML, so this is a test that over-specifies rather than a bug in the export.

Note the failure was not YAML formatting drift, which is what the symptom initially suggested.

## Fix

Assert the parsed structure for the paths, and keep separate string assertions for the formatting this test genuinely covers — block sequences and inline empty arrays:

```php
$parsed = Yaml::parse($result);

$this->assertSame('api_dummy_cars_get_collection', $parsed['paths']['/dummy_cars']['get']['operationId']);
$this->assertSame(['DummyCar'], $parsed['paths']['/dummy_cars']['get']['tags']);
$this->assertSame('api_dummy_cars_id_get', $parsed['paths']['/dummy_cars/{id}']['get']['operationId']);
$this->assertSame([], $parsed['paths']['/dummy_cars/{id}']['get']['tags']);
```

The remaining assertions — literal-style multiline description, quoted title, the nested `security` block — are unchanged; they were already order-independent and still pass.

## Verification

Reproduced locally with CI's recipe (`composer config minimum-stability dev`), which installs `symfony/yaml`, `symfony/serializer` and `symfony/framework-bundle` at 8.2.x-dev. The full file then passes:

| symfony | result |
| --- | --- |
| 8.2.x-dev | OK — 6 tests, 36 assertions |
| 8.1 stable | OK — 6 tests, 36 assertions |

(The 6 `risky` notices about exception handlers are pre-existing and appear on both.)