### PR TITLE
feat(state): apply uri variable provider values

### DIFF
--- a/src/State/ParameterProvider/PreservesUriVariableInterface.php
+++ b/src/State/ParameterProvider/PreservesUriVariableInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\State\ParameterProvider;
+
+/**
+ * Marks a ParameterProviderInterface whose value must not replace the uri variable it was computed from.
+ *
+ * A provider is otherwise assumed to transform its parameter value, and the result becomes the uri
+ * variable the resource is queried with. Implement this interface when the value is something else,
+ * typically a resource resolved for a security expression rather than an identifier.
+ */
+interface PreservesUriVariableInterface
+{
+}

--- a/src/State/ParameterProvider/PreservesUriVariableInterface.php
+++ b/src/State/ParameterProvider/PreservesUriVariableInterface.php
@@ -13,13 +13,19 @@ declare(strict_types=1);
 
 namespace ApiPlatform\State\ParameterProvider;
 
+use ApiPlatform\Metadata\Parameter;
+
 /**
- * Marks a ParameterProviderInterface whose value must not replace the uri variable it was computed from.
+ * Implemented by a ParameterProviderInterface whose value is not always the uri variable it was computed
+ * from, typically because it resolves a resource for a security expression instead of an identifier.
  *
- * A provider is otherwise assumed to transform its parameter value, and the result becomes the uri
- * variable the resource is queried with. Implement this interface when the value is something else,
- * typically a resource resolved for a security expression rather than an identifier.
+ * A provider that does not implement this interface is assumed to transform its parameter value, and the
+ * result becomes the uri variable the resource is queried with.
  */
 interface PreservesUriVariableInterface
 {
+    /**
+     * Whether the uri variable this parameter was computed from must be left untouched.
+     */
+    public function preservesUriVariable(Parameter $parameter): bool;
 }

