### PR TITLE
fix(laravel): accept boolean query literals

### DIFF
--- a/src/Laravel/Eloquent/Filter/BooleanFilter.php
+++ b/src/Laravel/Eloquent/Filter/BooleanFilter.php
@@ -39,7 +39,7 @@ final class BooleanFilter implements FilterInterface, JsonSchemaFilterInterface
             return $builder;
         }
 
-        return $builder->{$context['whereClause'] ?? 'where'}($this->getQueryProperty($parameter), $values);
+        return $builder->{$context['whereClause'] ?? 'where'}($this->getQueryProperty($parameter), self::BOOLEAN_VALUES[$values]);
     }
 
     public function getSchema(Parameter $parameter): array

--- a/src/Laravel/Metadata/ParameterValidationResourceMetadataCollectionFactory.php
+++ b/src/Laravel/Metadata/ParameterValidationResourceMetadataCollectionFactory.php
@@ -22,6 +22,8 @@ use Psr\Container\ContainerInterface;
 
 final class ParameterValidationResourceMetadataCollectionFactory implements ResourceMetadataCollectionFactoryInterface
 {
+    private const BOOLEAN_VALUES = ['true', 'false', '1', '0'];
+
     public function __construct(
         private readonly ?ResourceMetadataCollectionFactoryInterface $decorated = null,
         private readonly ?ContainerInterface $filterLocator = null,
@@ -145,7 +147,7 @@ final class ParameterValidationResourceMetadataCollectionFactory implements Reso
         }
 
         if (isset($schema['type']) && 'boolean' === $schema['type']) {
-            $assertions[] = 'boolean';
+            $assertions[] = Rule::in(self::BOOLEAN_VALUES);
         }
 
         if (!$assertions) {

--- a/src/Laravel/Tests/EloquentTest.php
+++ b/src/Laravel/Tests/EloquentTest.php
@@ -433,9 +433,17 @@ class EloquentTest extends TestCase
 
     public function testBooleanFilter(): void
     {
-        BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
+        $books = BookFactory::new()->has(AuthorFactory::new())->count(10)->create();
         $res = $this->get('/api/books?published=notabool', ['Accept' => ['application/ld+json']]);
         $this->assertEquals($res->getStatusCode(), 422);
+
+        $res = $this->get('/api/books?published=true', ['Accept' => ['application/ld+json']]);
+        $res->assertOk();
+        $this->assertSame($books->count(), $res->json()['totalItems']);
+
+        $res = $this->get('/api/books?published=false', ['Accept' => ['application/ld+json']]);
+        $res->assertOk();
+        $this->assertSame(0, $res->json()['totalItems']);
 
         $res = $this->get('/api/books?published=0', ['Accept' => ['application/ld+json']]);
         $this->assertEquals($res->getStatusCode(), 200);


### PR DESCRIPTION
## Summary

- accept the documented BooleanFilter literals during generated Laravel parameter validation
- bind the filter's mapped native boolean value in Eloquent predicates
- cover `true` and `false` through request-level regression tests

## Test verification (RED → GREEN)

- RED on upstream `4.3`: `published=true` returned HTTP 422 from Laravel's `boolean` validator
- GREEN after the patch: focused request test passed (1 test, 7 assertions)
- patch-revert proof: reverting both production changes restored the HTTP 422 failure
- full local validation: affected `EloquentTest` class passed (32 tests, 65 assertions), Laravel PHPStan reported no errors, and PHP CS Fixer reported no fixable files
- changed-line coverage: PCOV recorded hits on both changed executable source lines (2/2, 100%)

Closes #8481
