### PR TITLE
fix(laravel): key the iri operation cache on Relation

### DIFF
--- a/src/Laravel/Routing/IriConverter.php
+++ b/src/Laravel/Routing/IriConverter.php
@@ -108,7 +108,8 @@ class IriConverter implements IriConverterInterface
             $operation = $this->operationMetadataFactory->create($context['item_uri_template']);
         }
 
-        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_s' : '_o').($operation instanceof CollectionOperationInterface ? '_c' : '_i');
+        // A Relation skips the resource class promotion below, it can not share a cache entry with its related model.
+        $localOperationCacheKey = ($operation?->getName() ?? '').$resourceClass.(\is_string($resource) ? '_s' : '_o').($operation instanceof CollectionOperationInterface ? '_c' : '_i').($resource instanceof Relation ? '_r' : '');
         if ($operation && isset($this->localOperationCache[$localOperationCacheKey])) {
             return $this->generateRoute($resource, $referenceType, $this->localOperationCache[$localOperationCacheKey], $context, $this->localIdentifiersExtractorOperationCache[$localOperationCacheKey] ?? null);
         }

--- a/src/Laravel/Tests/IriConverterRelationTest.php
+++ b/src/Laravel/Tests/IriConverterRelationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Laravel\Tests;
+
+use ApiPlatform\Metadata\IriConverterInterface;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\TestCase;
+use Workbench\App\Models\Author;
+use Workbench\App\Models\BookVariant;
+
+class IriConverterRelationTest extends TestCase
+{
+    use WithWorkbench;
+
+    public function testRelationKeepsItsSkolemIriAfterTheRelatedModelWasResolved(): void
+    {
+        $iriConverter = $this->app->make(IriConverterInterface::class);
+
+        $model = new BookVariant();
+        $model->id = 1;
+
+        $this->assertSame('/api/books/1', $iriConverter->getIriFromResource($model));
+        $this->assertStringStartsWith('/api/.well-known/genid/', $iriConverter->getIriFromResource($this->relation()));
+    }
+
+    public function testRelationKeepsItsSkolemIriWhenResolvedFirst(): void
+    {
+        $iriConverter = $this->app->make(IriConverterInterface::class);
+
+        $model = new BookVariant();
+        $model->id = 1;
+
+        $this->assertStringStartsWith('/api/.well-known/genid/', $iriConverter->getIriFromResource($this->relation()));
+        $this->assertSame('/api/books/1', $iriConverter->getIriFromResource($model));
+    }
+
+    /**
+     * @return HasMany<BookVariant, Author>
+     */
+    private function relation(): HasMany
+    {
+        $related = new BookVariant();
+        $related->id = 1;
+
+        return new HasMany($related->newQuery(), new Author(), 'author_id', 'id');
+    }
+}

--- a/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
+++ b/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
@@ -18,6 +18,7 @@ use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Get;
 use ApiPlatform\Metadata\GetCollection;
 use ApiPlatform\Metadata\IdentifiersExtractorInterface;
+use ApiPlatform\Metadata\IriConverterInterface;
 use ApiPlatform\Metadata\Operation\Factory\OperationMetadataFactoryInterface;
 use ApiPlatform\Metadata\Operations;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
@@ -25,9 +26,17 @@ use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use ApiPlatform\Metadata\UrlGeneratorInterface;
 use ApiPlatform\State\ProviderInterface;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 use Workbench\App\Models\Book;
