### PR TITLE
feat(test): keep ApiTestCase BrowserKit assertions verbose for Symfony 8.2

### DIFF
--- a/src/Symfony/Bundle/Test/ApiTestCase.php
+++ b/src/Symfony/Bundle/Test/ApiTestCase.php
@@ -55,6 +55,20 @@ abstract class ApiTestCase extends KernelTestCase
         $this->symfonyErrorHandlerWasRegistered = self::isSymfonyErrorHandlerRegistered();
     }
 
+    /**
+     * Symfony >= 8.2 flips the default verbosity of BrowserKit response assertions to false, so a failing
+     * assertion (e.g. assertResponseStatusCodeSame()) no longer prints the response body. That default targets
+     * full HTML pages; API responses are compact JSON payloads whose body is exactly what you need to debug a
+     * failing test. Keep verbose output on by default here so upgrading Symfony does not silently degrade API
+     * test failures. Projects can still opt out per suite (setBrowserKitAssertionsAsVerbose(false) in setUp(),
+     * which runs after this hook) or per assertion (verbose: false).
+     */
+    #[Before]
+    protected function keepBrowserKitAssertionsVerbose(): void
+    {
+        self::setBrowserKitAssertionsAsVerbose(true);
+    }
+
     #[After]
     protected function restoreExceptionHandlerStack(): void
     {

--- a/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
+++ b/tests/Symfony/Bundle/Test/ApiTestCaseTest.php
@@ -425,6 +425,23 @@ JSON
         $this->assertSame('application/json', $client->getKernelBrowser()->getRequest()->headers->get('Content-Type'));
     }
 
+    public function testBrowserKitAssertionsStayVerboseByDefault(): void
+    {
+        // The trait's static property is flattened into ApiTestCase (which directly uses the assertions trait)
+        // and shared with subclasses, so read it there rather than on the trait or this subclass.
+        $verboseMode = new \ReflectionProperty(ApiTestCase::class, 'defaultVerboseMode');
+
+        // Simulate the Symfony >= 8.2 default (non-verbose) or a previous test that opted out.
+        self::setBrowserKitAssertionsAsVerbose(false);
+        fwrite(\STDOUT, \sprintf("[issue-8450] before ApiTestCase before-hook: defaultVerboseMode = %s\n", var_export($verboseMode->getValue(), true)));
+
+        // Re-run the exact before-hook ApiTestCase registers; reverting the fix removes it and this test fails.
+        $this->keepBrowserKitAssertionsVerbose();
+
+        fwrite(\STDOUT, \sprintf("[issue-8450] after ApiTestCase before-hook:  defaultVerboseMode = %s\n", var_export($verboseMode->getValue(), true)));
+        $this->assertTrue($verboseMode->getValue(), 'ApiTestCase must keep BrowserKit assertions verbose so failing API tests still show the response body.');
+    }
+
     public function testDoNotRebootKernelOnCreateClient(): void
     {
         self::$alwaysBootKernel = false;


### PR DESCRIPTION
Symfony >= 8.2 flips BrowserKit response assertions to non-verbose by default, hiding the response body on failure. ApiTestCase now re-enables verbose assertions in a #[Before] hook so failing API tests keep showing the (JSON) body; projects can still opt out via setBrowserKitAssertionsAsVerbose(false) in setUp() or per-assertion verbose: false.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
PHPUnit 12.5.35 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.25
Configuration: /app/phpunit.xml.dist

[issue-8450] before ApiTestCase before-hook: defaultVerboseMode = false
E                                                                   1 / 1 (100%)

Time: 00:00.007, Memory: 18.00 MB

There was 1 error:

1) ApiPlatform\Tests\Symfony\Bundle\Test\ApiTestCaseTest::testBrowserKitAssertionsStayVerboseByDefault
Error: Call to undefined method ApiPlatform\Tests\Symfony\Bundle\Test\ApiTestCaseTest::keepBrowserKitAssertionsVerbose()

/app/tests/Symfony/Bundle/Test/ApiTestCaseTest.php:439

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
PHPUnit 12.5.35 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.25
Configuration: /app/phpunit.xml.dist

[issue-8450] before ApiTestCase before-hook: defaultVerboseMode = false
[issue-8450] after ApiTestCase before-hook:  defaultVerboseMode = true
.                                                                   1 / 1 (100%)

Time: 00:00.006, Memory: 18.00 MB

OK (1 test, 1 assertion)
```

## Full local suite

Command: `docker run --rm -v "$PWD":/app -w /app php:8.4-cli bash -c 'php vendor/bin/phpunit --ignore-baseline && php vendor/bin/php-cs-fixer fix --dry-run --diff'`

```
Found 0 of 2964 files that can be fixed in 36.649 seconds, 126.00 MB memory used
```

Fix #8450
