### PR TITLE
ci: align the whole symfony stack on the 8.1 edge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,8 +909,11 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Allow unstable project dependencies
         run: composer config minimum-stability dev
-      - name: Force Symfony 8.1 dev for framework-bundle and json-streamer
-        run: composer require --dev --no-update --no-interaction "symfony/framework-bundle:8.1.x-dev" "symfony/json-streamer:8.1.x-dev"
+      # minimum-stability dev lets unpinned components float to the next minor's dev branch, and
+      # mixing Symfony minor dev branches is not supported: framework-bundle 8.1.x-dev with
+      # property-info/serializer/type-info 8.2.x-dev loses property metadata entirely
+      - name: Force Symfony 8.1 dev
+        run: composer require --dev --no-update --no-interaction "symfony/framework-bundle:8.1.x-dev" "symfony/json-streamer:8.1.x-dev" "symfony/serializer:8.1.x-dev" "symfony/property-info:8.1.x-dev" "symfony/type-info:8.1.x-dev"
       - name: Cache dependencies
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:


### PR DESCRIPTION
Makes `PHPUnit (PHP 8.5) (Symfony 8.1)` report on Symfony 8.1 instead of on an unsupported dependency mix.

## Problem

The job sets `minimum-stability: dev` but pins only two packages:

```yaml
composer require --dev --no-update "symfony/framework-bundle:8.1.x-dev" "symfony/json-streamer:8.1.x-dev"
```

Everything else then floats to the **next minor's** dev branch. The actual resolution is:

| package | resolved |
| --- | --- |
| symfony/framework-bundle | 8.1.x-dev (pinned) |
| symfony/json-streamer | 8.1.x-dev (pinned) |
| symfony/serializer | **8.2.x-dev** |
| symfony/property-info | **8.2.x-dev** |
| symfony/type-info | **8.2.x-dev** |

Mixing Symfony minor dev branches is not supported, and here it silently breaks property discovery — nested objects serialize as `{}` and interface-backed DTO properties disappear:

```
JsonLd\InterfaceDtoOutputTest::testCollectionExposesOnlyInterfaceProperties
Failed asserting that an array has the key 'name'.

Serializer\ConstructorDeserializationTest::testPostHydratesObjectViaConstructor
-      '@type' => 'DummyObjectWithoutConstructor',
-      'foo' => 'bar',
```

## Evidence

Reproduced locally with the job's own recipe, then varied only the resolution:

| resolution | result |
| --- | --- |
| framework-bundle 8.1.x-dev + serializer/property-info/type-info 8.2.x-dev (current job) | both tests **fail** |
| everything 8.2.x-dev | both pass |
| everything 8.1.x-dev | both pass |

So the failures come from the mix, not from API Platform and not from any Symfony version on its own. The `Symfony dev` job — which sets `minimum-stability: dev` without pins, so everything lands on 8.2.x-dev consistently — does not report these two failures, which matches.

## Fix

Pin the serializer stack alongside framework-bundle so the job resolves a coherent 8.1 line.

The job stays `continue-on-error: true`; this is about the signal being meaningful rather than about turning it into a gate. Without this it reports failures that no user can hit, which is worse than reporting nothing.