+
+/**
+ * A model that is not a resource itself but extends one.
+ */
+class BookVariant extends Book
+{
+}
 
 class IriConverterTest extends TestCase
 {
@@ -154,6 +163,53 @@ class IriConverterTest extends TestCase
         $this->assertSame('/api/books', $iriConverter->getIriFromResource(Book::class, UrlGeneratorInterface::ABS_PATH, new GetCollection()));
         $this->assertSame('/api/books/1', $iriConverter->getIriFromResource(Book::class, UrlGeneratorInterface::ABS_PATH, null, $context));
         $this->assertSame('/api/books', $iriConverter->getIriFromResource(Book::class, UrlGeneratorInterface::ABS_PATH, new GetCollection()));
+    }
+
+    public function testLocalOperationCacheKeyDistinguishesRelationFromModel(): void
+    {
+        $itemOpName = 'item_op';
+        $itemOp = (new Get())->withName($itemOpName)->withClass(Book::class);
+
+        $model = new BookVariant();
+        $relation = $this->createStub(Relation::class);
+        $relation->method('getRelated')->willReturn($model);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->expects($this->once())
+            ->method('generate')
+            ->with($itemOpName, ['id' => 1], UrlGeneratorInterface::ABS_PATH)
+            ->willReturn('/api/books/1');
+
+        $resourceMetadataFactory = $this->createStub(ResourceMetadataCollectionFactoryInterface::class);
+        $resourceMetadataFactory->method('create')->willReturnCallback(static fn (string $resourceClass): ResourceMetadataCollection => Book::class === $resourceClass
+            ? new ResourceMetadataCollection(Book::class, [
+                (new ApiResource())->withOperations(new Operations([$itemOpName => $itemOp])),
+            ])
+            : new ResourceMetadataCollection($resourceClass));
+
+        // BookVariant is not a resource, but it is an instance of one: only the model gets promoted to Book.
+        $resourceClassResolver = $this->createStub(ResourceClassResolverInterface::class);
+        $resourceClassResolver->method('isResourceClass')->willReturn(true);
+        $resourceClassResolver->method('getResourceClass')->willReturn(Book::class);
+
+        $identifiersExtractor = $this->createStub(IdentifiersExtractorInterface::class);
+        $identifiersExtractor->method('getIdentifiersFromItem')->willReturn(['id' => 1]);
+
+        $decorated = $this->createStub(IriConverterInterface::class);
+        $decorated->method('getIriFromResource')->willReturn('/api/.well-known/genid/1');
+
+        $iriConverter = new IriConverter(
+            $this->createStub(ProviderInterface::class),
+            $this->createStub(OperationMetadataFactoryInterface::class),
+            $router,
+            $identifiersExtractor,
+            $resourceClassResolver,
+            $resourceMetadataFactory,
+            $decorated,
+        );
+
+        $this->assertSame('/api/books/1', $iriConverter->getIriFromResource($model));
+        $this->assertSame('/api/.well-known/genid/1', $iriConverter->getIriFromResource($relation));
     }
 
     private function createIriConverter(RouterInterface $router, ResourceMetadataCollectionFactoryInterface $resourceMetadataFactory): IriConverter

--- a/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
+++ b/src/Laravel/Tests/Unit/Routing/IriConverterTest.php
@@ -30,13 +30,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 use Workbench\App\Models\Book;
-
-/**
- * A model that is not a resource itself but extends one.
- */
-class BookVariant extends Book
-{
-}
+use Workbench\App\Models\BookVariant;
 
 class IriConverterTest extends TestCase
 {

--- a/src/Laravel/workbench/app/Models/BookVariant.php
+++ b/src/Laravel/workbench/app/Models/BookVariant.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Workbench\App\Models;
+
+/**
+ * Not a resource itself, but an instance of one: IRI generation promotes it to Book.
+ */
+class BookVariant extends Book
+{
+    protected $table = 'books';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | follow-up to #8472
| License       | MIT

#8472 added a `localOperationCache` read inside the unnamed-operation branch of `getIriFromResource()`. On the Laravel side an Eloquent `Relation` and its related model share a cache key but do **not** resolve the same way, so that read can hand a `Relation` an operation that was resolved for a plain model.

`src/Laravel/Routing/IriConverter.php`:

- `:103` overrides `$resourceClass` with the *related* model's class for a `Relation`.
- `:111` builds the key from `(name).$resourceClass.(_s|_o).(_c|_i)` — identical for both inputs.
- `:122` gates the resource class promotion on the object's **own** class, so a `Relation` (`HasMany`, …) never gets promoted while the plain model does.

For a model that is not itself a resource but extends one, the two inputs therefore share a key and resolve differently, and the result depends on call order within the request:

| order | `getIriFromResource($relation)` returns |
| --- | --- |
| relation first | `/api/.well-known/genid/…` |
| model first | `InvalidArgumentException: Unable to generate an IRI for the item of type "Book"` |

The model-first call caches the promoted parent operation under the shared key; the `Relation` call then reads it and `generateRoute()` throws trying to extract `id` off the `HasMany` object. Checked out `3fe1838a6~1` and confirmed both orders returned a skolem IRI before #8472, so this is a regression.

Only one direction can poison: relation-first hits `OperationNotFoundException` (verified — `AttributesResourceMetadataCollectionFactory` uses `ReflectionClass::getAttributes()`, which does not inherit, so an undeclared subclass yields an empty metadata collection) and returns the skolem IRI before the cache write.

Fix: append `_r` to the key when `$resource instanceof Relation`, same shape as the `item_uri_template` fix in #8472. The `Relation` path can only ever produce a skolem IRI anyway — `generateRoute()` cannot extract identifiers from a `Relation` — so this restores the pre-#8472 behaviour in both orders.

- [ ] Update Changelog.md
