### PR TITLE
test: stop mercure tests hitting a public hub

### DIFF
--- a/tests/Fixtures/TestBundle/Mercure/TestHub.php
+++ b/tests/Fixtures/TestBundle/Mercure/TestHub.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
 use Symfony\Component\Mercure\ProtocolVersion;
 use Symfony\Component\Mercure\Update;
+use Symfony\Component\Uid\Uuid;
 
 final class TestHub implements HubInterface
 {
@@ -26,7 +27,11 @@ final class TestHub implements HubInterface
      */
     private array $updates = [];
 
-    public function __construct(private readonly HubInterface $hub)
+    /**
+     * Only the dedicated Mercure test env runs a hub; publishing anywhere else would call an
+     * unrelated third party over the network and make the whole suite flaky.
+     */
+    public function __construct(private readonly HubInterface $hub, private readonly bool $publishToHub = false)
     {
     }
 
@@ -70,6 +75,10 @@ final class TestHub implements HubInterface
     public function publish(Update $update): string
     {
         $this->updates[] = $update;
+
+        if (!$this->publishToHub) {
+            return 'urn:uuid:'.Uuid::v4()->toRfc4122();
+        }
 
         return $this->hub->publish($update);
     }

--- a/tests/Fixtures/app/config/config_common.yml
+++ b/tests/Fixtures/app/config/config_common.yml
@@ -1,8 +1,10 @@
 parameters:
     container.autowiring.strict_mode: true
     .container.dumper.inline_class_loader: true
-    env(MERCURE_URL): https://demo.mercure.rocks
+    env(MERCURE_URL): http://localhost:1337/.well-known/mercure
     env(MERCURE_JWT_SECRET): eyJhbGciOiJIUzI1NiJ9.eyJtZXJjdXJlIjp7InB1Ymxpc2giOlsiKiJdLCJzdWJzY3JpYmUiOlsiaHR0cHM6Ly9leGFtcGxlLmNvbS9teS1wcml2YXRlLXRvcGljIiwie3NjaGVtZX06Ly97K2hvc3R9L2RlbW8vYm9va3Mve2lkfS5qc29ubGQiLCIvLndlbGwta25vd24vbWVyY3VyZS9zdWJzY3JpcHRpb25zey90b3BpY317L3N1YnNjcmliZXJ9Il0sInBheWxvYWQiOnsidXNlciI6Imh0dHBzOi8vZXhhbXBsZS5jb20vdXNlcnMvZHVuZ2xhcyIsInJlbW90ZUFkZHIiOiIxMjcuMC4wLjEifX19.KKPIikwUzRuB3DTpVw6ajzwSChwFw5omBMmMcWKiDcM
+    # Only config_mercure.yml (APP_ENV=mercure) runs a hub and flips this on.
+    app.mercure.publish_to_hub: false
 
 doctrine:
     dbal:
@@ -25,9 +27,6 @@ web_profiler:
 mercure:
     hubs:
         default:
-            url: '%env(MERCURE_URL)%'
-            jwt: '%env(MERCURE_JWT_SECRET)%'
-        debug:
             url: '%env(MERCURE_URL)%'
             jwt: '%env(MERCURE_JWT_SECRET)%'
 
@@ -295,10 +294,19 @@ services:
         tags:
             - name: 'api_platform.validation_groups_generator'
 
+    # Plain service, not a second `mercure.hubs` entry: the bundle registers one messenger
+    # handler per hub, so a second hub published every async update a second time, unguarded.
+    app.mercure.inner_hub:
+        class: Symfony\Component\Mercure\Hub
+        arguments:
+            $url: '%env(MERCURE_URL)%'
+            $jwtProvider: '@mercure.hub.default.jwt.provider'
+
     mercure.hub.default.test_hub:
         class: ApiPlatform\Tests\Fixtures\TestBundle\Mercure\TestHub
         arguments:
-           $hub: '@mercure.hub.debug'
+           $hub: '@app.mercure.inner_hub'
+           $publishToHub: '%app.mercure.publish_to_hub%'
         public: true
     mercure.hub.default: '@mercure.hub.default.test_hub'
 

--- a/tests/Fixtures/app/config/config_mercure.yml
+++ b/tests/Fixtures/app/config/config_mercure.yml
@@ -1,2 +1,5 @@
 imports:
     - { resource: config_test.yml }
+
+parameters:
+    app.mercure.publish_to_hub: true

--- a/tests/Functional/GraphQl/SubscriptionTest.php
+++ b/tests/Functional/GraphQl/SubscriptionTest.php
@@ -103,7 +103,7 @@ final class SubscriptionTest extends ApiTestCase
         $this->assertSame('Dummy Mercure #1', $data['dummyMercure']['name']);
         $this->assertSame('myId', $data['clientSubscriptionId']);
         $this->assertMatchesRegularExpression(
-            '@^https://demo\.mercure\.rocks\?topic=http://[^/]+/subscriptions/[a-f0-9]+$@',
+            '@^http://localhost:1337/\.well-known/mercure\?topic=http://[^/]+/subscriptions/[a-f0-9]+$@',
             $data['mercureUrl'],
         );
 
@@ -120,7 +120,7 @@ final class SubscriptionTest extends ApiTestCase
         $data = $response->toArray()['data']['updateDummyMercureSubscribe'];
         $this->assertSame('/dummy_mercures/2', $data['dummyMercure']['id']);
         $this->assertMatchesRegularExpression(
-            '@^https://demo\.mercure\.rocks\?topic=http://[^/]+/subscriptions/[a-f0-9]+$@',
+            '@^http://localhost:1337/\.well-known/mercure\?topic=http://[^/]+/subscriptions/[a-f0-9]+$@',
             $data['mercureUrl'],
         );
     }