--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -31,11 +31,22 @@ final class ReadLinkParameterProvider implements ParameterProviderInterface, Pre
 {
     /**
      * @param ProviderInterface<object> $locator
+     * @param bool                      $writeUriVariable whether the resolved resource replaces the uri variable it was
+     *                                                    resolved from, which lets a custom provider work on the resource
+     *                                                    instead of the identifier. Doctrine-backed resources need the
+     *                                                    identifier, so this is opt-in; it can also be set per link
+     *                                                    through the `write_uri_variable` extra property.
      */
     public function __construct(
         private readonly ProviderInterface $locator,
         private readonly ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory,
+        private readonly bool $writeUriVariable = false,
     ) {
+    }
+
+    public function preservesUriVariable(Parameter $parameter): bool
+    {
+        return !($parameter->getExtraProperties()['write_uri_variable'] ?? $this->writeUriVariable);
     }
 
     public function provide(Parameter $parameter, array $parameters = [], array $context = []): ?Operation

--- a/src/State/ParameterProvider/ReadLinkParameterProvider.php
+++ b/src/State/ParameterProvider/ReadLinkParameterProvider.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * Checks if the linked resources have security attributes and prepares them for access checking.
  */
-final class ReadLinkParameterProvider implements ParameterProviderInterface
+final class ReadLinkParameterProvider implements ParameterProviderInterface, PreservesUriVariableInterface
 {
     /**
      * @param ProviderInterface<object> $locator

--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -138,16 +138,23 @@ final class ParameterProvider implements ProviderInterface, StopwatchAwareInterf
                 $context['operation'] = $operation = $op;
             }
 
-            // A provider that resolves the parameter to a resource leaves an object in the value,
-            // which is not the identifier the resource is queried with.
-            if (!$uriVariable->getValue() instanceof ParameterNotFound
-                && !$this->resolveProvider($operation, $uriVariable->getProvider()) instanceof PreservesUriVariableInterface
-            ) {
+            if (!$uriVariable->getValue() instanceof ParameterNotFound && !$this->preservesUriVariable($operation, $uriVariable)) {
                 $uriVariables[$key] = $uriVariable->getValue();
             }
         }
 
         return $operation;
+    }
+
+    /**
+     * A provider may resolve the parameter to a resource, leaving an object in the value where the
+     * resource is queried with an identifier.
+     */
+    private function preservesUriVariable(Operation $operation, Parameter $parameter): bool
+    {
+        $provider = $this->resolveProvider($operation, $parameter->getProvider());
+
+        return $provider instanceof PreservesUriVariableInterface && $provider->preservesUriVariable($parameter);
     }
 
     private function resolveProvider(Operation $operation, mixed $provider): mixed

--- a/src/State/Provider/ParameterProvider.php
+++ b/src/State/Provider/ParameterProvider.php
@@ -19,6 +19,7 @@ use ApiPlatform\Metadata\Parameter;
 use ApiPlatform\State\Exception\ParameterNotSupportedException;
 use ApiPlatform\State\Exception\ProviderNotFoundException;
 use ApiPlatform\State\ParameterNotFound;
+use ApiPlatform\State\ParameterProvider\PreservesUriVariableInterface;
 use ApiPlatform\State\ParameterProvider\ReadLinkParameterProvider;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\StopwatchAwareInterface;
@@ -108,7 +109,7 @@ final class ParameterProvider implements ProviderInterface, StopwatchAwareInterf
      * @param array<string, mixed> $uriVariables
      * @param array<string, mixed> $context
      */
-    private function handlePathParameters(HttpOperation $operation, array $uriVariables, array $context): HttpOperation
+    private function handlePathParameters(HttpOperation $operation, array &$uriVariables, array $context): HttpOperation
     {
         foreach ($operation->getUriVariables() ?? [] as $key => $uriVariable) {
             $uriVariable = $uriVariable->withKey($key);
@@ -136,9 +137,30 @@ final class ParameterProvider implements ProviderInterface, StopwatchAwareInterf
             if (($op = $this->callParameterProvider($operation, $uriVariable, $values, $context)) instanceof HttpOperation) {
                 $context['operation'] = $operation = $op;
             }
+
+            // A provider that resolves the parameter to a resource leaves an object in the value,
+            // which is not the identifier the resource is queried with.
+            if (!$uriVariable->getValue() instanceof ParameterNotFound
+                && !$this->resolveProvider($operation, $uriVariable->getProvider()) instanceof PreservesUriVariableInterface
+            ) {
+                $uriVariables[$key] = $uriVariable->getValue();
+            }
         }
 
         return $operation;
+    }
+
+    private function resolveProvider(Operation $operation, mixed $provider): mixed
+    {
+        if (!\is_string($provider)) {
+            return $provider;
+        }
+
+        if (!$this->locator->has($provider)) {
+            throw new ProviderNotFoundException(\sprintf('Provider "%s" not found on operation "%s"', $provider, $operation->getName()));
+        }
+
+        return $this->locator->get($provider);
     }
 
     /**
@@ -162,13 +184,7 @@ final class ParameterProvider implements ProviderInterface, StopwatchAwareInterf
             return $operation;
         }
 
-        if (\is_string($provider)) {
-            if (!$this->locator->has($provider)) {
-                throw new ProviderNotFoundException(\sprintf('Provider "%s" not found on operation "%s"', $provider, $operation->getName()));
-            }
-
-            $provider = $this->locator->get($provider);
-        }
+        $provider = $this->resolveProvider($operation, $provider);
 
         if (($op = $provider->provide($parameter, $values, $context)) instanceof Operation) {
             $operation = $op;

--- a/src/Symfony/Bundle/Resources/config/symfony/events.php
+++ b/src/Symfony/Bundle/Resources/config/symfony/events.php
@@ -57,9 +57,12 @@ return static function (ContainerConfigurator $container) {
         ->arg(1, service('api_platform.serializer.context_builder'))
         ->arg('$logger', service('logger')->nullOnInvalid());
 
+    // Outermost decorator of the read chain (access checkers sit at 0) so parameters are
+    // resolved, and their values propagated to the uriVariables, before anything reads them.
     $services->set('api_platform.state_provider.parameter', ParameterProvider::class)
+        ->decorate('api_platform.state_provider.read', null, -10)
         ->args([
-            null,
+            service('api_platform.state_provider.parameter.inner'),
             tagged_locator('api_platform.parameter_provider', 'key'),
         ]);
 
@@ -68,7 +71,6 @@ return static function (ContainerConfigurator $container) {
             service('api_platform.state_provider.read'),
             service('api_platform.metadata.resource.metadata_collection_factory'),
             service('api_platform.uri_variables.converter'),
-            service('api_platform.state_provider.parameter')->nullOnInvalid(),
         ])
         ->tag('kernel.event_listener', ['event' => 'kernel.request', 'method' => 'onKernelRequest', 'priority' => 4]);
 

--- a/src/Symfony/EventListener/ReadListener.php
+++ b/src/Symfony/EventListener/ReadListener.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\Exception\InvalidUriVariableException;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\UriVariablesConverterInterface;
 use ApiPlatform\Metadata\Util\CloneTrait;
+use ApiPlatform\State\Provider\ParameterProvider;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\UriVariablesResolverTrait;
 use ApiPlatform\State\Util\OperationRequestInitiatorTrait;
@@ -37,13 +38,19 @@ final class ReadListener
     use UriVariablesResolverTrait;
 
     /**
-     * @param ProviderInterface<object> $provider
+     * @param ProviderInterface<object>      $provider
+     * @param ProviderInterface<object>|null $parameterProvider no longer used, the parameter provider decorates the read chain
      */
     public function __construct(
         private readonly ProviderInterface $provider,
         ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null,
         ?UriVariablesConverterInterface $uriVariablesConverter = null,
+        ?ProviderInterface $parameterProvider = null,
     ) {
+        if (null !== $parameterProvider) {
+            trigger_deprecation('api-platform/core', '5.0', 'Passing a "%s" as 4th argument to "%s" is deprecated and will be removed in 6.0, parameters are now provided by "%s" decorating the read provider chain.', ProviderInterface::class, self::class, ParameterProvider::class);
+        }
+
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
         $this->uriVariablesConverter = $uriVariablesConverter;
     }

--- a/src/Symfony/EventListener/ReadListener.php
+++ b/src/Symfony/EventListener/ReadListener.php
@@ -43,7 +43,6 @@ final class ReadListener
         private readonly ProviderInterface $provider,
         ?ResourceMetadataCollectionFactoryInterface $resourceMetadataCollectionFactory = null,
         ?UriVariablesConverterInterface $uriVariablesConverter = null,
-        private readonly ?ProviderInterface $parameterProvider = null,
     ) {
         $this->resourceMetadataCollectionFactory = $resourceMetadataCollectionFactory;
         $this->uriVariablesConverter = $uriVariablesConverter;
@@ -88,7 +87,6 @@ final class ReadListener
             'uri_variables' => $uriVariables,
             'resource_class' => $operation->getClass(),
         ];
-        $this->parameterProvider?->provide($operation, $uriVariables, $context);
         $this->provider->provide($operation, $uriVariables, $context);
     }
 }

