### PR TITLE
chore(metadata): defer FilterInterface::getDescription() removal to 6.0

### DIFF
--- a/src/Metadata/FilterInterface.php
+++ b/src/Metadata/FilterInterface.php
@@ -51,7 +51,7 @@ interface FilterInterface
      *
      * @return array<string, array{property?: string, type?: string, required?: bool, description?: string, strategy?: string, is_collection?: bool, openapi?: \ApiPlatform\OpenApi\Model\Parameter, schema?: array<string, mixed>}>
      *
-     * @deprecated in 4.2, to be removed in 5.0
+     * @deprecated in 4.2, to be removed in 6.0
      */
     public function getDescription(string $resourceClass): array;
 }

--- a/src/OpenApi/Factory/OpenApiFactory.php
+++ b/src/OpenApi/Factory/OpenApiFactory.php
@@ -720,7 +720,7 @@ final class OpenApiFactory implements OpenApiFactoryInterface
     private function getFilterParameter(string $name, array $description, string $shortName, string $filter): Parameter
     {
         if (isset($description['swagger'])) {
-            trigger_deprecation('api-platform/core', '4.0', \sprintf('Using the "swagger" field of the %s::getDescription() (%s) is deprecated.', $filter, $shortName));
+            trigger_deprecation('api-platform/core', '4.0', \sprintf('Using the "swagger" field of the %s::getDescription() (%s) is deprecated and will be removed in 6.0.', $filter, $shortName));
         }
 
         if (!isset($description['openapi']) || $description['openapi'] instanceof Parameter) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | #8367
| License       | MIT
| Doc PR        | n/a

`FilterInterface::getDescription()` and the `swagger` field of a filter description were initially announced for removal in 5.0. 

#8367 decided to keep them in 5.0 and defer their removal to 6.0:

> FilterInterface::getDescription() and the OpenApi swagger field stay deferred to 6.0.