--- a/tests/Functional/Mercure/MercureTest.php
+++ b/tests/Functional/Mercure/MercureTest.php
@@ -49,7 +49,7 @@ final class MercureTest extends ApiTestCase
         ]);
 
         $this->assertContains(
-            '<https://demo.mercure.rocks>; rel="mercure"',
+            '<http://localhost:1337/.well-known/mercure>; rel="mercure"',
             $response->getHeaders()['link'],
         );
     }
@@ -59,7 +59,7 @@ final class MercureTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/');
 
         $this->assertNotContains(
-            '<https://demo.mercure.rocks/hub>; rel="mercure"',
+            '<http://localhost:1337/.well-known/mercure>; rel="mercure"',
             $response->getHeaders()['link'] ?? [],
         );
     }

--- a/tests/Functional/Mercure/TestHubTest.php
+++ b/tests/Functional/Mercure/TestHubTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Mercure;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\Mercure\TestHub;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Update;
+
+final class TestHubTest extends TestCase
+{
+    public function testItRecordsWithoutReachingTheHub(): void
+    {
+        $inner = $this->createMock(HubInterface::class);
+        $inner->expects($this->never())->method('publish');
+
+        $hub = new TestHub($inner);
+        $update = new Update('/dummies/1', '{}');
+
+        $id = $hub->publish($update);
+
+        $this->assertNotSame('', $id);
+        $this->assertSame([$update], $hub->getUpdates());
+    }
+
+    public function testItForwardsWhenPublishingIsEnabled(): void
+    {
+        $update = new Update('/dummies/1', '{}');
+
+        $inner = $this->createMock(HubInterface::class);
+        $inner->expects($this->once())->method('publish')->with($update)->willReturn('urn:uuid:from-hub');
+
+        $hub = new TestHub($inner, true);
+
+        $this->assertSame('urn:uuid:from-hub', $hub->publish($update));
+        $this->assertSame([$update], $hub->getUpdates());
+    }
+}


### PR DESCRIPTION
## What

Mercure tests in the general PHPUnit matrix published to the **public** `https://demo.mercure.rocks`. When that third party hiccups, jobs go red — it caused 2 of the reds on `4.3` today (`PHPUnit (PHP 8.3)`, `PHPUnit (PHP 8.5) (Symfony 8.1)`), and a plain re-run went green with no code change.

## Root cause

The fixture app declared **two** mercure hubs on the same URL:

```yaml
mercure:
    hubs:
        default: { url: '%env(MERCURE_URL)%', ... }
        debug:   { url: '%env(MERCURE_URL)%', ... }
```

MercureBundle registers one messenger handler per hub, and both are tagged `messenger.message_handler` for the same `Update` message:

- `mercure.hub.default.message_handler` → `mercure.hub.default.traceable` → `TestHub` ✅
- `mercure.hub.debug.message_handler` → real `Hub` ❌

So **every async mercure update was published twice** — once through `TestHub` (recorded, and what the assertions read) and once straight over the network through an unguarded hub. `TestHub` was also a decorator rather than a fake: `publish()` recorded *and* forwarded, even though nothing anywhere consumes its return value.

The `debug` hub existed only to be `TestHub`'s inner; nothing targets it by name.

## Change

- Collapse the second hub into a plain `app.mercure.inner_hub` service, so a single messenger handler remains and the duplicate publish is gone.
- `TestHub` gains `$publishToHub` (default `false`): it always records, and forwards only when asked.
- `config_mercure.yml` (`APP_ENV=mercure`) sets `app.mercure.publish_to_hub: true`, so the dedicated `PHPUnit (Mercure)` job keeps real end-to-end coverage against its local hub container.
- `MERCURE_URL` now defaults to `http://localhost:1337/.well-known/mercure` — the hub that job already runs — instead of a public URL.
- New `TestHubTest` locks the invariant in, so re-introducing forwarding fails loudly instead of going quietly flaky.

No changes to `.github/workflows/ci.yml` were needed.

Two assertions hardcoded `demo.mercure.rocks` and were updated. Note `testNoDiscoveryLinkOnNonMercureEndpoint` previously asserted the absence of a `.../hub` URL that was never emitted, so it was vacuous; it now asserts the absence of the real discovery link.

## Verification

- `tests/Functional/Mercure/` + `SubscriptionTest`: **9 tests, 84 assertions, green fully offline** (before this change they died at 22 assertions).
- `app.mercure.publish_to_hub` resolves `true` under `APP_ENV=mercure`, `false` under `test`.
- php-cs-fixer: 0 fixes. PHPStan: clean on the changed files (local run shows only the usual `Doctrine\ODM\MongoDB` `class.notFound` noise on untouched lines).

I stopped a local full-suite run partway for thermal reasons — CI is the authority on the full matrix here.