### PR TITLE
fix(metadata): stop alerting on inline unwired filters at warmup

### DIFF
--- a/src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php
+++ b/src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Orm\Tests\Metadata\Resource;
+
+use ApiPlatform\Doctrine\Orm\Filter\DateFilter;
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\FilterInterface;
+use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
+use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
+use ApiPlatform\Metadata\Property\PropertyNameCollection;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\Resource\Factory\AttributesResourceMetadataCollectionFactory;
+use ApiPlatform\Metadata\Resource\Factory\ParameterResourceMetadataCollectionFactory;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class UnwiredLegacyFilterParameterTest extends TestCase
+{
+    public function testUnwiredRegistryAwareFilterIsLoggedAtDebug(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('alert');
+        $logger->expects($this->once())->method('debug');
+
+        $this->createFactory($logger)->create(ResourceWithInlineDateFilter::class);
+    }
+
+    public function testFilterFailureUnrelatedToTheManagerRegistryStillAlerts(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('alert');
+        $logger->expects($this->never())->method('debug');
+
+        $this->createFactory($logger)->create(ResourceWithThrowingFilter::class);
+    }
+
+    private function createFactory(LoggerInterface $logger): ParameterResourceMetadataCollectionFactory
+    {
+        $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $propertyNameCollectionFactory->method('create')->willReturn(new PropertyNameCollection(['id', 'updatedAt']));
+
+        $propertyMetadataFactory = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadataFactory->method('create')->willReturn(new ApiProperty(readable: true));
+
+        return new ParameterResourceMetadataCollectionFactory(
+            $propertyNameCollectionFactory,
+            $propertyMetadataFactory,
+            new AttributesResourceMetadataCollectionFactory(),
+            null,
+            null,
+            $logger,
+        );
+    }
+}
+
+final class ThrowingFilter implements FilterInterface
+{
+    public function getDescription(string $resourceClass): array
+    {
+        throw new RuntimeException('Something unexpected happened.');
+    }
+}
+
+#[ApiResource(operations: [
+    new GetCollection(parameters: ['updatedAt' => new QueryParameter(filter: new DateFilter())]),
+])]
+final class ResourceWithInlineDateFilter
+{
+    public $id;
+    public $updatedAt;
+}
+
+#[ApiResource(operations: [
+    new GetCollection(parameters: ['updatedAt' => new QueryParameter(filter: new ThrowingFilter())]),
+])]
+final class ResourceWithThrowingFilter
+{
+    public $id;
+    public $updatedAt;
+}

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Resource\Factory;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
 use ApiPlatform\Doctrine\Common\Filter\PropertyAwareFilterInterface;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Exception\RuntimeException;
@@ -422,7 +423,16 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             try {
                 return $this->getLegacyFilterMetadata($parameter, $operation, $filter);
             } catch (RuntimeException $exception) {
-                $this->logger?->alert($exception->getMessage(), ['exception' => $exception]);
+                // An inline filter instance (e.g. `new NumericFilter()`) passed to a QueryParameter is
+                // never wired with a ManagerRegistry, unlike a filter resolved through the filter locator
+                // as a service. Its getDescription() then fails on the Doctrine metadata lookup. This is
+                // expected and recoverable during cache warmup, so log it at debug level instead of the
+                // alarming ALERT reserved for genuinely unexpected registry failures.
+                if ($filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
+                    $this->logger?->debug($exception->getMessage(), ['exception' => $exception]);
+                } else {
+                    $this->logger?->alert($exception->getMessage(), ['exception' => $exception]);
+                }
 
                 return $parameter;
             }

