### PR TITLE
ci: ignore files inside component test directories in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "src/**/Tests/"
+  - "src/**/Tests/**"


### PR DESCRIPTION
The `src/**/Tests/` ignore pattern in `codecov.yml` does not exclude anything.

Codecov compiles it to:

```
(?s:src/.*/Tests/)\Z
```

The `\Z` anchor sits right after the trailing slash, so the pattern only matches a path that *ends* in `Tests/` — never a file inside that directory. (Verified against `https://codecov.io/validate`.)

Consequently component test files are still part of the Codecov report at 0% coverage — the root `phpunit.xml.dist` `<source>` instruments them because it includes `.` and only excludes `tests` and `vendor`, while the per-component suites correctly exclude `./Tests`.

The visible effect is that test-heavy pull requests get an unfairly low `codecov/patch` score. For example on #8420 the diff is 20 measured lines: 1 production line (hit) plus 19 lines of the new `src/State/Tests/Processor/ObjectMapperOutputProcessorTest.php` (counted as missed), giving 5% patch coverage.

Using `src/**/Tests/**` compiles to:

```
(?s:src/.*/Tests/.*)\Z
```

which matches the files as intended. Validated with the Codecov config validator.