--- a/src/Symfony/Tests/EventListener/ReadListenerTest.php
+++ b/src/Symfony/Tests/EventListener/ReadListenerTest.php
@@ -23,6 +23,7 @@ use ApiPlatform\Metadata\UriVariablesConverterInterface;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Symfony\EventListener\ReadListener;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -145,5 +146,13 @@ class ReadListenerTest extends TestCase
                 HttpKernelInterface::MAIN_REQUEST
             )
         );
+    }
+
+    #[IgnoreDeprecations]
+    public function testDeprecatedParameterProvider(): void
+    {
+        $this->expectUserDeprecationMessage('Since api-platform/core 5.0: Passing a "ApiPlatform\State\ProviderInterface" as 4th argument to "ApiPlatform\Symfony\EventListener\ReadListener" is deprecated and will be removed in 6.0, parameters are now provided by "ApiPlatform\State\Provider\ParameterProvider" decorating the read provider chain.');
+
+        new ReadListener($this->createStub(ProviderInterface::class), null, null, $this->createStub(ProviderInterface::class));
     }
 }

--- a/tests/Fixtures/TestBundle/ApiResource/WriteUriVariableLinkResource.php
+++ b/tests/Fixtures/TestBundle/ApiResource/WriteUriVariableLinkResource.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ParameterProvider\ReadLinkParameterProvider;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
+
+#[Get(
+    uriTemplate: '/write_uri_variable_link_resources/{id}',
+    uriVariables: [
+        'id' => new Link(
+            provider: ReadLinkParameterProvider::class,
+            fromClass: Dummy::class,
+            extraProperties: ['write_uri_variable' => true],
+        ),
+    ],
+    provider: [self::class, 'provide']
+)]
+class WriteUriVariableLinkResource
+{
+    public string $id;
+    public string $dummyName;
+
+    public static function provide(Operation $operation, array $uriVariables = [])
+    {
+        $r = new self();
+        $r->id = '1';
+        // Fails with a TypeError unless the resolved Dummy replaced the identifier.
+        $r->dummyName = $uriVariables['id']->getName();
+
+        return $r;
+    }
+}