--- a/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
+++ b/src/Metadata/Resource/Factory/ParameterResourceMetadataCollectionFactory.php
@@ -423,11 +423,8 @@ final class ParameterResourceMetadataCollectionFactory implements ResourceMetada
             try {
                 return $this->getLegacyFilterMetadata($parameter, $operation, $filter);
             } catch (RuntimeException $exception) {
-                // An inline filter instance (e.g. `new NumericFilter()`) passed to a QueryParameter is
-                // never wired with a ManagerRegistry, unlike a filter resolved through the filter locator
-                // as a service. Its getDescription() then fails on the Doctrine metadata lookup. This is
-                // expected and recoverable during cache warmup, so log it at debug level instead of the
-                // alarming ALERT reserved for genuinely unexpected registry failures.
+                // An inline filter instance never gets a ManagerRegistry, unlike one resolved as a service
+                // through the filter locator: failing to describe it is expected, not an alert-worthy event.
                 if ($filter instanceof ManagerRegistryAwareInterface && !$filter->hasManagerRegistry()) {
                     $this->logger?->debug($exception->getMessage(), ['exception' => $exception]);
                 } else {

--- a/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Tests\Resource\Factory;
 
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
+use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Parameters;
@@ -29,6 +32,7 @@ use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\WithParameter;
 use ApiPlatform\OpenApi\Model\Parameter;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\TypeInfo\Type;
 
@@ -460,6 +464,120 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertNotNull($param);
         $this->assertArrayNotHasKey('nested_properties_info', $param->getExtraProperties());
     }
+
+    /**
+     * An inline filter instance (e.g. `new NumericFilter()`) passed to a QueryParameter is never wired
+     * with a ManagerRegistry. Its getDescription() then throws during cache warmup: this is expected and
+     * recoverable, so it must be logged at debug level rather than the alarming ALERT (see issue #7361).
+     */
+    public function testInlineRegistryAwareFilterFailureIsLoggedAtDebug(): void
+    {
+        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'name']));
+
+        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadata->method('create')->willReturn(new ApiProperty(readable: true));
+
+        $filterLocator = $this->createStub(ContainerInterface::class);
+        $filterLocator->method('has')->willReturn(false);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('alert');
+        $logger->expects($this->once())->method('debug');
+
+        $parameterFactory = new ParameterResourceMetadataCollectionFactory(
+            $nameCollection,
+            $propertyMetadata,
+            new AttributesResourceMetadataCollectionFactory(),
+            $filterLocator,
+            null,
+            $logger,
+        );
+
+        $parameterFactory->create(HasInlineRegistryAwareFilterParameter::class);
+    }
+
+    /**
+     * A filter that is not ManagerRegistry-aware (or is already wired) but still throws during
+     * getDescription() reflects an unexpected condition and must keep the ALERT level.
+     */
+    public function testNonRegistryAwareFilterFailureIsLoggedAtAlert(): void
+    {
+        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'name']));
+
+        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
+        $propertyMetadata->method('create')->willReturn(new ApiProperty(readable: true));
+
+        $filterLocator = $this->createStub(ContainerInterface::class);
+        $filterLocator->method('has')->willReturn(false);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('alert');
+        $logger->expects($this->never())->method('debug');
+
+        $parameterFactory = new ParameterResourceMetadataCollectionFactory(
+            $nameCollection,
+            $propertyMetadata,
+            new AttributesResourceMetadataCollectionFactory(),
+            $filterLocator,
+            null,
+            $logger,
+        );
+
+        $parameterFactory->create(HasThrowingFilterParameter::class);
+    }
+}
+
+class InlineRegistryAwareThrowingFilter implements FilterInterface, ManagerRegistryAwareInterface
+{
+    use ManagerRegistryAwareTrait;
+
+    public function getDescription(string $resourceClass): array
+    {
+        // Mimics an unwired Doctrine AbstractFilter reaching the metadata during cache warmup.
+        $this->getManagerRegistry();
+
+        return [];
+    }
+}
+
+class ThrowingFilter implements FilterInterface
+{
+    public function getDescription(string $resourceClass): array
+    {
+        throw new RuntimeException('boom');
+    }
+}
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'name' => new QueryParameter(filter: new InlineRegistryAwareThrowingFilter()),
+            ]
+        ),
+    ]
+)]
+class HasInlineRegistryAwareFilterParameter
+{
+    public $id;
+    public $name;
+}
+
+#[ApiResource(
+    operations: [
+        new GetCollection(
+            parameters: [
+                'name' => new QueryParameter(filter: new ThrowingFilter()),
+            ]
+        ),
+    ]
+)]
+class HasThrowingFilterParameter
+{
+    public $id;
+    public $name;
 }
 
 class RepeatedPlaceholderExactFilter implements FilterInterface

--- a/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
+++ b/src/Metadata/Tests/Resource/Factory/ParameterResourceMetadataCollectionFactoryTest.php
@@ -13,11 +13,8 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Tests\Resource\Factory;
 
-use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareInterface;
-use ApiPlatform\Doctrine\Common\Filter\ManagerRegistryAwareTrait;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\FilterInterface;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\Parameters;
@@ -32,7 +29,6 @@ use ApiPlatform\Metadata\Tests\Fixtures\ApiResource\WithParameter;
 use ApiPlatform\OpenApi\Model\Parameter;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\TypeInfo\Type;
 
@@ -464,120 +460,6 @@ class ParameterResourceMetadataCollectionFactoryTest extends TestCase
         $this->assertNotNull($param);
         $this->assertArrayNotHasKey('nested_properties_info', $param->getExtraProperties());
     }
