### PR TITLE
fix(state): support output DTOs on write operations with ObjectMapper

### DIFF
--- a/src/Serializer/SerializerContextBuilder.php
+++ b/src/Serializer/SerializerContextBuilder.php
@@ -16,6 +16,7 @@ namespace ApiPlatform\Serializer;
 use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Error as ErrorOperation;
 use ApiPlatform\Metadata\Exception\RuntimeException;
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
 use ApiPlatform\Metadata\Util\AttributesExtractor;
 use ApiPlatform\State\SerializerContextBuilderInterface;
@@ -70,6 +71,19 @@ final class SerializerContextBuilder implements SerializerContextBuilderInterfac
         // Special case as this is usually handled by our OperationContextTrait, here we want to force the IRI in the response
         if (!$operation instanceof CollectionOperationInterface && method_exists($operation, 'getItemUriTemplate') && $operation->getItemUriTemplate()) {
             $context['item_uri_template'] = $operation->getItemUriTemplate();
+        } elseif (
+            $normalization
+            && $operation instanceof HttpOperation
+            && !$operation instanceof CollectionOperationInterface
+            && !method_exists($operation, 'getItemUriTemplate')
+            && $operation->canMap()
+            && null !== ($context['output']['class'] ?? null)
+            && !\in_array($operation->getMethod(), ['GET', 'HEAD', 'OPTIONS'], true)
+            && $operation->getUriTemplate()
+        ) {
+            // A mapped output DTO on an item write operation (PUT/PATCH): the operation's own
+            // URI template is the item template, use it to generate the IRI of the DTO.
+            $context['item_uri_template'] = $operation->getUriTemplate();
         }
 
         if ($types = $operation->getTypes()) {

--- a/src/State/Processor/ObjectMapperOutputProcessor.php
+++ b/src/State/Processor/ObjectMapperOutputProcessor.php
@@ -48,7 +48,7 @@ final class ObjectMapperOutputProcessor implements ProcessorInterface
 
         $request = $context['request'] ?? null;
         $request?->attributes->set('persisted_data', $data);
-        $dto = $this->objectMapper->map($data, $operation->getClass());
+        $dto = $this->objectMapper->map($data, $operation->getOutput()['class'] ?? $operation->getClass());
 
         return $this->decorated ? $this->decorated->process($dto, $operation, $uriVariables, $context) : $dto;
     }

--- a/src/State/Provider/ObjectMapperProvider.php
+++ b/src/State/Provider/ObjectMapperProvider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\State\Provider;
 
+use ApiPlatform\Metadata\HttpOperation;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Util\CloneTrait;
 use ApiPlatform\State\Pagination\MappedObjectPaginator;
@@ -41,7 +42,12 @@ final class ObjectMapperProvider implements ProviderInterface
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $data = $this->decorated->provide($operation, $uriVariables, $context);
-        $class = $operation->getOutput()['class'] ?? $operation->getClass();
+
+        // On write operations the provided data is the deserialization target (object to populate),
+        // it must stay an instance of the resource class; the output class is mapped to after
+        // persistence by the ObjectMapperOutputProcessor.
+        $isWrite = $operation instanceof HttpOperation && !\in_array($operation->getMethod(), ['GET', 'HEAD', 'OPTIONS'], true);
+        $class = $isWrite ? $operation->getClass() : ($operation->getOutput()['class'] ?? $operation->getClass());
 
         if (!$this->objectMapper || !$operation->canMap()) {
             return $data;

--- a/src/State/Tests/Processor/ObjectMapperOutputProcessorTest.php
+++ b/src/State/Tests/Processor/ObjectMapperOutputProcessorTest.php
@@ -107,6 +107,31 @@ class ObjectMapperOutputProcessorTest extends TestCase
         $this->assertSame($result, $processor->process($entity, $operation));
     }
 
