### PR TITLE
ci: restore the PMU_VERSION pin that the merge up dropped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ permissions:
 env:
   COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   COMPOSER_ROOT_VERSION: "5.0.x-dev"
+  # Pinned build tooling: these are installed and executed on the runner, so an
+  # unconstrained version would run whatever the registry serves that day.
+  PMU_VERSION: "0.3.0"
 
 jobs:
   architecture:
@@ -156,7 +159,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Update project dependencies
         run: |
-          composer global require soyuka/pmu
+          composer global require "soyuka/pmu:$PMU_VERSION"
           composer global config allow-plugins.soyuka/pmu true --no-interaction
           composer global link .
       - name: Codemod unit tests


### PR DESCRIPTION
`main` is currently red in **90 of its 91 failing checks**, and so is every pull
request targeting it — [#8448](https://github.com/api-platform/core/pull/8448)
shows 108 failures, all from the same step.

## Cause

#8442 pinned the build tooling by introducing `PMU_VERSION` in the workflow `env:`
block and rewriting every call site to `soyuka/pmu:$PMU_VERSION`. That landed on
`4.3`. Merging up to `main` kept the 21 rewritten call sites but **dropped the
`env:` entry that defines the variable**, so the command expands to:

```
composer global require "soyuka/pmu:"
```

and composer aborts:

```
##[error]Option soyuka/pmu is missing a version constraint, use e.g. soyuka/pmu:^1.0

In BaseCommand.php line 403:
  Option soyuka/pmu is missing a version constraint, use e.g. soyuka/pmu:^1.0
```

Every job that installs pmu dies there — the step is variously named
`Update project dependencies`, `PMU` or `Linking`, which is why the failure looks
like several unrelated problems. It is one.

## Change

- Restore the `PMU_VERSION` entry in `env:`, with the same value and comment as `4.3`.
- Constrain the one call site #8442 did not cover — the `Upgrade Filter Codemod`
  job still ran the unpinned `composer global require soyuka/pmu`, which is exactly
  what that comment warns against.

## Validation

This is a workflow-config change, so there is no meaningful unit test to add. The
invariant it restores is checkable directly — every `composer global require
soyuka/pmu` must carry a constraint, and that constraint must resolve:

| | `PMU_VERSION` defined | pmu requires | using `$PMU_VERSION` | unconstrained |
|---|---|---|---|---|
| `main` before | **no** | 22 | 21 | **1** |
| `main` after | yes | 22 | 22 | 0 |
| `4.3` (reference) | yes | 21 | 21 | 0 |

CI on this PR exercises the fix directly: the jobs that abort on `main` are the
same ones that must reach their real work here.