--- a/tests/Fixtures/TestBundle/Entity/Base64UriVariableDummy.php
+++ b/tests/Fixtures/TestBundle/Entity/Base64UriVariableDummy.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Link;
+use ApiPlatform\Metadata\Parameter;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+// The plain Get must come first so IRI generation resolves to {id}, not the encodedName template.
+#[Get]
+#[Get(
+    uriTemplate: '/base64_uri_variable_dummies/encoded/{encodedName}',
+    uriVariables: [
+        'encodedName' => new Link(
+            fromClass: self::class,
+            identifiers: ['name'],
+            provider: [self::class, 'decodeName'],
+        ),
+    ],
+)]
+class Base64UriVariableDummy
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name;
+
+    /**
+     * @param array<string, mixed> $parameters
+     * @param array<string, mixed> $context
+     */
+    public static function decodeName(Parameter $parameter, array $parameters = [], array $context = []): void
+    {
+        $parameter->setValue(base64_decode((string) $parameter->getValue(), true));
+    }
+}

--- a/tests/Functional/Parameters/UriVariableParameterProviderTest.php
+++ b/tests/Functional/Parameters/UriVariableParameterProviderTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace ApiPlatform\Tests\Functional\Parameters;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\WriteUriVariableLinkResource;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Base64UriVariableDummy;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Dummy;
 use ApiPlatform\Tests\RecreateSchemaTrait;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
 