+    public function testProcessMapsEntityToDefinedOutputClass(): void
+    {
+        $entity = new \stdClass();
+        $entity->id = 1;
+        $dto = new \stdClass();
+        $dto->id = 1;
+        $result = new \stdClass();
+        $operation = new Post(class: ObjectMapperOutputDummy::class, output: ['class' => ObjectMapperOutputDtoDummy::class], map: true);
+
+        $objectMapper = $this->createMock(ObjectMapperInterface::class);
+        $objectMapper->expects($this->once())
+            ->method('map')
+            ->with($entity, ObjectMapperOutputDtoDummy::class)
+            ->willReturn($dto);
+
+        $decorated = $this->createMock(ProcessorInterface::class);
+        $decorated->expects($this->once())
+            ->method('process')
+            ->with($dto, $operation, [], $this->anything())
+            ->willReturn($result);
+
+        $processor = new ObjectMapperOutputProcessor($objectMapper, $decorated);
+        $this->assertSame($result, $processor->process($entity, $operation));
+    }
+
     public function testProcessSetsPersistedDataOnRequest(): void
     {
         $entity = new \stdClass();
@@ -134,5 +159,9 @@ class ObjectMapperOutputProcessorTest extends TestCase
 }
 
 class ObjectMapperOutputDummy
+{
+}
+
+class ObjectMapperOutputDtoDummy
 {
 }

--- a/src/State/Util/HttpResponseHeadersTrait.php
+++ b/src/State/Util/HttpResponseHeadersTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ApiPlatform\State\Util;
 
+use ApiPlatform\Metadata\CollectionOperationInterface;
 use ApiPlatform\Metadata\Error;
 use ApiPlatform\Metadata\Exception\HttpExceptionInterface;
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
@@ -118,6 +119,9 @@ trait HttpResponseHeadersTrait
                 $iri = null;
                 if ($hasData) {
                     $iri = $this->iriConverter->getIriFromResource($originalData);
+                } elseif (\is_object($originalData) && ($itemUriTemplate = $this->getMappedOutputItemUriTemplate($operation))) {
+                    // A mapped (non-resource) output DTO: derive the item IRI from the operation's item URI template
+                    $iri = $this->iriConverter->getIriFromResource($originalData, UrlGeneratorInterface::ABS_PATH, null, ['item_uri_template' => $itemUriTemplate]);
                 } elseif ($operation->getClass()) {
                     $iri = $this->iriConverter->getIriFromResource($operation->getClass(), UrlGeneratorInterface::ABS_PATH, $operation);
                 }
@@ -146,6 +150,19 @@ trait HttpResponseHeadersTrait
         }
 
         return $headers;
+    }
+
+    private function getMappedOutputItemUriTemplate(HttpOperation $operation): ?string
+    {
+        if (!$operation->canMap() || null === ($operation->getOutput()['class'] ?? null)) {
+            return null;
+        }
+
+        if (method_exists($operation, 'getItemUriTemplate')) {
+            return $operation->getItemUriTemplate();
+        }
+
+        return $operation instanceof CollectionOperationInterface ? null : $operation->getUriTemplate();
     }
 
     private function addLinkedDataPlatformHeaders(array &$headers, HttpOperation $operation): void

--- a/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithOutput.php
+++ b/tests/Fixtures/TestBundle/ApiResource/MappedResourceWithOutput.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\ApiResource;
+
+use ApiPlatform\Doctrine\Orm\State\Options;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Patch;
+use ApiPlatform\Metadata\Post;
+use ApiPlatform\Tests\Fixtures\TestBundle\Dto\MappedOutputDto;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedOutputEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[ApiResource(
+    stateOptions: new Options(entityClass: MappedOutputEntity::class),
+    operations: [
+        new Get(),
+        new Post(output: MappedOutputDto::class, itemUriTemplate: '/mapped_resource_with_outputs/{id}{._format}'),
+        new Patch(output: MappedOutputDto::class),
+    ],
+    normalizationContext: ['hydra_prefix' => false],
+)]
+#[Map(target: MappedOutputEntity::class)]
+class MappedResourceWithOutput
+{
+    #[Map(if: false)]
+    public ?int $id = null;
+
+    public ?string $name = null;
+
+    public ?string $description = null;
+}

