### PR TITLE
test(metadata): build the elasticsearch state options in the compatibility expectation

### DIFF
--- a/src/Metadata/Tests/Extractor/ResourceMetadataCompatibilityTest.php
+++ b/src/Metadata/Tests/Extractor/ResourceMetadataCompatibilityTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\Metadata\Tests\Extractor;
 
+use ApiPlatform\Elasticsearch\State\Options as ElasticsearchOptions;
 use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Delete;
 use ApiPlatform\Metadata\Extractor\XmlResourceExtractor;
@@ -729,7 +730,15 @@ final class ResourceMetadataCompatibilityTest extends TestCase
         $configuration = reset($values);
         switch (key($values)) {
             case 'elasticsearchOptions':
-                return null;
+                // Mirrors the extractors, which only build the options when the component is installed:
+                // the expectation must not assume that api-platform/elasticsearch is absent.
+                if (!class_exists(ElasticsearchOptions::class)) {
+                    return null;
+                }
+
+                return new ElasticsearchOptions(
+                    isset($configuration['index']) ? (string) $configuration['index'] : null,
+                );
         }
 
         throw new \LogicException(\sprintf('Unsupported "%s" state options.', key($values)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Tickets       | Fixes #8495
| License       | MIT
| Doc PR        | /

`ResourceMetadataCompatibilityTest` asserted that `stateOptions` is `null` for the `elasticsearchOptions` fixture, while both extractors build a real `ApiPlatform\Elasticsearch\State\Options` whenever the component is installed:

```php
// XmlResourceExtractor::buildStateOptions()
if (isset($stateOptions->elasticsearchOptions) && class_exists(ElasticsearchOptions::class)) {
    return new ElasticsearchOptions(...);
}
```

The expectation now mirrors that `class_exists()` guard, so it holds in both environments instead of only in the one where `api-platform/elasticsearch` is missing.

### Why CI was green

`phpunit-components` runs each component from its own directory with its own `vendor/`, so `ApiPlatform\Elasticsearch\State\Options` does not exist for the `api-platform/metadata` job and the extractors return `null`. Running the same test from the monorepo root, where every component is autoloaded, fails on both data sets — and the rendered diff drags in unrelated keys such as `strictQueryParameterValidation`, which makes it look like several things are broken. Removing `src/Elasticsearch/State/Options.php` turns the whole test green, so `stateOptions` was the only real difference.

### Checked

- `vendor/bin/phpunit src/Metadata/Tests/Extractor/ResourceMetadataCompatibilityTest.php` from the repository root: green, was 2 failures.
- The same run with `src/Elasticsearch/State/Options.php` moved out of the way, which reproduces the isolated component job: still green.
- PHPStan and PHP-CS-Fixer clean on the file.

As a side effect the `elasticsearchOptions` branch of `buildStateOptions()` is now actually asserted somewhere.