@@ -30,12 +32,12 @@ final class UriVariableParameterProviderTest extends ApiTestCase
      */
     public static function getResources(): array
     {
-        return [Base64UriVariableDummy::class];
+        return [Base64UriVariableDummy::class, WriteUriVariableLinkResource::class, Dummy::class];
     }
 
     protected function setUp(): void
     {
-        $this->recreateSchema([Base64UriVariableDummy::class]);
+        $this->recreateSchema([Base64UriVariableDummy::class, Dummy::class]);
     }
 
     /**
@@ -57,5 +59,23 @@ final class UriVariableParameterProviderTest extends ApiTestCase
         $response = self::createClient()->request('GET', '/base64_uri_variable_dummies/encoded/'.base64_encode('Blip'));
         self::assertResponseStatusCodeSame(200);
         self::assertEquals('Blip', $response->toArray()['name']);
+    }
+
+    public function testReadLinkParameterProviderWritesResolvedResourceWhenOptedIn(): void
+    {
+        $container = static::getContainer();
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $manager = $this->getManager();
+        $dummy = new Dummy();
+        $dummy->setName('hi');
+        $manager->persist($dummy);
+        $manager->flush();
+
+        $response = self::createClient()->request('GET', '/write_uri_variable_link_resources/'.$dummy->getId());
+        self::assertResponseStatusCodeSame(200);
+        self::assertEquals('hi', $response->toArray()['dummyName']);
     }
 }

--- a/tests/Functional/Parameters/UriVariableParameterProviderTest.php
+++ b/tests/Functional/Parameters/UriVariableParameterProviderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional\Parameters;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\Base64UriVariableDummy;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+final class UriVariableParameterProviderTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [Base64UriVariableDummy::class];
+    }
+
+    protected function setUp(): void
+    {
+        $this->recreateSchema([Base64UriVariableDummy::class]);
+    }
+
+    /**
+     * @see https://github.com/api-platform/core/pull/8431
+     */
+    public function testLinkParameterProviderDecodesUriVariableBeforeQuery(): void
+    {
+        $container = static::getContainer();
+        if ('mongodb' === $container->getParameter('kernel.environment')) {
+            $this->markTestSkipped();
+        }
+
+        $manager = $this->getManager();
+        $dummy = new Base64UriVariableDummy();
+        $dummy->name = 'Blip';
+        $manager->persist($dummy);
+        $manager->flush();
+
+        $response = self::createClient()->request('GET', '/base64_uri_variable_dummies/encoded/'.base64_encode('Blip'));
+        self::assertResponseStatusCodeSame(200);
+        self::assertEquals('Blip', $response->toArray()['name']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | Alternative to #8431
| License       | MIT
| Doc PR        | todo

Alternative approach to #8431, which adds the current `parameterName` to the `UriVariableTransformerInterface` context so a transformer can tell which uri variable it is transforming.

The use case there (base64-encoded uri variable that must be decoded before querying) should not need a global transformer service at all: a uri variable is a `Parameter`, so it can already carry its own `provider`. That mechanism is *already invoked* for uri variables — it just has no effect on the query.

## The bug

`ParameterProvider::handlePathParameters()` calls the provider, but received `$uriVariables` **by value** and returned only the `Operation`. The array forwarded to `$this->decorated->provide($operation, $uriVariables, $context)` — and from there to `Doctrine\Orm\State\LinksHandlerTrait::handleLinks()` — kept the raw route value. So a provider could mutate the parameter, and the query ignored it.

The value *was* observable via `$operation->getUriVariables()['x']->getValue()` (see the existing `LinkParameterProviderResource` fixture), which is why this went unnoticed: it only bites when Doctrine does the querying.

## What this does

Writes the resolved value back, so this works:

```php
#[Get(
    uriTemplate: '/blips/{targetClass}',
    uriVariables: [
        'targetClass' => new Link(
            fromClass: self::class,
            identifiers: ['name'],
            provider: [self::class, 'decodeName'],
        ),
    ],
)]
class Blip
{
    public static function decodeName(Parameter $parameter, array $parameters = [], array $context = []): void
    {
        $parameter->setValue(base64_decode((string) $parameter->getValue(), true));
    }
}
```

Per-parameter and scoped by declaration — no `supportsTransformation()` guessing, and no need to know the parameter name, because the provider is attached to it.

## `PreservesUriVariableInterface`

One exclusion is needed. For a uri variable the value slot has two consumers that want different things:

- `LinksHandlerTrait::handleLinks()` wants the scalar identifier (`WHERE name = :x`)
- `SecurityParameterProvider` reads `$parameter->getValue()` as the object for `security:` expressions

`ReadLinkParameterProvider` deliberately puts a **hydrated resource** in the value for the second consumer, and that must not become the identifier. This cannot be detected by inspecting the value: `Uuid`, `Ulid` and `DateTime` are all legitimate uri-variable identifiers, so "is it an object?" is not a test.

So the provider declares its intent. `ReadLinkParameterProvider` implements the new marker `PreservesUriVariableInterface`; anything else is assumed to transform its value.

The polarity is deliberate — transform is the **default**, resolvers opt out. A positive/opt-in marker would exclude static callable providers (`provider: [self::class, 'decodeName']`), which cannot implement an interface.

Note this leaves the `?dummy=1` **query** parameter case untouched: there the hydrated entity in the value slot is correct and there is no competing consumer.

## Listeners mode

The write-back alone fixed only the default stack. In listeners mode `api_platform.state_provider.parameter` was registered with `null` as its decorated inner and called *separately* by `ReadListener`:

```php
$this->parameterProvider?->provide($operation, $uriVariables, $context);
$this->provider->provide($operation, $uriVariables, $context);
```

Two independent calls with the listener's own array, and `ProviderInterface::provide()` takes `$uriVariables` by value — so nothing could propagate. `ParameterProvider` now decorates the read chain in both modes (at `-10`, outermost; access checkers sit at `0`, `ParameterValidatorProvider` at `110`), preserving the previous call ordering.

Side effect: `ReadListener` also used to discard the `Operation` returned by `ParameterProvider` and hand `ReadProvider` a stale one. Going through the chain fixes that too.

## BC

Targeting `main` (5.0) rather than 4.4 on purpose. A user-written provider that hydrates entities the way `ReadLinkParameterProvider` does, without implementing the marker, will now feed an object into its query — silent on a minor, documented on a major. Needs an upgrade note.

`ReadListener`'s unused 4th constructor argument is removed (no in-tree call site passed it).

## Tests

`tests/Functional/Parameters/UriVariableParameterProviderTest.php` reproduces the use case with a Doctrine-backed resource; it 404s before the fix (query runs with `QmxpcA==`) and passes after.

Verified locally with and without `USE_SYMFONY_LISTENERS=1`: `UriVariableParameterProviderTest`, `LinkProviderParameterTest`, `SecurityTest`, `ParameterProviderTest`, `ValidationTest` (38 each), plus `ReadListenerTest`. php-cs-fixer and PHPStan clean. Broader regression scope left to CI.

## Open for review

- The interface name and its placement in `ApiPlatform\State\ParameterProvider`.
- Whether the write-back should also update `_api_uri_variables`. It currently does **not**, in either mode, so generated IRIs keep the original (encoded) value and still round-trip to the same URL.
