### PR TITLE
feat(symfony): map UniqueConstraintViolationException to 422 by default

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -23,6 +23,7 @@ use ApiPlatform\Symfony\Controller\MainController;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\OptimisticLockException;
 use GraphQL\GraphQL;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerHelper;
@@ -592,6 +593,7 @@ final class Configuration implements ConfigurationInterface
                         SerializerExceptionInterface::class => Response::HTTP_BAD_REQUEST,
                         InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
                         OptimisticLockException::class => Response::HTTP_CONFLICT,
+                        UniqueConstraintViolationException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
                     ])
                     ->info('The list of exceptions mapped to their HTTP status code.')
                     ->normalizeKeys(false)

--- a/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
+++ b/tests/Symfony/Bundle/DependencyInjection/ConfigurationTest.php
@@ -15,6 +15,7 @@ namespace ApiPlatform\Tests\Symfony\Bundle\DependencyInjection;
 
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
 use ApiPlatform\Symfony\Bundle\DependencyInjection\Configuration;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\OptimisticLockException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -101,6 +102,7 @@ class ConfigurationTest extends TestCase
                 ExceptionInterface::class => Response::HTTP_BAD_REQUEST,
                 InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
                 OptimisticLockException::class => Response::HTTP_CONFLICT,
+                UniqueConstraintViolationException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
             ],
             'path_segment_name_generator' => 'api_platform.metadata.path_segment_name_generator.underscore',
             'inflector' => 'api_platform.metadata.inflector',


### PR DESCRIPTION
Follow-up to the second point of #8405, where @soyuka concluded "Probably just a 422": `Doctrine\DBAL\Exception\UniqueConstraintViolationException` is now mapped to 422 in the default `exception_to_status`, next to the existing `OptimisticLockException => 409`. Referencing the class stays safe when the DBAL is not installed, like the existing `OptimisticLockException` entry (`::class` does not load the class).

The first point of the issue (merging user config with the defaults) is left out, per the same comment ("we won't change the behavior").