-
-    /**
-     * An inline filter instance (e.g. `new NumericFilter()`) passed to a QueryParameter is never wired
-     * with a ManagerRegistry. Its getDescription() then throws during cache warmup: this is expected and
-     * recoverable, so it must be logged at debug level rather than the alarming ALERT (see issue #7361).
-     */
-    public function testInlineRegistryAwareFilterFailureIsLoggedAtDebug(): void
-    {
-        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
-        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'name']));
-
-        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
-        $propertyMetadata->method('create')->willReturn(new ApiProperty(readable: true));
-
-        $filterLocator = $this->createStub(ContainerInterface::class);
-        $filterLocator->method('has')->willReturn(false);
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->never())->method('alert');
-        $logger->expects($this->once())->method('debug');
-
-        $parameterFactory = new ParameterResourceMetadataCollectionFactory(
-            $nameCollection,
-            $propertyMetadata,
-            new AttributesResourceMetadataCollectionFactory(),
-            $filterLocator,
-            null,
-            $logger,
-        );
-
-        $parameterFactory->create(HasInlineRegistryAwareFilterParameter::class);
-    }
-
-    /**
-     * A filter that is not ManagerRegistry-aware (or is already wired) but still throws during
-     * getDescription() reflects an unexpected condition and must keep the ALERT level.
-     */
-    public function testNonRegistryAwareFilterFailureIsLoggedAtAlert(): void
-    {
-        $nameCollection = $this->createStub(PropertyNameCollectionFactoryInterface::class);
-        $nameCollection->method('create')->willReturn(new PropertyNameCollection(['id', 'name']));
-
-        $propertyMetadata = $this->createStub(PropertyMetadataFactoryInterface::class);
-        $propertyMetadata->method('create')->willReturn(new ApiProperty(readable: true));
-
-        $filterLocator = $this->createStub(ContainerInterface::class);
-        $filterLocator->method('has')->willReturn(false);
-
-        $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($this->once())->method('alert');
-        $logger->expects($this->never())->method('debug');
-
-        $parameterFactory = new ParameterResourceMetadataCollectionFactory(
-            $nameCollection,
-            $propertyMetadata,
-            new AttributesResourceMetadataCollectionFactory(),
-            $filterLocator,
-            null,
-            $logger,
-        );
-
-        $parameterFactory->create(HasThrowingFilterParameter::class);
-    }
-}
-
-class InlineRegistryAwareThrowingFilter implements FilterInterface, ManagerRegistryAwareInterface
-{
-    use ManagerRegistryAwareTrait;
-
-    public function getDescription(string $resourceClass): array
-    {
-        // Mimics an unwired Doctrine AbstractFilter reaching the metadata during cache warmup.
-        $this->getManagerRegistry();
-
-        return [];
-    }
-}
-
-class ThrowingFilter implements FilterInterface
-{
-    public function getDescription(string $resourceClass): array
-    {
-        throw new RuntimeException('boom');
-    }
-}
-
-#[ApiResource(
-    operations: [
-        new GetCollection(
-            parameters: [
-                'name' => new QueryParameter(filter: new InlineRegistryAwareThrowingFilter()),
-            ]
-        ),
-    ]
-)]
-class HasInlineRegistryAwareFilterParameter
-{
-    public $id;
-    public $name;
-}
-
-#[ApiResource(
-    operations: [
-        new GetCollection(
-            parameters: [
-                'name' => new QueryParameter(filter: new ThrowingFilter()),
-            ]
-        ),
-    ]
-)]
-class HasThrowingFilterParameter
-{
-    public $id;
-    public $name;
 }
 
 class RepeatedPlaceholderExactFilter implements FilterInterface


### PR DESCRIPTION
| Q             | A   |
|---------------|-----|
| Branch?       | 4.4 |
| Bug fix?      | yes |
| New feature?  | no  |
| Deprecations? | no  |
| Issues        | Fixes #7361 |
| License       | MIT |
| Doc PR        | n/a |

Supersedes #8408 by @alexisLefebvre, whose commit is cherry-picked here (the diagnosis and the fix are his).

## What

An inline filter instance passed to a `QueryParameter` is never wired with a `ManagerRegistry`, unlike a filter resolved as a service through the filter locator. Reading its legacy description during metadata build therefore throws, gets caught, and is logged at `alert` — one identical `ALERT ManagerRegistry must be initialized before accessing it.` line per parameter on every `cache:clear`. Filtering itself is unaffected: `ParameterExtension` wires the registry at query time.

That failure is expected on this path, so it is now logged at `debug`. A `RuntimeException` from any other cause — a filter that is not `ManagerRegistryAware`, or one that is already wired — still logs at `alert`.

## Why this shape

The condition is knowable before calling `getLegacyFilterMetadata()`, so an early `return` looked tempting. It is not safe: a userland filter extending `AbstractFilter` (hence `ManagerRegistryAwareInterface`) may override `getDescription()` with something that needs no registry, and skipping would silently drop its description. Downgrading inside the `catch` only changes the level of a message on a path that already failed, so nothing that works today changes.

Note this does not go away on its own for the surviving filters: on `main`, `DateFilter` is standalone but still `use ManagerRegistryAwareTrait`, and `DateFilterTrait::getDescription()` still calls `getClassMetadata()`. Users migrated to the canonical filters (`ExactFilter`, `SortFilter`, `ComparisonFilter`, …) are already unaffected — `BackwardCompatibleFilterDescriptionTrait` returns an empty description and never touches Doctrine.

## Tests

`src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php` drives a real `new QueryParameter(filter: new DateFilter())` — the exact declaration from the issue — and asserts `debug` rather than `alert`, plus a second case pinning that an unrelated failure still alerts. It lives in doctrine-orm rather than metadata because `api-platform/metadata` does not depend on `api-platform/doctrine-common`, so a fixture using `ManagerRegistryAwareTrait` would make the split package's suite fatal.