### PR TITLE
fix(serializer): read Symfony attributes through their public properties

### DIFF
--- a/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
+++ b/src/Serializer/Mapping/Loader/PropertyMetadataLoader.php
@@ -70,15 +70,15 @@ final class PropertyMetadataLoader implements LoaderInterface
 
             if ($attribute instanceof DiscriminatorMap) {
                 $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
-                    method_exists($attribute, 'getTypeProperty') ? $attribute->getTypeProperty() : $attribute->typeProperty,
-                    method_exists($attribute, 'getMapping') ? $attribute->getMapping() : $attribute->mapping,
-                    method_exists($attribute, 'getDefaultType') ? $attribute->getDefaultType() : ($attribute->defaultType ?? null),
+                    $attribute->typeProperty,
+                    $attribute->mapping,
+                    $attribute->defaultType,
                 ));
                 continue;
             }
 
             if ($attribute instanceof Groups) {
-                $classGroups = method_exists($attribute, 'getGroups') ? $attribute->getGroups() : $attribute->groups;
+                $classGroups = $attribute->groups;
 
                 continue;
             }
@@ -123,7 +123,7 @@ final class PropertyMetadataLoader implements LoaderInterface
             // This code is adapted from Symfony\Component\Serializer\Mapping\Loader\AttributeLoader
             foreach ($attributes[$propertyName] as $attr) {
                 if ($attr instanceof Groups) {
-                    $groups = method_exists($attr, 'getGroups') ? $attr->getGroups() : $attr->groups;
+                    $groups = $attr->groups;
                     foreach ($groups as $group) {
                         $attributeMetadata->addGroup($group);
                     }
@@ -131,9 +131,9 @@ final class PropertyMetadataLoader implements LoaderInterface
                 }
 
                 match (true) {
-                    $attr instanceof MaxDepth => $attributeMetadata->setMaxDepth(method_exists($attr, 'getMaxDepth') ? $attr->getMaxDepth() : $attr->maxDepth),
-                    $attr instanceof SerializedName => $attributeMetadata->setSerializedName(method_exists($attr, 'getSerializedName') ? $attr->getSerializedName() : $attr->serializedName),
-                    $attr instanceof SerializedPath => $attributeMetadata->setSerializedPath(method_exists($attr, 'getSerializedPath') ? $attr->getSerializedPath() : $attr->serializedPath),
+                    $attr instanceof MaxDepth => $attributeMetadata->setMaxDepth($attr->maxDepth),
+                    $attr instanceof SerializedName => $attributeMetadata->setSerializedName($attr->serializedName),
+                    $attr instanceof SerializedPath => $attributeMetadata->setSerializedPath($attr->serializedPath),
                     $attr instanceof Ignore => $attributeMetadata->setIgnore(true),
                     $attr instanceof Context => $this->setAttributeContextsForGroups($attr, $attributeMetadata),
                     default => null,
@@ -156,10 +156,10 @@ final class PropertyMetadataLoader implements LoaderInterface
 
     private function setAttributeContextsForGroups(Context $annotation, AttributeMetadataInterface $attributeMetadata): void
     {
-        $context = method_exists($annotation, 'getContext') ? $annotation->getContext() : $annotation->context;
-        $groups = method_exists($annotation, 'getGroups') ? $annotation->getGroups() : $annotation->groups;
-        $normalizationContext = method_exists($annotation, 'getNormalizationContext') ? $annotation->getNormalizationContext() : $annotation->normalizationContext;
-        $denormalizationContext = method_exists($annotation, 'getDenormalizationContext') ? $annotation->getDenormalizationContext() : $annotation->denormalizationContext;
+        $context = $annotation->context;
+        $groups = $annotation->groups;
+        $normalizationContext = $annotation->normalizationContext;
+        $denormalizationContext = $annotation->denormalizationContext;
 
         if ($normalizationContext || $context) {
             $attributeMetadata->setNormalizationContextForGroups($normalizationContext ?: $context, $groups);

--- a/src/Serializer/Tests/Fixtures/Model/AbstractWithOtherDiscriminator.php
+++ b/src/Serializer/Tests/Fixtures/Model/AbstractWithOtherDiscriminator.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+
+#[DiscriminatorMap(typeProperty: 'kind', mapping: ['other' => ConcreteWithDiscriminator::class], defaultType: 'other')]
+abstract class AbstractWithOtherDiscriminator
+{
+}

--- a/src/Serializer/Tests/Fixtures/Model/HasClassAttributes.php
+++ b/src/Serializer/Tests/Fixtures/Model/HasClassAttributes.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[Groups(['classA', 'classB'])]
+#[Context(normalizationContext: ['classNorm' => 'cn'], denormalizationContext: ['classDenorm' => 'cd'], groups: ['classGroup'])]
+class HasClassAttributes
+{
+    public ?string $any = null;
+
+    public ?string $other = null;
+}

--- a/src/Serializer/Tests/Fixtures/Model/HasSerializerAttributes.php
+++ b/src/Serializer/Tests/Fixtures/Model/HasSerializerAttributes.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the API Platform project.
+ *
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ApiPlatform\Serializer\Tests\Fixtures\Model;
+
+use ApiPlatform\Metadata\ApiProperty;
+use Symfony\Component\Serializer\Attribute\Context;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\Ignore;
+use Symfony\Component\Serializer\Attribute\MaxDepth;
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Serializer\Attribute\SerializedPath;
+
+class HasSerializerAttributes
+{
+    #[ApiProperty(serialize: [new MaxDepth(2)])]
+    public ?self $shallow = null;
+
+    #[ApiProperty(serialize: [new MaxDepth(7)])]
+    public ?self $deep = null;
+
+    #[ApiProperty(serialize: [new SerializedName('renamed')])]
+    public ?string $first = null;
+
+    #[ApiProperty(serialize: [new SerializedName('otherName')])]
+    public ?string $second = null;
+
+    #[ApiProperty(serialize: [new SerializedPath('[nested][path]')])]
+    public ?string $nested = null;
+
+    #[ApiProperty(serialize: [new SerializedPath('[other][spot]')])]
+    public ?string $elsewhere = null;
+
+    #[ApiProperty(serialize: [new Groups(['read'])])]
+    public ?string $readable = null;
+
+    #[ApiProperty(serialize: [new Groups(['write', 'admin'])])]
+    public ?string $writable = null;
+
+    #[ApiProperty(serialize: [new Ignore()])]
+    public ?string $hidden = null;
+
+    public ?string $plain = null;
+
+    #[ApiProperty(serialize: [new Context(normalizationContext: ['norm' => 'n'], denormalizationContext: ['denorm' => 'd'], groups: ['split'])])]
+    public ?string $splitContext = null;
+
+    #[ApiProperty(serialize: [new Context(context: ['shared' => 's'], groups: ['both'])])]
+    public ?string $sharedContext = null;
+}

--- a/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
+++ b/src/Serializer/Tests/Mapping/Loader/PropertyMetadataLoaderTest.php
@@ -17,26 +17,22 @@ use ApiPlatform\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface
 use ApiPlatform\Metadata\Property\PropertyNameCollection;
 use ApiPlatform\Serializer\Mapping\Loader\PropertyMetadataLoader;
 use ApiPlatform\Serializer\Tests\Fixtures\Model\AbstractWithDiscriminator;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\AbstractWithOtherDiscriminator;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\ConcreteWithDiscriminator;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\HasClassAttributes;
 use ApiPlatform\Serializer\Tests\Fixtures\Model\HasRelation;
+use ApiPlatform\Serializer\Tests\Fixtures\Model\HasSerializerAttributes;
 use ApiPlatform\Serializer\Tests\Fixtures\Model\Relation;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
+use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
 
 final class PropertyMetadataLoaderTest extends TestCase
 {
     public function testCreateMappingForASetOfProperties(): void
     {
-        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
-        $coll->method('create')->willReturn(new PropertyNameCollection(['relation']));
-        $loader = new PropertyMetadataLoader($coll);
-        $classMetadata = new ClassMetadata(HasRelation::class);
-        $loader->loadClassMetadata($classMetadata);
-        if (method_exists($classMetadata, 'getAttributesMetadata')) { // @phpstan-ignore-line
-            $attributesMetadata = $classMetadata->getAttributesMetadata();
-        } else {
-            $attributesMetadata = $classMetadata->attributesMetadata; // @phpstan-ignore-line
-        }
+        $attributesMetadata = $this->loadAttributesMetadata(['relation'], HasRelation::class);
 
         $this->assertArrayHasKey('relation', $attributesMetadata);
         $this->assertEquals(['read'], $attributesMetadata['relation']->getGroups());
@@ -44,34 +40,129 @@ final class PropertyMetadataLoaderTest extends TestCase
 
     public function testCreateMappingForAClass(): void
     {
-        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
-        $coll->method('create')->willReturn(new PropertyNameCollection(['name']));
-        $loader = new PropertyMetadataLoader($coll);
-        $classMetadata = new ClassMetadata(Relation::class);
-        $loader->loadClassMetadata($classMetadata);
-        if (method_exists($classMetadata, 'getAttributesMetadata')) { // @phpstan-ignore-line
-            $attributesMetadata = $classMetadata->getAttributesMetadata();
-        } else {
-            $attributesMetadata = $classMetadata->attributesMetadata; // @phpstan-ignore-line
-        }
+        $attributesMetadata = $this->loadAttributesMetadata(['name'], Relation::class);
+
         $this->assertArrayHasKey('name', $attributesMetadata);
         $this->assertEquals(['read'], $attributesMetadata['name']->getGroups());
     }
 
-    public function testForwardsDiscriminatorDefaultType(): void
+    public function testForwardsMaxDepth(): void
     {
-        if (!method_exists(ClassDiscriminatorMapping::class, 'getDefaultType')) { // @phpstan-ignore-line
-            $this->markTestSkipped('ClassDiscriminatorMapping::getDefaultType() requires symfony/serializer 7.1+.');
-        }
+        $attributesMetadata = $this->loadAttributesMetadata(['shallow', 'deep']);
 
+        $this->assertSame(2, $attributesMetadata['shallow']->getMaxDepth());
+        $this->assertSame(7, $attributesMetadata['deep']->getMaxDepth());
+    }
+
+    public function testForwardsSerializedName(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['first', 'second']);
+
+        $this->assertSame('renamed', $attributesMetadata['first']->getSerializedName());
+        $this->assertSame('otherName', $attributesMetadata['second']->getSerializedName());
+    }
+
+    public function testForwardsSerializedPath(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['nested', 'elsewhere']);
+
+        $this->assertSame('[nested][path]', (string) $attributesMetadata['nested']->getSerializedPath());
+        $this->assertSame('[other][spot]', (string) $attributesMetadata['elsewhere']->getSerializedPath());
+    }
+
+    public function testForwardsPropertyGroups(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['readable', 'writable']);
+
+        $this->assertSame(['read'], $attributesMetadata['readable']->getGroups());
+        $this->assertSame(['write', 'admin'], $attributesMetadata['writable']->getGroups());
+    }
+
+    public function testForwardsIgnore(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['hidden', 'plain']);
+
+        $this->assertTrue($attributesMetadata['hidden']->isIgnored());
+        $this->assertFalse($attributesMetadata['plain']->isIgnored());
+    }
+
+    public function testForwardsSplitContextForGroups(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['splitContext']);
+
+        $this->assertSame(['norm' => 'n'], $attributesMetadata['splitContext']->getNormalizationContextForGroups(['split']));
+        $this->assertSame(['denorm' => 'd'], $attributesMetadata['splitContext']->getDenormalizationContextForGroups(['split']));
+    }
+
+    public function testForwardsSharedContextForGroups(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['sharedContext']);
+
+        $this->assertSame(['shared' => 's'], $attributesMetadata['sharedContext']->getNormalizationContextForGroups(['both']));
+        $this->assertSame(['shared' => 's'], $attributesMetadata['sharedContext']->getDenormalizationContextForGroups(['both']));
+    }
+
+    public function testForwardsClassGroupsToEveryProperty(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['any', 'other'], HasClassAttributes::class);
+
+        $this->assertSame(['classA', 'classB'], $attributesMetadata['any']->getGroups());
+        $this->assertSame(['classA', 'classB'], $attributesMetadata['other']->getGroups());
+    }
+
+    public function testForwardsClassContextToEveryProperty(): void
+    {
+        $attributesMetadata = $this->loadAttributesMetadata(['any', 'other'], HasClassAttributes::class);
+
+        foreach (['any', 'other'] as $property) {
+            $this->assertSame(['classNorm' => 'cn'], $attributesMetadata[$property]->getNormalizationContextForGroups(['classGroup']));
+            $this->assertSame(['classDenorm' => 'cd'], $attributesMetadata[$property]->getDenormalizationContextForGroups(['classGroup']));
+        }
+    }
+
+    /**
+     * @param class-string         $class
+     * @param array<string, mixed> $expectedMapping
+     */
+    #[DataProvider('provideDiscriminatorCases')]
+    public function testForwardsDiscriminatorMapping(string $class, string $expectedTypeProperty, array $expectedMapping, string $expectedDefaultType): void
+    {
         $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
         $coll->method('create')->willReturn(new PropertyNameCollection([]));
         $loader = new PropertyMetadataLoader($coll);
-        $classMetadata = new ClassMetadata(AbstractWithDiscriminator::class);
+        $classMetadata = new ClassMetadata($class);
         $loader->loadClassMetadata($classMetadata);
 
         $mapping = $classMetadata->getClassDiscriminatorMapping();
         $this->assertNotNull($mapping);
-        $this->assertSame('concrete', $mapping->getDefaultType());
+        $this->assertSame($expectedTypeProperty, $mapping->getTypeProperty());
+        $this->assertSame($expectedMapping, $mapping->getTypesMapping());
+        $this->assertSame($expectedDefaultType, $mapping->getDefaultType());
+    }
+
+    /**
+     * @return iterable<string, array{class-string, string, array<string, mixed>, string}>
+     */
+    public static function provideDiscriminatorCases(): iterable
+    {
+        yield 'discr' => [AbstractWithDiscriminator::class, 'discr', ['concrete' => ConcreteWithDiscriminator::class], 'concrete'];
+        yield 'kind' => [AbstractWithOtherDiscriminator::class, 'kind', ['other' => ConcreteWithDiscriminator::class], 'other'];
+    }
+
+    /**
+     * @param list<string>      $properties
+     * @param class-string|null $class
+     *
+     * @return array<string, AttributeMetadataInterface>
+     */
+    private function loadAttributesMetadata(array $properties, ?string $class = null): array
+    {
+        $coll = $this->createStub(PropertyNameCollectionFactoryInterface::class);
+        $coll->method('create')->willReturn(new PropertyNameCollection($properties));
+        $loader = new PropertyMetadataLoader($coll);
+        $classMetadata = new ClassMetadata($class ?? HasSerializerAttributes::class);
+        $loader->loadClassMetadata($classMetadata);
+
+        return $classMetadata->getAttributesMetadata();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Reading a Symfony serializer attribute went through a `method_exists()` guard that preferred the getter and fell back to the public property:

```php
$groups = method_exists($attr, 'getGroups') ? $attr->getGroups() : $attr->groups;
```

The getter is deprecated:

```php
#[\Deprecated('Use the "groups" property instead', 'symfony/serializer:7.4')]
public function getGroups(): array
{
    return $this->groups;
}
```

https://github.com/symfony/serializer/blob/7.4/Attribute/Groups.php

symfony/serializer CHANGELOG:
-  7.4 - Deprecate getters in attribute classes in favor of public properties
-  8.0 - Remove getters in attribute classes in favor of public properties

https://github.com/symfony/serializer/blob/8.0/CHANGELOG.md

<details>
<summary>tests</summary>

I also added tests to cover the attribute forwarding and make sure regressions in each individual read are caught. The existing tests did not detect incorrect values being forwarded, which is why the test coverage needed to be strengthened.

The forwarding of those attributes had no test at all. Mutating the loader went unnoticed by every suite in the repository: `PropertyMetadataLoaderTest`, the `api-platform/serializer` component suite, and `tests/Functional` all stayed green with this in place:

```php
$attr instanceof MaxDepth => $attributeMetadata->setMaxDepth(0),
$attr instanceof SerializedName => $attributeMetadata->setSerializedName('aa'),
```

`PropertyMetadataLoaderTest` only asserted `groups` and the discriminator `defaultType`. `maxDepth`, `serializedName`, `serializedPath`, `Ignore` and `Context` were never asserted, in this component or anywhere else.

A single assertion per attribute is not enough either: replacing the read with the value the fixture happens to carry also survives:

```php
// caught: "Failed asserting that 0 is identical to 2"
$attr instanceof MaxDepth => $attributeMetadata->setMaxDepth(0),

// survives: the only fixture declared MaxDepth(2)
$attr instanceof MaxDepth => $attributeMetadata->setMaxDepth(2),
```

So every attribute is now declared twice with distinct values, and the normalization and denormalization contexts differ from each other so that swapping the two reads fails. `DiscriminatorMap` is covered by a `DataProvider`
over two fixtures whose `typeProperty`, `mapping` and `defaultType` all differ.

Each of the 13 reads in the loader was then mutated one at a time, using the fixture's own value as the replacement. All 13 are caught.

**`method_exists($classMetadata, 'getAttributesMetadata')`**

```php
if (method_exists($classMetadata, 'getAttributesMetadata')) { // @phpstan-ignore-line
    $attributesMetadata = $classMetadata->getAttributesMetadata();
} else {
    $attributesMetadata = $classMetadata->attributesMetadata; // @phpstan-ignore-line
}
```

The fallback is not just unreachable, it could never have worked: the property is private, and the getter is present on both bounds of the supported range:

```php
private array $attributesMetadata = [];        // line 26

public function getAttributesMetadata(): array // line 47
```

https://github.com/symfony/serializer/blob/7.4/Mapping/ClassMetadata.php
https://github.com/symfony/serializer/blob/8.1/Mapping/ClassMetadata.php

**`method_exists(ClassDiscriminatorMapping::class, 'getDefaultType')` (`testForwardsDiscriminatorDefaultType`)**

```php
if (!method_exists(ClassDiscriminatorMapping::class, 'getDefaultType')) { // @phpstan-ignore-line
    $this->markTestSkipped('ClassDiscriminatorMapping::getDefaultType() requires symfony/serializer 7.1+.');
}
```

Superseded by `testForwardsDiscriminatorMapping`, which asserts `typeProperty`, `mapping` and `defaultType` on two fixtures instead of `defaultType` on one. Its guard could no longer trigger either, with the Symfony floor at `^7.4`:

```php
$this->markTestSkipped('ClassDiscriminatorMapping::getDefaultType() requires symfony/serializer 7.1+.');
```

`getDefaultType()` is present and undeprecated on both bounds:

```php
public function getDefaultType(): ?string // line 66
```

https://github.com/symfony/serializer/blob/7.4/Mapping/ClassDiscriminatorMapping.php
https://github.com/symfony/serializer/blob/8.1/Mapping/ClassDiscriminatorMapping.php

</details>