--- a/tests/Fixtures/TestBundle/Dto/MappedOutputDto.php
+++ b/tests/Fixtures/TestBundle/Dto/MappedOutputDto.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Dto;
+
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedOutputEntity;
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * Output DTO mapped from the entity: exposes only "name", not "description".
+ */
+#[Map(source: MappedOutputEntity::class)]
+class MappedOutputDto
+{
+    public ?int $id = null;
+
+    public ?string $name = null;
+}

--- a/tests/Fixtures/TestBundle/Entity/MappedOutputEntity.php
+++ b/tests/Fixtures/TestBundle/Entity/MappedOutputEntity.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Fixtures\TestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class MappedOutputEntity
+{
+    #[ORM\Column(type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    public ?int $id = null;
+
+    #[ORM\Column]
+    public string $name;
+
+    #[ORM\Column]
+    public string $description;
+}

--- a/tests/Functional/MappedResourceOutputTest.php
+++ b/tests/Functional/MappedResourceOutputTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Tests\Functional;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\MappedResourceWithOutput;
+use ApiPlatform\Tests\Fixtures\TestBundle\Entity\MappedOutputEntity;
+use ApiPlatform\Tests\RecreateSchemaTrait;
+use ApiPlatform\Tests\SetupClassResourcesTrait;
+
+/**
+ * Verifies the behavior of write operations declaring an `output` DTO with the ObjectMapper.
+ */
+final class MappedResourceOutputTest extends ApiTestCase
+{
+    use RecreateSchemaTrait;
+    use SetupClassResourcesTrait;
+    protected static ?bool $alwaysBootKernel = false;
+
+    /**
+     * @return class-string[]
+     */
+    public static function getResources(): array
+    {
+        return [MappedResourceWithOutput::class];
+    }
+
+    public function testPostWithOutputDtoReturnsOutputDto(): void
+    {
+        if (!$this->getContainer()->has('api_platform.object_mapper')) {
+            $this->markTestSkipped('ObjectMapper not installed');
+        }
+
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('MongoDB not tested');
+        }
+
+        $this->recreateSchema([MappedOutputEntity::class]);
+
+        $client = self::createClient();
+        $response = $client->request('POST', '/mapped_resource_with_outputs', [
+            'json' => ['name' => 'a name', 'description' => 'a description'],
+        ]);
+
+        fwrite(\STDERR, "\n=== POST status: ".$response->getStatusCode()."\n");
+        fwrite(\STDERR, "=== POST response body ===\n".substr($response->getContent(false), 0, 2000)."\n");
+        fwrite(\STDERR, '=== Location header: '.var_export($response->getHeaders(false)['location'][0] ?? null, true)."\n");
+        fwrite(\STDERR, '=== Content-Location header: '.var_export($response->getHeaders(false)['content-location'][0] ?? null, true)."\n");
+
+        self::assertResponseStatusCodeSame(201);
+        $data = $response->toArray(false);
+
+        // The output DTO exposes "name" but not "description"
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayNotHasKey('description', $data, 'Response should be the output DTO, not the resource');
+
+        // Item IRI expected on a 201, not the collection IRI
+        $location = $response->getHeaders(false)['location'][0] ?? null;
+        $this->assertNotNull($location);
+        $this->assertMatchesRegularExpression('~^/mapped_resource_with_outputs/\d+$~', $location, 'Location must be the item IRI');
+        $this->assertSame($location, $data['@id'] ?? null, '@id must be the item IRI');
+    }
+
+    public function testPatchWithOutputDtoPreservesUnsentFields(): void
+    {
+        if (!$this->getContainer()->has('api_platform.object_mapper')) {
+            $this->markTestSkipped('ObjectMapper not installed');
+        }
+
+        if ($this->isMongoDB()) {
+            $this->markTestSkipped('MongoDB not tested');
+        }
+
+        $this->recreateSchema([MappedOutputEntity::class]);
+
+        $manager = $this->getManager();
+        $entity = new MappedOutputEntity();
+        $entity->name = 'original name';
+        $entity->description = 'original description';
+        $manager->persist($entity);
+        $manager->flush();
+        $id = $entity->id;
+        $manager->clear();
+
+        $client = self::createClient();
+        $response = $client->request('PATCH', '/mapped_resource_with_outputs/'.$id, [
+            'headers' => ['content-type' => 'application/merge-patch+json'],
+            'json' => ['name' => 'updated name'],
+        ]);
+
+        fwrite(\STDERR, "\n=== PATCH status: ".$response->getStatusCode()."\n");
+        fwrite(\STDERR, "=== PATCH response body ===\n".substr($response->getContent(false), 0, 2000)."\n");
+
+        self::assertResponseIsSuccessful();
+        $data = $response->toArray(false);
+
+        // The response must be the output DTO with a proper item IRI
+        $this->assertArrayHasKey('name', $data);
+        $this->assertArrayNotHasKey('description', $data, 'Response should be the output DTO, not the resource');
+        $this->assertSame('/mapped_resource_with_outputs/'.$id, $data['@id']);
+
+        // PATCH semantics: unsent fields must be preserved on the entity
+        $manager = $this->getManager();
+        $manager->clear();
+        $persisted = $manager->getRepository(MappedOutputEntity::class)->find($id);
+        $this->assertSame('updated name', $persisted->name);
+        $this->assertSame('original description', $persisted->description, 'PATCH must not touch fields the client did not send');
+    }
+}

