### PR TITLE
test: drop the symfony/property-info 6.4 compatibility guards

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -85,7 +85,6 @@ parameters:
 
 		# Expected, due to backward compatibility
 		- '#Access to an undefined property GraphQL\\Type\\Definition\\NamedType&GraphQL\\Type\\Definition\\Type::\$name\.#'
-		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\PropertyInfo\\\\\\\\PropertyInfoExtractor' and 'getType' will always evaluate to true\\.#"
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\HttpFoundation\\\\\\\\Request' and 'getContentTypeFormat' will always evaluate to true\\.#"
 		- '#Call to an undefined method Symfony\\Component\\HttpFoundation\\Request::getContentType\(\)\.#'
 		- "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\Serializer\\\\\\\\Serializer' and 'getSupportedTypes' will always evaluate to true\\.#"

--- a/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
+++ b/src/JsonSchema/Tests/Metadata/Property/Factory/SchemaPropertyMetadataFactoryTest.php
@@ -25,7 +25,6 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\TypeInfo\Type;
 
 class SchemaPropertyMetadataFactoryTest extends TestCase
@@ -88,10 +87,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
 
     public function testUnionTypeAnyOfIsArray(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         $apiProperty = new ApiProperty(nativeType: Type::union(Type::string(), Type::int()));
         $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);
