### PR TITLE
test(doctrine): adapt unwired filter test to 5.0

### DIFF
--- a/src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php
+++ b/src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php
@@ -30,11 +30,11 @@ use Psr\Log\LoggerInterface;
 
 final class UnwiredLegacyFilterParameterTest extends TestCase
 {
-    public function testUnwiredRegistryAwareFilterIsLoggedAtDebug(): void
+    public function testUnwiredRegistryAwareFilterIsNotLogged(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->never())->method('alert');
-        $logger->expects($this->once())->method('debug');
+        $logger->expects($this->never())->method('debug');
 
         $this->createFactory($logger)->create(ResourceWithInlineDateFilter::class);
     }


### PR DESCRIPTION
## Problem

`UnwiredLegacyFilterParameterTest::testUnwiredRegistryAwareFilterIsLoggedAtDebug` is red on `main` (all linked `api-platform/doctrine-orm` PHPUnit jobs):

```
Expectation failed for method name is "debug" when invoked 1 time.
Method was expected to be called 1 time, actually called 0 times.
```

## Cause

The test arrived on `main` via the 4.4 up-merge and encodes 4.4-specific behaviour.

On **4.4**, `DateFilter extends AbstractFilter`, whose `getDescription()` throws a `RuntimeException` when no `ManagerRegistry` was injected. `ParameterResourceMetadataCollectionFactory` catches it and logs at `debug` rather than `alert` for an unwired `ManagerRegistryAwareInterface` filter (#8490, closes #7361).

On **5.0**, `DateFilter` is a standalone filter (#8351): it implements `ManagerRegistryAwareInterface` directly, and `getClassMetadata()` falls back to `new ClassMetadata($resourceClass)` when `hasManagerRegistry()` is false. It never throws, so `getLegacyFilterMetadata()` succeeds, the `catch` block is never entered, and **neither `debug` nor `alert`** is called.

That 5.0 behaviour is correct and still satisfies #7361 — it avoids the warmup noise by not failing at all, rather than by downgrading the log level.

## Change

Test-only. The first case now asserts the actual 5.0 contract (nothing is logged) and is renamed accordingly. `testFilterFailureUnrelatedToTheManagerRegistryStillAlerts` is untouched and still pins the alert path for an unrelated filter failure.

```
vendor/bin/phpunit src/Doctrine/Orm/Tests/Metadata/Resource/UnwiredLegacyFilterParameterTest.php
OK (2 tests, 2 assertions)
```

No production code changed.