### PR TITLE
fix(doctrine): keep zero-backed enum filter values

### DIFF
--- a/src/Doctrine/Orm/Filter/BackedEnumFilter.php
+++ b/src/Doctrine/Orm/Filter/BackedEnumFilter.php
@@ -130,7 +130,7 @@ final class BackedEnumFilter extends AbstractFilter
         $normalizedValues = array_filter(array_map(
             fn ($v) => $this->normalizeValue($v, $property),
             $values
-        ));
+        ), static fn ($value) => null !== $value);
 
         if (empty($normalizedValues)) {
             return;

--- a/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTest.php
+++ b/src/Doctrine/Orm/Tests/Filter/BackedEnumFilterTest.php
@@ -16,6 +16,8 @@ namespace ApiPlatform\Doctrine\Orm\Tests\Filter;
 use ApiPlatform\Doctrine\Orm\Filter\BackedEnumFilter;
 use ApiPlatform\Doctrine\Orm\Tests\DoctrineOrmFilterTestCase;
 use ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity\Dummy;
+use ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity\IntegerBackedEnumDummy;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * @author Rémi Marseille <marseille.remi@gmail.com>
@@ -25,6 +27,23 @@ final class BackedEnumFilterTest extends DoctrineOrmFilterTestCase
     use BackedEnumFilterTestTrait;
 
     protected string $filterClass = BackedEnumFilter::class;
+
+    #[DataProvider('provideNonPositiveIntegerValues')]
+    public function testApplyNonPositiveIntegerValue(string $value): void
+    {
+        $this->doTestApply(
+            ['value' => null],
+            ['value' => $value],
+            \sprintf('SELECT o FROM %s o WHERE o.value = :value_p1', IntegerBackedEnumDummy::class),
+            resourceClass: IntegerBackedEnumDummy::class,
+        );
+    }
+
+    public static function provideNonPositiveIntegerValues(): iterable
+    {
+        yield 'zero' => ['0'];
+        yield 'negative' => ['-1'];
+    }
 
     public static function provideApplyTestData(): array
     {

--- a/src/Doctrine/Orm/Tests/Fixtures/Entity/IntegerBackedEnum.php
+++ b/src/Doctrine/Orm/Tests/Fixtures/Entity/IntegerBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity;
+
+enum IntegerBackedEnum: int
+{
+    case Negative = -1;
+    case Zero = 0;
+}

--- a/src/Doctrine/Orm/Tests/Fixtures/Entity/IntegerBackedEnumDummy.php
+++ b/src/Doctrine/Orm/Tests/Fixtures/Entity/IntegerBackedEnumDummy.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class IntegerBackedEnumDummy
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public ?int $id = null;
+
+    #[ORM\Column(enumType: IntegerBackedEnum::class)]
+    public IntegerBackedEnum $value;
+}


### PR DESCRIPTION
Fix #8475

`BackedEnumFilter` normalized integer-backed enum query values before checking whether any valid values remained. The default `array_filter()` callback also removed the valid integer value `0`, causing the filter to be silently skipped.

This keeps every normalized value except `null`, which is the sentinel returned for invalid enum values. A regression test covers zero and confirms negative values remain supported.

## Test verification (RED → GREEN)

On unmodified `4.3`, the new test failed for the zero-backed case:

```text
Failed asserting that two strings are identical.
-'SELECT o FROM ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity\IntegerBackedEnumDummy o WHERE o.value = :value_p1'
+'SELECT o FROM ApiPlatform\Doctrine\Orm\Tests\Fixtures\Entity\IntegerBackedEnumDummy o'
Tests: 2, Assertions: 2, Failures: 1.
```

With the fix:

```text
OK (2 tests, 2 assertions)
```

## Full local suite

Command: `./run-ci.sh` (Doctrine ORM `BackedEnumFilterTest` on PHP 8.4 and PHP 8.5, matching the affected component CI job).

Result: same-or-better than the upstream baseline, with no new failures, skips, ignores, or errors.

```text
Upstream 4.3: OK (7 tests, 9 assertions)
PHP 8.4: OK (9 tests, 11 assertions)
PHP 8.5: OK (9 tests, 11 assertions)
PHP CS Fixer 3.93.1: 0 of 4 files can be fixed
Changed production lines: 100% covered (1/1)
```