@@ -115,10 +110,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
      */
     public function testRelationWithGenIdFalseIsEmbeddedInOutputSchema(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         $resourceClassResolver->method('isResourceClass')->willReturn(true);
 
@@ -143,10 +134,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
      */
     public function testRelationOnNonResourceParentFollowsReadableLinkInOutputSchema(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         // the parent (DummyWithEnum) is not a resource, the related class (Dummy) is
         $resourceClassResolver->method('isResourceClass')->willReturnCallback(static fn (string $class): bool => Dummy::class === $class);
@@ -170,10 +157,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
      */
     public function testNonResourceRelationOnNonResourceParentIsEmbeddedInOutputSchema(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         // neither the parent nor the property type is a resource
         $resourceClassResolver->method('isResourceClass')->willReturn(false);
@@ -195,10 +178,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
      */
     public function testRelationOnResourceParentStaysIriReference(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         // both the parent and the related class are resources
         $resourceClassResolver->method('isResourceClass')->willReturn(true);
@@ -216,10 +195,6 @@ class SchemaPropertyMetadataFactoryTest extends TestCase
 
     public function testMixed(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceClassResolver = $this->createMock(ResourceClassResolverInterface::class);
         $apiProperty = new ApiProperty(nativeType: Type::mixed());
         $decorated = $this->createMock(PropertyMetadataFactoryInterface::class);

--- a/src/JsonSchema/Tests/SchemaFactoryTest.php
+++ b/src/JsonSchema/Tests/SchemaFactoryTest.php
@@ -41,7 +41,6 @@ use ApiPlatform\Metadata\ResourceClassResolverInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\TypeInfo\Type;
 
@@ -51,10 +50,6 @@ class SchemaFactoryTest extends TestCase
 
     public function testBuildSchemaForNonResourceClass(): void
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $resourceMetadataFactoryProphecy = $this->prophesize(ResourceMetadataCollectionFactoryInterface::class);
 
         $propertyNameCollectionFactoryProphecy = $this->prophesize(PropertyNameCollectionFactoryInterface::class);
@@ -599,10 +594,6 @@ class SchemaFactoryTest extends TestCase
      */
     private function buildPropertiesWithReference(string $propertyName, ApiProperty $propertyMetadata): array
     {
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
-            $this->markTestSkipped('This test only supports type-info component');
-        }
-
         $propertyNameCollectionFactory = $this->createStub(PropertyNameCollectionFactoryInterface::class);
         $propertyNameCollectionFactory->method('create')->willReturnCallback(
             static fn (string $class): PropertyNameCollection => new PropertyNameCollection(

--- a/tests/Functional/UnionIriCollectionTest.php
+++ b/tests/Functional/UnionIriCollectionTest.php
@@ -18,7 +18,6 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Bar;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Container;
 use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\UnionIriCollection\Foo;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 
 final class UnionIriCollectionTest extends ApiTestCase
 {
@@ -36,12 +35,6 @@ final class UnionIriCollectionTest extends ApiTestCase
 
     public function testDenormalizeCollectionAcceptsIriOfEachUnionMember(): void
     {
-        // The union-collection IRI guard relies on the native type; the legacy
-        // property-info path (< 7.1) only keeps the first collection value type.
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->markTestSkipped('Requires symfony/property-info >= 7.1 (native types).');
-        }
-
         $response = self::createClient()->request('POST', '/union_iri_collection_containers', [
             'headers' => ['Content-Type' => 'application/ld+json', 'Accept' => 'application/ld+json'],
             'json' => ['attachments' => ['/union_iri_collection_foos/1', '/union_iri_collection_bars/2']],

--- a/tests/Functional/ValidationTest.php
+++ b/tests/Functional/ValidationTest.php
@@ -18,7 +18,6 @@ use ApiPlatform\Tests\Fixtures\TestBundle\ApiResource\Issue7228\ValidationGroupS
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\DummyWithCollectDenormalizationErrors;
 use ApiPlatform\Tests\Fixtures\TestBundle\Entity\RelatedDummy;
 use ApiPlatform\Tests\SetupClassResourcesTrait;
-use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 
 /**
  * Tests denormalization error collection feature.
@@ -92,35 +91,19 @@ final class ValidationTest extends ApiTestCase
         $violationQux = $findViolation('qux');
         $this->assertNotNull($violationQux);
 
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->assertSame('This value should be of type string.', $violationQux['message']);
-        } else {
-            $this->assertSame('This value should be of type null|string.', $violationQux['message']);
-        }
+        $this->assertSame('This value should be of type null|string.', $violationQux['message']);
 
         $violationFoo = $findViolation('foo');
         $this->assertNotNull($violationFoo);
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->assertSame('This value should be of type bool.', $violationFoo['message']);
-        } else {
-            $this->assertSame('This value should be of type bool|null.', $violationFoo['message']);
-        }
+        $this->assertSame('This value should be of type bool|null.', $violationFoo['message']);
 
         $violationBar = $findViolation('bar');
         $this->assertNotNull($violationBar);
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->assertSame('This value should be of type int.', $violationBar['message']);
-        } else {
-            $this->assertSame('This value should be of type int|null.', $violationBar['message']);
-        }
+        $this->assertSame('This value should be of type int|null.', $violationBar['message']);
 
         $violationUuid = $findViolation('uuid');
         $this->assertNotNull($violationUuid);
-        if (!method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->assertSame('This value should be of type uuid.', $violationUuid['message']);
-        } else {
-            $this->assertSame('This value should be of type uuid|null.', $violationUuid['message']);
-        }
+        $this->assertSame('This value should be of type uuid|null.', $violationUuid['message']);
         $this->assertArrayHasKey('hint', $violationUuid);
         $this->assertSame('Invalid UUID string: y', $violationUuid['hint']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | main
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice with a short description of your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Branch: 
- the stable/latest 4.x for bug fixes
- main for new features

For security issues please email contact@les-tilleuls.coop.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the current stable version branch.
 - Features and deprecations must be submitted against the main branch.
 - Legacy code removals go to the main branch.
 - Update CHANGELOG.md file.
 - Follow the [Conventional Commits specification](https://www.conventionalcommits.org/).
-->

Thirteen tests guarded their body behind a `method_exists()` check on `PropertyInfoExtractor::getType()`, with a comment claiming property-info 6.4 was still supported:

```php
if (!method_exists(PropertyInfoExtractor::class, 'getType')) { // @phpstan-ignore-line symfony/property-info 6.4 is still allowed and this may be true
    $this->markTestSkipped('This test only supports type-info component');
}
```

`symfony/property-info` is constrained to `^7.4 || ^8.0` in the root and in the components that require it, and `getType()` is present and undeprecated on both bounds:

```php
public function getType(string $class, string $property, array $context = []): ?Type  // 7.4 line 57, 8.1 line 56
```

https://github.com/symfony/property-info/blob/7.4/PropertyInfoExtractor.php
https://github.com/symfony/property-info/blob/8.1/PropertyInfoExtractor.php

So the guard always evaluates to true and none of those could run.
