### PR TITLE
ci: drop distribution release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,24 +49,6 @@ jobs:
       - name: Split to manyrepo
         run: find src -maxdepth 3 -name composer.json -print0 | xargs -I '{}' -n 1 -0 bash subtree.sh {} ${{ github.ref }}
 
-  dispatch-distribution-update:
-    name: Dispatch Distribution Update
-    runs-on: ubuntu-latest
-    needs: split
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Generate App Token
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.API_PLATFORM_APP_ID }}
-          private_key: ${{ secrets.API_PLATFORM_APP_PRIVATE_KEY }}
-
-      - name: Update distribution
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: gh workflow run -R api-platform/api-platform release.yml -f tag=${{ github.ref_name }}
-
   dispatch-demo-update:
     name: Dispatch Demo Update
     runs-on: ubuntu-latest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | ∅
| License       | MIT
| Doc PR        | ∅

## What

Removes the `dispatch-distribution-update` job from the release pipeline.

## Why

The job failed on the v4.3.18 release ([run](https://github.com/api-platform/core/actions/runs/33857321277/job/100974865523)):

```
could not create workflow dispatch event: HTTP 422:
Workflow does not have 'workflow_dispatch' trigger
```

`api-platform/api-platform` is now the installer, and its `release.yml` is a different workflow: it is `on: push: tags: v*` only and builds the static binary (PHAR + micro SAPI, per os/arch). It has no `workflow_dispatch` trigger and no `tag` input, so `gh workflow run -R api-platform/api-platform release.yml -f tag=<tag>` cannot succeed.

Nothing needs to be re-adapted on the distribution side either: the installer pins no core version. `SymfonyScaffold` runs `composer require api-platform/symfony api-platform/doctrine-orm …` and `LaravelScaffold` runs `composer require api-platform/laravel`, both resolved at install time on the user's machine. A core tag has nothing to propagate there.

`dispatch-demo-update` is untouched — `api-platform/demo` still has `upgrade-api-platform.yml` and that job succeeded in the same run.

The job exists on 4.1 through main; landing this on 4.3 and merging up covers the branches that are still tagged.