--- a/tests/State/Provider/ObjectMapperProviderTest.php
+++ b/tests/State/Provider/ObjectMapperProviderTest.php
@@ -169,22 +169,24 @@ class ObjectMapperProviderTest extends TestCase
         $this->assertSame($targetResource2, $items[1]);
     }
 
-    public function testProvideIgnoresInputClassAndMapsToOutputClass(): void
+    public function testProvideIgnoresInputAndOutputClassesOnWrite(): void
     {
         $sourceEntity = new SourceEntity();
-        $outputResource = new OutputResource();
+        $targetResource = new TargetResource();
         $operation = new Patch(class: TargetResource::class, input: ['class' => InputResource::class], output: ['class' => OutputResource::class], map: true);
         $objectMapper = $this->createMock(ObjectMapperInterface::class);
         $objectMapper->expects($this->once())
             ->method('map')
-            ->with($sourceEntity, OutputResource::class)
-            ->willReturn($outputResource);
+            ->with($sourceEntity, TargetResource::class)
+            ->willReturn($targetResource);
         $decorated = $this->createStub(ProviderInterface::class);
         $decorated->method('provide')->willReturn($sourceEntity);
         $provider = new ObjectMapperProvider($objectMapper, $decorated);
 
+        // On a write operation the provided data is the deserialization target: it must be
+        // the resource class, the output class is only mapped to after persistence.
         $result = $provider->provide($operation);
-        $this->assertSame($outputResource, $result);
+        $this->assertSame($targetResource, $result);
     }
 
     public function testProvideMapsToOutputClassWhenNoInput(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| License       | MIT
| Doc PR        | to follow (see "Documentation" below)

Follow-up to #8420 (closed), which attempted to fix this with a one-liner in `ObjectMapperOutputProcessor`. @soyuka's review was right: that diff alone silently degraded IRIs and headers. This PR addresses the whole write path instead, and answers each concern raised there. It comes with functional tests asserting on `Location`, `Content-Location` and `@id`, not just response bodies.

## Problem

Declaring `output:` on a write operation with the ObjectMapper integration (`stateOptions: new Options(entityClass: ...)`) is currently broken *before* the output mapping is ever reached — it doesn't just return the wrong representation:

- **PATCH → 500.** `ObjectMapperProvider` maps the entity to the *output* class on reads (#7601). On a PATCH, that mapped DTO becomes `OBJECT_TO_POPULATE`, but the deserializer discards it because it is not an instance of the resource class (`ObjectToPopulateTrait::extractObjectToPopulate`). A **fresh resource instance is built from the request body alone**, and `ObjectMapperInputProcessor` then maps it onto the entity — clobbering every field the client didn't send:
  ```
  Expected argument of type "string", "null" given at property path "description".
  ```
  This is a genuine break of merge-patch semantics, in the same family as #7886 (fixed by #7892), but on a different path.
- **POST → 400** (`Unable to generate an IRI for the item of type ...`) when the resource IRI can't be generated from the write result — the exact use case that motivates a dedicated output DTO in the first place.

## What this PR changes

Four small, gated changes (each new path requires `canMap()` **and** an explicit `output` class, so non-ObjectMapper users and read operations are untouched):

1. **`ObjectMapperProvider`** — on write methods, map the entity to the **resource class**, not the output class. The provided data is the deserialization target: it must be an instance of the resource class for `object_to_populate` to work. This fixes the PATCH 500 and preserves merge semantics — the output class is only mapped to *after* persistence. (Covered by a dedicated test asserting a partial PATCH body leaves unsent fields untouched, guarding the #7886 regression class explicitly.)
2. **`ObjectMapperOutputProcessor`** — map the persisted entity to `getOutput()['class'] ?? getClass()`, mirroring the read side (the #8420 one-liner, now safe).
3. **`HttpResponseHeadersTrait`** — when `original_data` is a mapped non-resource output DTO, derive `Location`/`Content-Location` from the operation's item URI template (`itemUriTemplate` on `Post`, the operation's own `uriTemplate` on `Patch`/`Put`) via the existing `item_uri_template` IriConverter support. No template → previous behavior, no silent change.
4. **`SerializerContextBuilder`** — set `item_uri_template` for mapped-output item write operations, so `Patch`/`Put` responses get a real `@id` (POST already gets it through `itemUriTemplate`, the mechanism the docs' `BookCreated` pattern relies on).

## Answering the concerns from #8420

> `Location`/`Content-Location` on a 201 would silently degrade to the collection IRI

Confirmed empirically — and fixed via (3). With `itemUriTemplate` declared, a POST now returns:

```
HTTP/1.1 201 Created
Location: /mapped_resource_with_outputs/1
Content-Location: /mapped_resource_with_outputs/1.jsonld

{"@id": "/mapped_resource_with_outputs/1", "@type": "MappedResourceWithOutput", "id": 1, "name": "a name"}
```

Without `itemUriTemplate`, behavior is unchanged from today (no silent degradation is introduced; failing loudly at metadata time could be a follow-up if preferred).

> ObjectMapper is not the place to convert a resource into the output class; users would need `#[Map]` between the entity and every custom output

The processor maps **entity → output**, exactly like `ObjectMapperProvider` has done on reads since #7601 — one `#[Map(source: MyEntity::class)]` attribute on the output DTO, same contract as the read side. The serializer then receives an actual instance of the output class, so the output serialization path is taken naturally. `ObjectMapperMetadataCollectionFactory` already validates the output class mapping (@yceruto's objection from #7611 is resolved in current code).

> We extended write-side mapping in #7879 and had to revert in #7892 because it broke PATCH

That revert concerned the provider mapping to the *input* class, pre-filling DTO properties before validation. This PR does the opposite: it makes the provider *stop* mapping to a non-resource class on writes (fixing the PATCH break described above), and only maps to the output class after persistence, where it can no longer affect what gets written.

## BC note

The provider previously mapped the entity to the output class on write operations. As demonstrated above, that behavior was not usable (500 on PATCH, 400 on POST in the standard setup), but if someone's output DTO happened to be populate-compatible with their resource class, they would see changed behavior. Happy to discuss if this needs a changelog entry beyond the fix itself.

## Tests

- `tests/Functional/MappedResourceOutputTest.php` (new fixtures only): POST asserting response body is the DTO, `@id`/`Location`/`Content-Location` are the item IRI; PATCH asserting the response DTO, a real `@id`, and — against the database — that unsent fields are preserved.
- `tests/State/Provider/ObjectMapperProviderTest.php`: one test updated, as it asserted the exact provider behavior shown broken above; a comment explains the new contract.
- Existing `MappingTest`, ObjectMapper validation/unit and DTO/CRUD suites pass unchanged.

## Documentation

If the approach is accepted I'll open the docs PR: `output:` + ObjectMapper on writes, the `#[Map(source: ...)]` contract for output DTOs, and the `itemUriTemplate` requirement for POST responses.
